### PR TITLE
Improve chat streaming scroll and thinking timer

### DIFF
--- a/dashboard/src/hooks/useElapsedSeconds.test.ts
+++ b/dashboard/src/hooks/useElapsedSeconds.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useElapsedSince } from "./useElapsedSeconds";
+
+describe("useElapsedSince", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("starts at 0 and advances each second", () => {
+    const startedAt = Date.now();
+    const { result } = renderHook(() => useElapsedSince(startedAt));
+
+    expect(result.current).toBe(0);
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(result.current).toBe(1);
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+    expect(result.current).toBe(3);
+  });
+
+  it("resets when startedAt changes", () => {
+    const t0 = Date.now();
+    const { result, rerender } = renderHook(
+      ({ startedAt }) => useElapsedSince(startedAt),
+      { initialProps: { startedAt: t0 } },
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+    expect(result.current).toBe(5);
+
+    const t1 = t0 + 5000;
+    rerender({ startedAt: t1 });
+    expect(result.current).toBe(0);
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+    expect(result.current).toBe(2);
+  });
+});

--- a/dashboard/src/hooks/useElapsedSeconds.ts
+++ b/dashboard/src/hooks/useElapsedSeconds.ts
@@ -1,0 +1,19 @@
+import { useEffect, useState } from "react";
+
+/** Elapsed whole seconds since ``startedAt`` (unix ms). */
+export function useElapsedSince(startedAt: number): number {
+  const [elapsed, setElapsed] = useState(() =>
+    Math.max(0, Math.floor((Date.now() - startedAt) / 1000)),
+  );
+
+  useEffect(() => {
+    const tick = () => {
+      setElapsed(Math.max(0, Math.floor((Date.now() - startedAt) / 1000)));
+    };
+    tick();
+    const timer = window.setInterval(tick, 1000);
+    return () => window.clearInterval(timer);
+  }, [startedAt]);
+
+  return elapsed;
+}

--- a/dashboard/src/pages/Chat/components/MessageList.tsx
+++ b/dashboard/src/pages/Chat/components/MessageList.tsx
@@ -17,6 +17,7 @@ import AssistantTurnView from "./AssistantTurnView";
 import ThinkingBubble from "./ThinkingBubble";
 import ScrollToBottomButton from "./ScrollToBottomButton";
 import ContinuingIndicator from "./ContinuingIndicator";
+import { useAutoScroll } from "../hooks/useAutoScroll";
 import { findLastBrowserTurnGroupIndex } from "../utils/messageContent";
 import {
   groupConsecutiveAssistantMessages,
@@ -54,6 +55,7 @@ interface MessageListProps {
   historyLoadingMore?: boolean;
   onLoadMoreHistory?: () => void;
   isStreaming?: boolean;
+  thinkingStartedAt?: number | null;
   sessionKey?: string;
   onCancel?: () => void;
   onRegenerate?: (messageId: string) => void;
@@ -184,6 +186,7 @@ export default function MessageList(props: MessageListProps) {
     historyLoadingMore,
     onLoadMoreHistory,
     isStreaming,
+    thinkingStartedAt = null,
     sessionKey,
     onCancel,
     onRegenerate,
@@ -203,13 +206,13 @@ export default function MessageList(props: MessageListProps) {
   const scrollerRef = useRef<HTMLElement | null>(null);
   const endRef = useRef<HTMLDivElement>(null);
   const bubbleRefsMap = useRef<Map<string, HTMLDivElement>>(new Map());
-  const lastAnchoredIdRef = useRef<string | null>(null);
   const prevInitialLoadingRef = useRef(false);
   const scrollHeightBeforePrependRef = useRef<number | null>(null);
   const loadMoreRequestedRef = useRef(false);
   const canLoadOlderRef = useRef(false);
-  const [atBottom, setAtBottom] = useState(true);
-  const [showScrollBtn, setShowScrollBtn] = useState(false);
+  const lastSmoothScrolledUserIdRef = useRef<string | null>(null);
+  const skipNextDepsScrollRef = useRef(false);
+  const [scrollerMountKey, setScrollerMountKey] = useState(0);
   const [useVirtualLocked, setUseVirtualLocked] = useState(false);
 
   const messageGroups = useMemo(
@@ -219,6 +222,19 @@ export default function MessageList(props: MessageListProps) {
 
   const useVirtual =
     useVirtualLocked || messageGroups.length >= VIRTUALIZE_THRESHOLD;
+
+  const lastMsg = messages[messages.length - 1];
+  const isAwaitingAssistantReply = Boolean(
+    isStreaming && (!lastMsg || lastMsg.role === "user"),
+  );
+  const showThinking = Boolean(!loading && isAwaitingAssistantReply);
+  const showContinuing =
+    isStreaming &&
+    !showThinking &&
+    lastMsg?.role === "assistant" &&
+    lastMsg.status === "done";
+
+  const stableSessionKey = sessionKey || "__default__";
 
   const requestOlderMessages = useCallback(() => {
     if (
@@ -236,7 +252,6 @@ export default function MessageList(props: MessageListProps) {
       scrollHeightBeforePrependRef.current = scroller.scrollHeight;
     }
     loadMoreRequestedRef.current = true;
-    setAtBottom(false);
     onLoadMoreHistory();
   }, [
     historyHasMore,
@@ -245,6 +260,52 @@ export default function MessageList(props: MessageListProps) {
     onLoadMoreHistory,
     useVirtual,
   ]);
+
+  const virtualScrollConfig = useMemo(
+    () =>
+      useVirtual
+        ? {
+            virtuosoRef,
+            scrollerRef,
+            itemCount: messageGroups.length,
+          }
+        : null,
+    [useVirtual, messageGroups.length],
+  );
+
+  const scrollFollowDeps = useMemo(
+    () => ({
+      count: messages.length,
+      lastId: lastMsg?.id ?? "",
+      lastContent: lastMsg?.content ?? "",
+      lastStatus: lastMsg?.status ?? "",
+      showThinking,
+      showContinuing,
+    }),
+    [messages.length, lastMsg, showThinking, showContinuing],
+  );
+
+  const {
+    showScrollBtn,
+    scrollToBottom,
+    armProgrammaticGuard,
+    handleAtBottomChange,
+  } = useAutoScroll({
+    containerRef,
+    endRef,
+    virtual: virtualScrollConfig,
+    scrollerMountKey,
+    onNearTop: requestOlderMessages,
+    deps: [
+      scrollFollowDeps.count,
+      scrollFollowDeps.lastId,
+      scrollFollowDeps.lastContent,
+      scrollFollowDeps.lastStatus,
+      scrollFollowDeps.showThinking,
+      scrollFollowDeps.showContinuing,
+    ],
+    skipNextDepsScrollRef,
+  });
 
   useEffect(() => {
     if (!loading && messages.length > 0) {
@@ -262,12 +323,13 @@ export default function MessageList(props: MessageListProps) {
     if (scrollHeightBeforePrependRef.current === null) return;
     const scroller = useVirtual ? scrollerRef.current : containerRef.current;
     if (scroller instanceof HTMLElement) {
+      armProgrammaticGuard();
       const delta =
         scroller.scrollHeight - scrollHeightBeforePrependRef.current;
       scroller.scrollTop += delta;
     }
     scrollHeightBeforePrependRef.current = null;
-  }, [messages, useVirtual]);
+  }, [messages, useVirtual, armProgrammaticGuard]);
 
   const historyHeader = useMemo(() => {
     if (!historyHasMore && !historyLoadingMore) return null;
@@ -306,54 +368,14 @@ export default function MessageList(props: MessageListProps) {
     [],
   );
 
-  const scrollToBottom = useCallback(
-    (instant = false) => {
-      if (useVirtual) {
-        if (messageGroups.length > 0) {
-          virtuosoRef.current?.scrollToIndex({
-            index: messageGroups.length - 1,
-            align: "end",
-            behavior: instant ? "auto" : "smooth",
-          });
-        }
-        setAtBottom(true);
-        setShowScrollBtn(false);
-        return;
-      }
-      const end = endRef.current;
-      if (!end) return;
-      end.scrollIntoView({
-        behavior: instant ? "instant" : "smooth",
-        block: "end",
-      });
-      setShowScrollBtn(false);
-    },
-    [messageGroups.length, useVirtual],
-  );
-
-  const scrollToAnchor = useCallback((anchorEl: HTMLElement) => {
-    const container = containerRef.current;
-    if (!container) return;
-    const elRect = anchorEl.getBoundingClientRect();
-    const containerRect = container.getBoundingClientRect();
-    const targetScrollTop =
-      container.scrollTop + (elRect.top - containerRect.top) - 16;
-    container.scrollTo({
-      top: Math.max(0, targetScrollTop),
-      behavior: "smooth",
-    });
-    setShowScrollBtn(false);
-  }, []);
-
-  const stableSessionKey = sessionKey || "__default__";
-
   useEffect(() => {
     setUseVirtualLocked(false);
     loadMoreRequestedRef.current = false;
     canLoadOlderRef.current = false;
-    lastAnchoredIdRef.current = null;
+    lastSmoothScrolledUserIdRef.current = null;
     scrollHeightBeforePrependRef.current = null;
-  }, [stableSessionKey]);
+    scrollToBottom(true);
+  }, [stableSessionKey, scrollToBottom]);
 
   useEffect(() => {
     if (messageGroups.length >= VIRTUALIZE_THRESHOLD) {
@@ -368,67 +390,20 @@ export default function MessageList(props: MessageListProps) {
     prevInitialLoadingRef.current = !!loading;
   }, [loading, messages.length, scrollToBottom]);
 
-  useEffect(() => {
-    if (!isStreaming) return;
-
-    const lastUserMsg = [...messages].reverse().find((m) => m.role === "user");
-    if (!lastUserMsg) return;
-    if (lastAnchoredIdRef.current === lastUserMsg.id) return;
-    lastAnchoredIdRef.current = lastUserMsg.id;
-
-    if (useVirtual) {
-      const index = messageGroups.findIndex((g) =>
-        g.messages.some((m) => m.id === lastUserMsg.id),
-      );
-      if (index >= 0) {
-        virtuosoRef.current?.scrollToIndex({
-          index,
-          align: "start",
-          offset: 16,
-          behavior: "smooth",
-        });
-      }
+  useLayoutEffect(() => {
+    if (!isStreaming) {
+      lastSmoothScrolledUserIdRef.current = null;
       return;
     }
 
-    const el = bubbleRefsMap.current.get(lastUserMsg.id);
-    if (el) scrollToAnchor(el);
-  }, [isStreaming, messages, messageGroups, scrollToAnchor, useVirtual]);
+    const lastUserMsg = [...messages].reverse().find((m) => m.role === "user");
+    if (!lastUserMsg) return;
+    if (lastSmoothScrolledUserIdRef.current === lastUserMsg.id) return;
+    lastSmoothScrolledUserIdRef.current = lastUserMsg.id;
 
-  useEffect(() => {
-    if (useVirtual || !isStreaming || !atBottom) return;
-    scrollToBottom(true);
-  }, [messages, isStreaming, atBottom, useVirtual, scrollToBottom]);
-
-  useEffect(() => {
-    if (useVirtual) return;
-    const container = containerRef.current;
-    if (!container) return;
-
-    const handleScroll = () => {
-      const bottom =
-        container.scrollHeight - container.scrollTop - container.clientHeight <=
-        80;
-      setAtBottom(bottom);
-      setShowScrollBtn(!bottom);
-      if (container.scrollTop <= 80) {
-        requestOlderMessages();
-      }
-    };
-
-    handleScroll();
-    container.addEventListener("scroll", handleScroll, { passive: true });
-    return () => container.removeEventListener("scroll", handleScroll);
-  }, [useVirtual, messageGroups.length, requestOlderMessages]);
-
-  const handleScrollBtnClick = useCallback(() => {
-    scrollToBottom();
-  }, [scrollToBottom]);
-
-  const handleAtBottomChange = useCallback((bottom: boolean) => {
-    setAtBottom(bottom);
-    setShowScrollBtn(!bottom);
-  }, []);
+    skipNextDepsScrollRef.current = true;
+    scrollToBottom(false);
+  }, [isStreaming, messages, scrollToBottom]);
 
   const groupContext = useMemo<GroupRenderContext>(
     () => ({
@@ -475,18 +450,10 @@ export default function MessageList(props: MessageListProps) {
     );
   }
 
-  const lastMsg = messages[messages.length - 1];
-  const showThinking = isStreaming && (!lastMsg || lastMsg.role === "user");
-  const showContinuing =
-    isStreaming &&
-    !showThinking &&
-    lastMsg?.role === "assistant" &&
-    lastMsg.status === "done";
-
   const footer = (
     <>
-      {showThinking && (
-        <ThinkingBubble onCancel={onCancel} sessionKey={stableSessionKey} />
+      {showThinking && thinkingStartedAt != null && (
+        <ThinkingBubble startedAt={thinkingStartedAt} onCancel={onCancel} />
       )}
       {showContinuing && <ContinuingIndicator onCancel={onCancel} />}
     </>
@@ -503,14 +470,16 @@ export default function MessageList(props: MessageListProps) {
           data={messageGroups}
           initialTopMostItemIndex={Math.max(0, messageGroups.length - 1)}
           increaseViewportBy={{ top: 600, bottom: 800 }}
-          followOutput={
-            isStreaming && atBottom && !historyLoadingMore ? "auto" : false
-          }
+          followOutput={false}
           atBottomStateChange={handleAtBottomChange}
           atTopThreshold={200}
           startReached={requestOlderMessages}
           scrollerRef={(el) => {
-            scrollerRef.current = el instanceof HTMLElement ? el : null;
+            const next = el instanceof HTMLElement ? el : null;
+            if (next !== scrollerRef.current) {
+              scrollerRef.current = next;
+              if (next) setScrollerMountKey((k) => k + 1);
+            }
           }}
           components={{
             ...virtuosoComponents,
@@ -539,7 +508,7 @@ export default function MessageList(props: MessageListProps) {
 
       <ScrollToBottomButton
         visible={showScrollBtn}
-        onClick={handleScrollBtnClick}
+        onClick={() => scrollToBottom()}
       />
     </div>
   );

--- a/dashboard/src/pages/Chat/components/ThinkingBubble.tsx
+++ b/dashboard/src/pages/Chat/components/ThinkingBubble.tsx
@@ -1,36 +1,19 @@
-import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { useElapsedSince } from "../../../hooks/useElapsedSeconds";
 import styles from "../index.module.less";
-
-const _thinkingStartedAtMap = new Map<string, number>();
 
 interface ThinkingBubbleProps {
   onCancel?: () => void;
-  sessionKey?: string;
+  startedAt: number;
 }
 
 export default function ThinkingBubble({
   onCancel,
-  sessionKey = "__default__",
+  startedAt,
 }: ThinkingBubbleProps) {
   const { t } = useTranslation();
   const symbolSrc = `${import.meta.env.BASE_URL}favico.svg`;
-
-  const [elapsed, setElapsed] = useState(() => {
-    let startedAt = _thinkingStartedAtMap.get(sessionKey);
-    if (startedAt === undefined) {
-      startedAt = Date.now();
-      _thinkingStartedAtMap.set(sessionKey, startedAt);
-    }
-    return Math.floor((Date.now() - startedAt) / 1000);
-  });
-
-  useEffect(() => {
-    const timer = setInterval(() => setElapsed((s) => s + 1), 1000);
-    return () => clearInterval(timer);
-  }, []);
-
-  const elapsedLabel = elapsed > 0 ? ` · ${elapsed}s` : "";
+  const elapsed = useElapsedSince(startedAt);
 
   return (
     <div className={styles.thinkingBubble}>
@@ -45,7 +28,7 @@ export default function ThinkingBubble({
         <span className={styles.thinkingDot} />
         <span className={styles.thinkingText}>
           {t("chat.thinking")}
-          {elapsedLabel}
+          {` · ${elapsed}s`}
         </span>
         {onCancel && (
           <button
@@ -60,8 +43,4 @@ export default function ThinkingBubble({
       </div>
     </div>
   );
-}
-
-export function clearThinkingTimer(sessionKey: string) {
-  _thinkingStartedAtMap.delete(sessionKey);
 }

--- a/dashboard/src/pages/Chat/hooks/chatStore.thinkingTimer.test.ts
+++ b/dashboard/src/pages/Chat/hooks/chatStore.thinkingTimer.test.ts
@@ -1,0 +1,26 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { getSnapshot, removeSession, sendTurn } from "./chatStore";
+
+const SESSION = "test-thinking-started-at";
+
+describe("thinkingStartedAt", () => {
+  afterEach(() => {
+    removeSession(SESSION);
+  });
+
+  it("is set when sendTurn starts and cleared when the turn ends", async () => {
+    expect(getSnapshot(SESSION).thinkingStartedAt).toBeNull();
+
+    const before = Date.now();
+    const turn = sendTurn(SESSION, "hi", "agent-1", "", undefined);
+    const snap = getSnapshot(SESSION);
+    expect(snap.thinkingStartedAt).not.toBeNull();
+    expect(snap.thinkingStartedAt).toBeGreaterThanOrEqual(before);
+    expect(snap.isStreaming).toBe(true);
+
+    await turn;
+
+    expect(getSnapshot(SESSION).thinkingStartedAt).toBeNull();
+    expect(getSnapshot(SESSION).isStreaming).toBe(false);
+  });
+});

--- a/dashboard/src/pages/Chat/hooks/chatStore.ts
+++ b/dashboard/src/pages/Chat/hooks/chatStore.ts
@@ -99,6 +99,7 @@ export type {
 const EMPTY_SNAPSHOT: SessionSnapshot = Object.freeze({
   messages: [],
   isStreaming: false,
+  thinkingStartedAt: null,
   runUsage: null,
   contextUsage: null,
   historyHasMore: false,
@@ -218,6 +219,7 @@ function buildSnapshot(state: SessionStreamState): SessionSnapshot {
   return {
     messages: state.messages,
     isStreaming: state.isStreaming,
+    thinkingStartedAt: state.thinkingStartedAt,
     runUsage: state.runUsage,
     contextUsage: state.contextUsage,
     historyHasMore: state.historyHasMore,
@@ -232,6 +234,7 @@ function getOrCreate(sessionId: string): SessionStreamState {
     state = {
       messages: [],
       isStreaming: false,
+      thinkingStartedAt: null,
       runUsage: null,
       contextUsage: null,
       abortController: null,
@@ -260,6 +263,16 @@ function notify(state: SessionStreamState) {
       /* ignore */
     }
   }
+}
+
+function beginStream(state: SessionStreamState): void {
+  state.thinkingStartedAt = Date.now();
+  state.isStreaming = true;
+}
+
+function clearStreamingFlags(state: SessionStreamState): void {
+  state.isStreaming = false;
+  state.thinkingStartedAt = null;
 }
 
 // ── Public API ────────────────────────────────────────────────────────────
@@ -364,7 +377,7 @@ export function truncateAndReplaceUserMessage(
     ...state.messages.slice(0, idx),
     { ...original, content: newContent, status: "done" as const },
   ];
-  state.isStreaming = false;
+  clearStreamingFlags(state);
   state.runUsage = null;
   state.streamMsg = "";
   state.streamId = "";
@@ -392,7 +405,7 @@ export function appendPushMessage(text: string) {
 export function clearMessages(sessionId: string) {
   const state = getOrCreate(sessionId);
   state.messages = [];
-  state.isStreaming = false;
+  clearStreamingFlags(state);
   state.runUsage = null;
   state.streamMsg = "";
   state.streamId = "";
@@ -410,7 +423,7 @@ export function cancelStream(sessionId: string) {
   if (!state) return;
   state.abortController?.abort();
   state.abortController = null;
-  state.isStreaming = false;
+  clearStreamingFlags(state);
   state.runUsage = null;
   state.messages = state.messages.map((m) =>
     m.status === "streaming" ? { ...m, status: "done" as const } : m,
@@ -1028,7 +1041,7 @@ function handleHitlRequired(
   request: Record<string, unknown>,
 ): void {
   finalizeStreamingMessages(state);
-  state.isStreaming = false;
+  clearStreamingFlags(state);
   state.messages = [
     ...state.messages,
     {
@@ -1180,7 +1193,7 @@ export async function sendTurn(
 
   if (!agentId) {
     appendErrorBubble(state, "No agent selected. Pick one from the top bar.");
-    state.isStreaming = false;
+    clearStreamingFlags(state);
     notify(state);
     onStreamEnd?.();
     return;
@@ -1192,7 +1205,7 @@ export async function sendTurn(
   state.streamMsg = "";
   state.streamId = "";
   state.streamBlockType = "";
-  state.isStreaming = true;
+  beginStream(state);
   state.runUsage = null;
   notify(state);
 
@@ -1204,7 +1217,7 @@ export async function sendTurn(
   const messageContent = buildUserMessageContent(text, attachments);
 
   const finish = () => {
-    state.isStreaming = false;
+    clearStreamingFlags(state);
     state.abortController = null;
     state.streamMsg = "";
     state.streamId = "";
@@ -1307,7 +1320,7 @@ export async function resumeHitl(
     ? "rejected"
     : "approved";
   resolveHitlPending(state, hitlStatus);
-  state.isStreaming = true;
+  beginStream(state);
   notify(state);
   emitStreamEvent({ kind: "streamStart", sessionId });
 
@@ -1324,7 +1337,7 @@ export async function resumeHitl(
   }
 
   const finish = () => {
-    state.isStreaming = false;
+    clearStreamingFlags(state);
     state.abortController = null;
     state.streamMsg = "";
     state.streamId = "";

--- a/dashboard/src/pages/Chat/hooks/sseHelpers.ts
+++ b/dashboard/src/pages/Chat/hooks/sseHelpers.ts
@@ -72,6 +72,8 @@ export interface ChatMessage {
 export interface SessionStreamState {
   messages: ChatMessage[];
   isStreaming: boolean;
+  /** Wall-clock ms when the current user turn started waiting on the model. */
+  thinkingStartedAt: number | null;
   runUsage: TokenUsage | null;
   /** Latest prompt/context token count from SSE state snapshots. */
   contextUsage: TokenUsage | null;
@@ -99,6 +101,7 @@ export interface SessionStreamState {
 export interface SessionSnapshot {
   messages: ChatMessage[];
   isStreaming: boolean;
+  thinkingStartedAt: number | null;
   runUsage: TokenUsage | null;
   contextUsage: TokenUsage | null;
   historyHasMore: boolean;

--- a/dashboard/src/pages/Chat/hooks/useAutoScroll.test.ts
+++ b/dashboard/src/pages/Chat/hooks/useAutoScroll.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { useAutoScroll } from "./useAutoScroll";
+
+function makeScroller({
+  scrollHeight = 1000,
+  clientHeight = 200,
+  scrollTop = 700,
+}: {
+  scrollHeight?: number;
+  clientHeight?: number;
+  scrollTop?: number;
+} = {}) {
+  const el = document.createElement("div");
+  let top = scrollTop;
+  Object.defineProperty(el, "scrollHeight", {
+    value: scrollHeight,
+    configurable: true,
+  });
+  Object.defineProperty(el, "clientHeight", {
+    value: clientHeight,
+    configurable: true,
+  });
+  Object.defineProperty(el, "scrollTop", {
+    get: () => top,
+    set: (value: number) => {
+      top = value;
+    },
+    configurable: true,
+  });
+  el.scrollTo = vi.fn(({ top: nextTop }: ScrollToOptions) => {
+    top = nextTop ?? top;
+  }) as unknown as typeof el.scrollTo;
+  return el;
+}
+
+describe("useAutoScroll", () => {
+  beforeEach(() => {
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation((cb) => {
+      cb(0);
+      return 1;
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("enters free mode on wheel up and shows the scroll button", () => {
+    const container = makeScroller();
+    const containerRef = { current: container };
+    const end = document.createElement("div");
+    end.scrollIntoView = vi.fn();
+    const endRef = { current: end };
+
+    const { result } = renderHook(() =>
+      useAutoScroll({ containerRef, endRef, deps: [] }),
+    );
+
+    act(() => {
+      container.dispatchEvent(new WheelEvent("wheel", { deltaY: -40, bubbles: true }));
+    });
+
+    expect(result.current.showScrollBtn).toBe(true);
+  });
+
+  it("does not follow new deps while in free mode", () => {
+    const container = makeScroller();
+    const containerRef = { current: container };
+    const endRef = { current: document.createElement("div") };
+    endRef.current.scrollIntoView = vi.fn();
+
+    const { result, rerender } = renderHook(
+      ({ token }: { token: number }) =>
+        useAutoScroll({ containerRef, endRef, deps: [token] }),
+      { initialProps: { token: 1 } },
+    );
+
+    act(() => {
+      container.dispatchEvent(new WheelEvent("wheel", { deltaY: -40, bubbles: true }));
+    });
+    expect(result.current.showScrollBtn).toBe(true);
+
+    endRef.current.scrollIntoView = vi.fn();
+    rerender({ token: 2 });
+
+    expect(endRef.current.scrollIntoView).not.toHaveBeenCalled();
+  });
+
+  it("resumes follow mode when scrollToBottom is called", () => {
+    const container = makeScroller({ scrollTop: 400 });
+    const containerRef = { current: container };
+    const endRef = { current: document.createElement("div") };
+    endRef.current.scrollIntoView = vi.fn();
+
+    const { result } = renderHook(() =>
+      useAutoScroll({ containerRef, endRef, deps: [] }),
+    );
+
+    act(() => {
+      container.dispatchEvent(new WheelEvent("wheel", { deltaY: -40, bubbles: true }));
+    });
+    expect(result.current.showScrollBtn).toBe(true);
+
+    act(() => {
+      result.current.scrollToBottom(true);
+    });
+
+    expect(result.current.showScrollBtn).toBe(false);
+    expect(endRef.current.scrollIntoView).toHaveBeenCalled();
+  });
+});

--- a/dashboard/src/pages/Chat/hooks/useAutoScroll.ts
+++ b/dashboard/src/pages/Chat/hooks/useAutoScroll.ts
@@ -1,15 +1,11 @@
 /**
  * useAutoScroll — streaming chat scroll state machine.
  *
- * Three mutually exclusive scroll modes (stored in scrollModeRef):
+ * Two mutually exclusive scroll modes (stored in scrollModeRef):
  *
- *  "follow"  — default. While streaming, each new token scrolls to the bottom.
- *  "anchor"  — activated on send. The viewport is locked at the user bubble
- *              (ANCHOR_TOP_OFFSET from the container top). Content grows
- *              downward; no auto-scroll happens. A hint ↓ button is shown
- *              when content overflows below the viewport.
- *  "free"    — user scrolled up intentionally. No automatic movement at all.
- *              ↓ button is shown. Restored to "follow" when user reaches bottom.
+ *  "follow" — default. New content scrolls to the bottom automatically.
+ *  "free"   — user scrolled up intentionally. No automatic movement.
+ *             ↓ button is shown. Restored to "follow" when user reaches bottom.
  *
  * Programmatic scroll guard:
  *  Any scrollTo / scrollIntoView fires scroll events. We mark them as
@@ -17,14 +13,12 @@
  */
 
 import { useCallback, useEffect, useRef, useState } from "react";
+import type { VirtuosoHandle } from "react-virtuoso";
 
 // ─── constants ────────────────────────────────────────────────────────────────
 
 /** px from bottom — counts as "at the bottom" */
-const AT_BOTTOM_THRESHOLD = 80;
-
-/** px gap between container top and anchored user bubble */
-const ANCHOR_TOP_OFFSET = 16;
+export const AT_BOTTOM_THRESHOLD = 80;
 
 /** ms to keep the programmatic-scroll guard alive (covers smooth-scroll animation) */
 const PROGRAMMATIC_GUARD_MS = 700;
@@ -32,38 +26,42 @@ const PROGRAMMATIC_GUARD_MS = 700;
 /** ms to wait after touchend before re-checking (iOS momentum settle) */
 const MOMENTUM_SETTLE_MS = 200;
 
+/** px before a touch gesture counts as intentional scroll-up */
+const TOUCH_SCROLL_UP_THRESHOLD = 10;
+
 // ─── types ────────────────────────────────────────────────────────────────────
 
-type ScrollMode = "follow" | "anchor" | "free";
+type ScrollMode = "follow" | "free";
+
+export interface VirtualScrollConfig {
+  virtuosoRef: React.RefObject<VirtuosoHandle | null>;
+  scrollerRef: React.RefObject<HTMLElement | null>;
+  itemCount: number;
+}
 
 export interface UseAutoScrollOptions {
   deps?: readonly unknown[];
   smooth?: boolean;
+  containerRef?: React.RefObject<HTMLElement | null>;
+  endRef?: React.RefObject<HTMLElement | null>;
+  virtual?: VirtualScrollConfig | null;
+  /** Bumps when the Virtuoso scroller element mounts so listeners re-bind. */
+  scrollerMountKey?: number;
+  onNearTop?: () => void;
+  nearTopThreshold?: number;
+  /** When true on a deps tick, skip the automatic instant follow scroll. */
+  skipNextDepsScrollRef?: React.MutableRefObject<boolean>;
 }
 
 export interface UseAutoScrollReturn {
   containerRef: React.RefObject<HTMLDivElement>;
   endRef: React.RefObject<HTMLDivElement>;
   showScrollBtn: boolean;
+  isFollowMode: boolean;
   scrollToBottom: (instant?: boolean) => void;
-  scrollToAnchor: (anchorEl: HTMLElement) => void;
-}
-
-// ─── helpers ──────────────────────────────────────────────────────────────────
-
-/**
- * Returns the scrollTop that places `el` exactly `topOffset` px below
- * the top edge of `container`, using viewport coordinates so the result
- * is independent of offsetParent chains and CSS Modules class-name hashing.
- */
-function calcAnchorScrollTop(
-  el: HTMLElement,
-  container: HTMLElement,
-  topOffset: number,
-): number {
-  const elRect = el.getBoundingClientRect();
-  const containerRect = container.getBoundingClientRect();
-  return container.scrollTop + (elRect.top - containerRect.top) - topOffset;
+  resumeAutoScroll: () => void;
+  armProgrammaticGuard: (ms?: number) => void;
+  handleAtBottomChange: (bottom: boolean) => void;
 }
 
 // ─── hook ─────────────────────────────────────────────────────────────────────
@@ -71,172 +69,180 @@ function calcAnchorScrollTop(
 export function useAutoScroll({
   deps = [],
   smooth = true,
+  containerRef: externalContainerRef,
+  endRef: externalEndRef,
+  virtual = null,
+  scrollerMountKey = 0,
+  onNearTop,
+  nearTopThreshold = AT_BOTTOM_THRESHOLD,
+  skipNextDepsScrollRef,
 }: UseAutoScrollOptions = {}): UseAutoScrollReturn {
-  const containerRef = useRef<HTMLDivElement>(null);
-  const endRef = useRef<HTMLDivElement>(null);
+  const internalContainerRef = useRef<HTMLDivElement>(null);
+  const internalEndRef = useRef<HTMLDivElement>(null);
+  const containerRef = externalContainerRef ?? internalContainerRef;
+  const endRef = externalEndRef ?? internalEndRef;
 
-  // Primary state machine — never use setState for this; refs are synchronous.
   const scrollModeRef = useRef<ScrollMode>("follow");
-
-  // RAF handle
   const rafRef = useRef<number | null>(null);
-
-  // Programmatic scroll guard
   const isProgrammaticRef = useRef(false);
   const guardTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  // Direction detection
   const prevScrollTopRef = useRef(0);
 
-  // Hint button — only this is React state (needs re-render)
   const [showScrollBtn, setShowScrollBtn] = useState(false);
+  const [isFollowMode, setIsFollowMode] = useState(true);
 
-  // ── guard helpers ──────────────────────────────────────────────────────────
+  const getScroller = useCallback((): HTMLElement | null => {
+    if (virtual?.scrollerRef.current) return virtual.scrollerRef.current;
+    return containerRef.current;
+  }, [virtual, containerRef]);
 
-  const armGuard = useCallback((ms: number) => {
+  const armProgrammaticGuard = useCallback((ms = PROGRAMMATIC_GUARD_MS) => {
     isProgrammaticRef.current = true;
     if (guardTimerRef.current !== null) clearTimeout(guardTimerRef.current);
     guardTimerRef.current = setTimeout(() => {
       guardTimerRef.current = null;
       isProgrammaticRef.current = false;
-      if (containerRef.current) {
-        prevScrollTopRef.current = containerRef.current.scrollTop;
+      const scroller = getScroller();
+      if (scroller) {
+        prevScrollTopRef.current = scroller.scrollTop;
       }
     }, ms);
-  }, []);
-
-  // ── position helpers ───────────────────────────────────────────────────────
+  }, [getScroller]);
 
   const isAtBottom = useCallback((): boolean => {
-    const c = containerRef.current;
+    const c = getScroller();
     if (!c) return true;
     return c.scrollHeight - c.scrollTop - c.clientHeight <= AT_BOTTOM_THRESHOLD;
+  }, [getScroller]);
+
+  const enterFollowMode = useCallback(() => {
+    scrollModeRef.current = "follow";
+    setIsFollowMode(true);
+    setShowScrollBtn(false);
   }, []);
 
-  const isContentBelowViewport = useCallback((): boolean => {
-    const c = containerRef.current;
-    if (!c) return false;
-    return c.scrollHeight - c.scrollTop - c.clientHeight > AT_BOTTOM_THRESHOLD;
+  const enterFreeMode = useCallback(() => {
+    scrollModeRef.current = "free";
+    setIsFollowMode(false);
+    setShowScrollBtn(true);
+    isProgrammaticRef.current = false;
+    if (guardTimerRef.current !== null) {
+      clearTimeout(guardTimerRef.current);
+      guardTimerRef.current = null;
+    }
+    if (rafRef.current !== null) {
+      cancelAnimationFrame(rafRef.current);
+      rafRef.current = null;
+    }
   }, []);
 
-  // ── public scroll actions ──────────────────────────────────────────────────
-
-  const scrollToBottom = useCallback(
+  const scrollToBottomInFollowMode = useCallback(
     (instant = false) => {
-      const container = containerRef.current;
-      const end = endRef.current;
-      if (!container || !end) return;
-
-      scrollModeRef.current = "follow";
+      if (scrollModeRef.current !== "follow") return;
 
       if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
       rafRef.current = requestAnimationFrame(() => {
         rafRef.current = null;
-        armGuard(instant ? 50 : PROGRAMMATIC_GUARD_MS);
+        if (scrollModeRef.current !== "follow") return;
+
+        armProgrammaticGuard(instant ? 50 : PROGRAMMATIC_GUARD_MS);
+
+        if (virtual && virtual.itemCount > 0) {
+          const scroller = virtual.scrollerRef.current;
+          if (scroller) {
+            scroller.scrollTo({
+              top: scroller.scrollHeight,
+              behavior: instant ? "auto" : "smooth",
+            });
+          } else {
+            virtual.virtuosoRef.current?.scrollToIndex({
+              index: virtual.itemCount - 1,
+              align: "end",
+              behavior: instant ? "auto" : "smooth",
+            });
+          }
+          return;
+        }
+
+        const end = endRef.current;
+        if (!end) return;
         end.scrollIntoView({
           behavior: instant || !smooth ? "instant" : "smooth",
           block: "end",
         });
-        setShowScrollBtn(false);
       });
     },
-    [smooth, armGuard],
+    [smooth, armProgrammaticGuard, virtual, endRef],
   );
 
-  const scrollToAnchor = useCallback(
-    (anchorEl: HTMLElement) => {
-      const container = containerRef.current;
-      if (!container) return;
-
-      scrollModeRef.current = "anchor";
-
-      if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
-      rafRef.current = requestAnimationFrame(() => {
-        rafRef.current = null;
-
-        const targetScrollTop = Math.max(
-          0,
-          calcAnchorScrollTop(anchorEl, container, ANCHOR_TOP_OFFSET),
-        );
-
-        armGuard(smooth ? PROGRAMMATIC_GUARD_MS : 50);
-        container.scrollTo({
-          top: targetScrollTop,
-          behavior: smooth ? "smooth" : "instant",
-        });
-        setShowScrollBtn(false);
-      });
+  const scrollToBottom = useCallback(
+    (instant = false) => {
+      enterFollowMode();
+      scrollToBottomInFollowMode(instant);
     },
-    [smooth, armGuard],
+    [enterFollowMode, scrollToBottomInFollowMode],
   );
 
-  // ── react to new content (deps change = new tokens / messages) ─────────────
+  const resumeAutoScroll = useCallback(() => {
+    scrollToBottom(smooth);
+  }, [scrollToBottom, smooth]);
+
+  const handleAtBottomChange = useCallback((_bottom: boolean) => {
+    // Virtuoso may report at-bottom after programmatic follow scrolls.
+    // Resuming follow is handled only by user scroll/wheel/touch listeners.
+  }, []);
 
   useEffect(() => {
-    const mode = scrollModeRef.current;
-
-    if (mode === "follow") {
-      // Instant scroll during content growth — smooth scroll on every token
-      // stacks animations and causes visible jitter on long responses.
-      scrollToBottom(true);
-    } else if (mode === "anchor") {
-      // Anchor mode: don't scroll, just update the hint button.
-      setShowScrollBtn(isContentBelowViewport());
+    if (skipNextDepsScrollRef?.current) {
+      skipNextDepsScrollRef.current = false;
+      return;
     }
-    // "free" mode: user is browsing history — do nothing.
+    if (scrollModeRef.current === "follow") {
+      scrollToBottomInFollowMode(true);
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- caller supplies dynamic dependency list
-  }, [...deps, scrollToBottom, isContentBelowViewport]);
-
-  // ── event listeners ────────────────────────────────────────────────────────
+  }, [...deps, scrollToBottomInFollowMode, skipNextDepsScrollRef]);
 
   useEffect(() => {
-    const container = containerRef.current;
+    const container = getScroller();
     if (!container) return;
 
     prevScrollTopRef.current = container.scrollTop;
 
-    // ── scroll ──
-    // Fires for all sources: wheel, scrollbar drag, keyboard, touch.
     const handleScroll = (): void => {
       const cur = container.scrollTop;
       const prev = prevScrollTopRef.current;
       prevScrollTopRef.current = cur;
 
-      // Ignore events produced by our own programmatic scrolls.
-      if (isProgrammaticRef.current) return;
-
-      const scrolledUp = cur < prev - 1; // 1px hysteresis
+      const scrolledUp = cur < prev - 1;
 
       if (scrolledUp) {
-        // User intentionally scrolled up — pause everything.
-        scrollModeRef.current = "free";
-        setShowScrollBtn(true);
-      } else if (isAtBottom()) {
-        // User scrolled back to the bottom — resume follow.
-        scrollModeRef.current = "follow";
-        setShowScrollBtn(false);
-      } else if (!isContentBelowViewport()) {
-        // Content doesn't overflow the viewport — no reason to show the button.
-        setShowScrollBtn(false);
+        enterFreeMode();
+        return;
       }
-    };
 
-    // ── wheel ──
-    // Fast-path for desktop: fires *before* scrollTop updates on some browsers.
-    const handleWheel = (e: WheelEvent): void => {
       if (isProgrammaticRef.current) return;
-      if (e.deltaY < 0) {
-        scrollModeRef.current = "free";
-        setShowScrollBtn(true);
-      } else if (e.deltaY > 0 && isAtBottom()) {
-        // User scrolled down and we're already at the bottom — hide the hint.
-        // scrollTop won't change so `handleScroll` may never fire; handle here.
-        scrollModeRef.current = "follow";
-        setShowScrollBtn(false);
+
+      if (isAtBottom()) {
+        enterFollowMode();
+      }
+
+      if (onNearTop && cur <= nearTopThreshold) {
+        onNearTop();
       }
     };
 
-    // ── touch ──
+    const handleWheel = (e: WheelEvent): void => {
+      if (e.deltaY < 0) {
+        enterFreeMode();
+        return;
+      }
+      if (isProgrammaticRef.current) return;
+      if (e.deltaY > 0 && isAtBottom()) {
+        enterFollowMode();
+      }
+    };
+
     let touchStartY = 0;
 
     const handleTouchStart = (e: TouchEvent): void => {
@@ -244,34 +250,24 @@ export function useAutoScroll({
     };
 
     const handleTouchMove = (e: TouchEvent): void => {
-      if (isProgrammaticRef.current) return;
       const dy = (e.touches[0]?.clientY ?? 0) - touchStartY;
-      if (dy > 0) {
-        // Swiping down = scrolling up = user wants to read history.
-        scrollModeRef.current = "free";
-        setShowScrollBtn(true);
+      if (dy > TOUCH_SCROLL_UP_THRESHOLD) {
+        enterFreeMode();
       }
     };
 
     const handleTouchEnd = (): void => {
       setTimeout(() => {
         if (isAtBottom()) {
-          scrollModeRef.current = "follow";
-          setShowScrollBtn(false);
+          enterFollowMode();
         }
       }, MOMENTUM_SETTLE_MS);
     };
 
-    // ── ResizeObserver ──
-    // Content height grew (new tokens painted). Act per current mode.
     const handleResize = (): void => {
-      const mode = scrollModeRef.current;
-      if (mode === "follow") {
-        scrollToBottom(true); // instant during streaming for snappiness
-      } else if (mode === "anchor") {
-        setShowScrollBtn(isContentBelowViewport());
+      if (scrollModeRef.current === "follow") {
+        scrollToBottomInFollowMode(true);
       } else {
-        // "free" — just keep the button state accurate
         setShowScrollBtn(!isAtBottom());
       }
     };
@@ -297,13 +293,26 @@ export function useAutoScroll({
       if (guardTimerRef.current !== null) clearTimeout(guardTimerRef.current);
       if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
     };
-  }, [scrollToBottom, isAtBottom, isContentBelowViewport]);
+  }, [
+    getScroller,
+    scrollToBottomInFollowMode,
+    isAtBottom,
+    enterFollowMode,
+    enterFreeMode,
+    onNearTop,
+    nearTopThreshold,
+    scrollerMountKey,
+    virtual,
+  ]);
 
   return {
-    containerRef,
-    endRef,
+    containerRef: internalContainerRef,
+    endRef: internalEndRef,
     showScrollBtn,
+    isFollowMode,
     scrollToBottom,
-    scrollToAnchor,
+    resumeAutoScroll,
+    armProgrammaticGuard,
+    handleAtBottomChange,
   };
 }

--- a/dashboard/src/pages/Chat/hooks/useChat.ts
+++ b/dashboard/src/pages/Chat/hooks/useChat.ts
@@ -551,6 +551,7 @@ export function useChat(
   const {
     messages,
     isStreaming,
+    thinkingStartedAt,
     runUsage,
     contextUsage,
     historyHasMore,
@@ -740,6 +741,7 @@ export function useChat(
   return {
     messages,
     isStreaming,
+    thinkingStartedAt,
     runUsage,
     contextUsage,
     historyLoading,

--- a/dashboard/src/pages/Chat/index.tsx
+++ b/dashboard/src/pages/Chat/index.tsx
@@ -166,6 +166,7 @@ function ChatPageInner() {
   const {
     messages,
     isStreaming,
+    thinkingStartedAt,
     historyLoading,
     historyHasMore,
     historyLoadingMore,
@@ -536,6 +537,7 @@ function ChatPageInner() {
                 historyLoadingMore={historyLoadingMore}
                 onLoadMoreHistory={() => void loadMoreHistory()}
                 isStreaming={isStreaming}
+                thinkingStartedAt={thinkingStartedAt}
                 sessionKey={activeThreadId ?? undefined}
                 onCancel={cancelStream}
                 onRegenerate={handleRegenerate}


### PR DESCRIPTION
## Summary
- Refactor `useAutoScroll` into follow/free scroll modes for streaming chat.
- Track `thinkingStartedAt` in `chatStore` and show elapsed seconds in `ThinkingBubble`.
- Add unit tests for auto-scroll and thinking timer behavior.

## Test plan
- [x] `cd dashboard && npx tsc --noEmit`
- [x] Dashboard unit tests for `useAutoScroll` and `useElapsedSince`

Made with [Cursor](https://cursor.com)