### PR TITLE
Add host root_dir browser and permission probe

### DIFF
--- a/dashboard/src/hooks/useAgentFormResources.ts
+++ b/dashboard/src/hooks/useAgentFormResources.ts
@@ -9,6 +9,7 @@ export interface AgentStorageBackend {
   name: string;
   kind: string;
   enabled: boolean;
+  bucket?: string | null;
 }
 
 export interface AgentFormResources {

--- a/dashboard/src/locales/en.json
+++ b/dashboard/src/locales/en.json
@@ -386,7 +386,16 @@
     "goToAdmin": "Go to Admin",
     "backendLabel": "Storage Backend",
     "backendRootDir": "Storage Root Dir",
-    "backendRootDirDesc": "Host filesystem root the backend may access, default `/`. Workspace file paths resolve relative to this directory; confirm permission scope before changing.",
+    "backendRootDirPlaceholder": "Browse subdirectories from /",
+    "backendRootDirDesc": "Browse from filesystem root `/` and pick a directory the agent may access. When you choose a path other than `/`, Octop checks read/write/execute access before saving.",
+    "rootDirListFailed": "Could not list subdirectories. Check permissions or choose another path.",
+    "rootDirProbe": {
+      "not_directory": "The selected path is not a valid directory.",
+      "not_allowed": "This path cannot be used as a storage root.",
+      "permission_denied": "The Octop service does not have full read, write, and execute access to this directory.",
+      "write_failed": "Could not create a test file in this directory: {{detail}}",
+      "guidance": "Choose a directory with sufficient permissions, or adjust ownership/permissions (e.g. chown, chmod) and try again."
+    },
     "backendPlaceholder": "Select a backend type",
     "backendPathMappings": "Path Mappings (optional)",
     "addPathMapping": "Add path mapping",

--- a/dashboard/src/locales/zh.json
+++ b/dashboard/src/locales/zh.json
@@ -385,7 +385,16 @@
     "goToAdmin": "前往配置",
     "backendLabel": "存储后端",
     "backendRootDir": "存储根目录",
-    "backendRootDirDesc": "后端可访问的主机文件系统根路径，默认为 /。工作区内的文件路径均相对此目录解析；修改前请确认权限范围。",
+    "backendRootDirPlaceholder": "从 / 起选择子目录",
+    "backendRootDirDesc": "从文件系统根目录 / 浏览并选择 Agent 可访问的目录；选择非 / 路径时，保存前会检测 Octop 服务是否具备读、写、执行权限。",
+    "rootDirListFailed": "无法列出子目录，请检查权限或选择其他路径。",
+    "rootDirProbe": {
+      "not_directory": "所选路径不是有效目录。",
+      "not_allowed": "不允许使用该路径作为存储根目录。",
+      "permission_denied": "Octop 服务对该目录没有完整的读、写、执行权限。",
+      "write_failed": "无法在该目录创建测试文件：{{detail}}",
+      "guidance": "请改用有权限的目录，或调整目录所有权/权限（例如 chown、chmod）后重试。"
+    },
     "backendPlaceholder": "选择存储后端类型",
     "backendModes": {
       "localShell": "本地完整环境（文件系统+指令执行）",

--- a/dashboard/src/pages/Experts/components/AgentBackendFields.tsx
+++ b/dashboard/src/pages/Experts/components/AgentBackendFields.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 import { Form, Input, Select } from "antd";
+import RootDirSelect from "./RootDirSelect";
 import { MinusCircle } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import {
@@ -130,7 +131,7 @@ export default function AgentBackendFields({
             label={t("experts.backendRootDir")}
             initialValue="/"
           >
-            <Input placeholder="/" />
+            <RootDirSelect />
           </Form.Item>
           <div style={{ margin: "-8px 0 12px" }}>
             <p

--- a/dashboard/src/pages/Experts/components/CreateFromExpertDrawer.tsx
+++ b/dashboard/src/pages/Experts/components/CreateFromExpertDrawer.tsx
@@ -27,6 +27,9 @@ import { useSkillSlugDisplayName } from "../../Agent/Skills/skillDisplayNames";
 import {
   buildBackendSpec,
   DEFAULT_BACKEND,
+  probeRootDir,
+  rootDirProbeMessage,
+  shouldProbeRootDir,
   validatePathMappings,
   type PathMapping,
 } from "./agentBackendForm";
@@ -114,6 +117,15 @@ export default function CreateFromExpertDrawer({
       const pathError = validatePathMappings(pathMappings, t);
       if (pathError) {
         message.error(pathError);
+        return;
+      }
+    }
+    if (shouldProbeRootDir(values.backend_choice, values.root_dir)) {
+      const probe = await probeRootDir(values.root_dir ?? "/");
+      if (!probe.ok) {
+        message.error(
+          `${rootDirProbeMessage(probe, t)}\n${t("experts.rootDirProbe.guidance")}`,
+        );
         return;
       }
     }

--- a/dashboard/src/pages/Experts/components/EditAgentDrawer.tsx
+++ b/dashboard/src/pages/Experts/components/EditAgentDrawer.tsx
@@ -35,6 +35,9 @@ import {
   buildBackendSpec,
   DEFAULT_BACKEND,
   parseBackendSpec,
+  probeRootDir,
+  rootDirProbeMessage,
+  shouldProbeRootDir,
   validatePathMappings,
   type PathMapping,
 } from "./agentBackendForm";
@@ -243,6 +246,15 @@ function EditAgentDrawerBody({
       const pathError = validatePathMappings(pathMappings, t);
       if (pathError) {
         message.error(pathError);
+        return;
+      }
+    }
+    if (shouldProbeRootDir(values.backend_choice, values.root_dir)) {
+      const probe = await probeRootDir(values.root_dir ?? "/");
+      if (!probe.ok) {
+        message.error(
+          `${rootDirProbeMessage(probe, t)}\n${t("experts.rootDirProbe.guidance")}`,
+        );
         return;
       }
     }

--- a/dashboard/src/pages/Experts/components/RootDirSelect.tsx
+++ b/dashboard/src/pages/Experts/components/RootDirSelect.tsx
@@ -1,0 +1,117 @@
+import { useCallback, useEffect, useState } from "react";
+import { message, Spin, TreeSelect } from "antd";
+import type { TreeSelectProps } from "antd";
+import { useTranslation } from "react-i18next";
+import { request } from "../../../api/request";
+
+interface DirEntry {
+  path: string;
+  name: string;
+}
+
+interface DirTreeNode {
+  value: string;
+  title: string;
+  isLeaf?: boolean;
+  children?: DirTreeNode[];
+}
+
+const ROOT_NODE: DirTreeNode = {
+  value: "/",
+  title: "/",
+  isLeaf: false,
+};
+
+function appendChildren(
+  nodes: DirTreeNode[],
+  parentPath: string,
+  children: DirTreeNode[],
+): DirTreeNode[] {
+  return nodes.map((node) => {
+    if (node.value === parentPath) {
+      const existing = node.children ?? [];
+      const seen = new Set(existing.map((child) => child.value));
+      const merged = [
+        ...existing,
+        ...children.filter((child) => !seen.has(child.value)),
+      ];
+      return { ...node, children: merged };
+    }
+    if (node.children?.length) {
+      return {
+        ...node,
+        children: appendChildren(node.children, parentPath, children),
+      };
+    }
+    return node;
+  });
+}
+
+function ensurePathInTree(nodes: DirTreeNode[], path: string): DirTreeNode[] {
+  if (!path || nodes.some((node) => node.value === path)) {
+    return nodes;
+  }
+  return [...nodes, { value: path, title: path, isLeaf: false }];
+}
+
+interface RootDirSelectProps {
+  value?: string;
+  onChange?: (value: string) => void;
+}
+
+export default function RootDirSelect({ value, onChange }: RootDirSelectProps) {
+  const { t } = useTranslation();
+  const [treeData, setTreeData] = useState<DirTreeNode[]>([ROOT_NODE]);
+
+  useEffect(() => {
+    if (!value) return;
+    setTreeData((prev) => ensurePathInTree(prev, value));
+  }, [value]);
+
+  const loadData = useCallback<NonNullable<TreeSelectProps["loadData"]>>(
+    async (node) => {
+      const path = String(node.value ?? "");
+      if (!path) return;
+
+      try {
+        const data = await request<{ entries: DirEntry[] }>(
+          `/filesystem/dirs?path=${encodeURIComponent(path)}`,
+        );
+        const children = data.entries.map((entry) => ({
+          value: entry.path,
+          title: entry.name,
+          isLeaf: false,
+        }));
+        setTreeData((prev) => appendChildren(prev, path, children));
+      } catch {
+        message.error(t("experts.rootDirListFailed"));
+      }
+    },
+    [t],
+  );
+
+  return (
+    <TreeSelect
+      value={value}
+      onChange={onChange}
+      treeData={treeData}
+      loadData={loadData}
+      showSearch
+      treeLine
+      treeDefaultExpandAll={false}
+      placeholder={t("experts.backendRootDirPlaceholder")}
+      notFoundContent={<Spin size="small" />}
+      style={{ width: "100%" }}
+      popupMatchSelectWidth={false}
+      dropdownStyle={{ maxHeight: 360, overflow: "auto" }}
+      filterTreeNode={(input, node) =>
+        String(node.title ?? "")
+          .toLowerCase()
+          .includes(input.trim().toLowerCase()) ||
+        String(node.value ?? "")
+          .toLowerCase()
+          .includes(input.trim().toLowerCase())
+      }
+    />
+  );
+}

--- a/dashboard/src/pages/Experts/components/agentBackendForm.ts
+++ b/dashboard/src/pages/Experts/components/agentBackendForm.ts
@@ -1,3 +1,5 @@
+import { request } from "../../../api/request";
+
 export const BUILTIN_BACKENDS = ["local_shell", "filesystem", "state"] as const;
 export const DEFAULT_BACKEND: BuiltinBackend = "local_shell";
 export type BuiltinBackend = (typeof BUILTIN_BACKENDS)[number];
@@ -13,6 +15,7 @@ export interface BackendOption {
   name: string;
   kind: string;
   enabled: boolean;
+  bucket?: string | null;
 }
 
 export function isNamedBackend(ref: string): ref is `named:${string}` {
@@ -38,6 +41,46 @@ export function backendRefToSpec(
 export function isValidCompositePath(path: string): boolean {
   const trimmed = path.trim();
   return trimmed.length > 0 && trimmed.startsWith("/") && trimmed !== "/";
+}
+
+export function needsRootDirProbe(choice: string): boolean {
+  return choice === "local_shell" || choice === "filesystem";
+}
+
+export type RootDirProbeCode =
+  | "not_directory"
+  | "permission_denied"
+  | "write_failed"
+  | "not_allowed";
+
+export interface RootDirProbeResult {
+  ok: boolean;
+  code?: RootDirProbeCode;
+  detail?: string;
+  path?: string;
+}
+
+export function shouldProbeRootDir(choice: string, rootDir?: string): boolean {
+  if (!needsRootDirProbe(choice)) return false;
+  const normalized = (rootDir?.trim() || "/").replace(/\/+$/, "") || "/";
+  return normalized !== "/";
+}
+
+export async function probeRootDir(path: string): Promise<RootDirProbeResult> {
+  return request<RootDirProbeResult>("/filesystem/probe", {
+    method: "POST",
+    body: JSON.stringify({ path: path.trim() || "/" }),
+  });
+}
+
+export function rootDirProbeMessage(
+  result: RootDirProbeResult,
+  t: (key: string, opts?: Record<string, unknown>) => string,
+): string {
+  if (result.ok) return "";
+  const code = result.code ?? "write_failed";
+  const key = `experts.rootDirProbe.${code}`;
+  return t(key, { detail: result.detail ?? "" });
 }
 
 export function validatePathMappings(

--- a/docs/api.md
+++ b/docs/api.md
@@ -258,6 +258,19 @@ Zed setup example.
 | `GET`/`POST`/`PATCH`/`DELETE` | `/storage-backends` | user | per-user remote backend connections |
 | `GET`/`POST`/`PATCH`/`DELETE` | `/admin/storage-backends` | admin | admin-managed backends |
 
+## Host filesystem (dashboard)
+
+Browse the host OS directory tree when configuring a local backend
+`root_dir` (`local_shell` / `filesystem`). Authenticated users only;
+sensitive mounts (`/proc`, `/sys`, `/dev`, `/etc`, `/root` on POSIX)
+are rejected. Listing is single-level and capped; write probe runs only
+for non-`/` paths.
+
+| Method | Path | Auth | Notes |
+|--------|------|------|-------|
+| `GET`    | `/filesystem/dirs?path=<abs>` | user | `{path, entries: [{path, name}]}` — one directory level |
+| `POST`   | `/filesystem/probe` | user | body `{path}` → `{ok, path?}` or `{ok: false, code, detail?}` (`not_directory`, `permission_denied`, `write_failed`, `not_allowed`) |
+
 ## Connectors & OAuth
 
 | Method | Path | Auth | Notes |

--- a/src/octop/api/app.py
+++ b/src/octop/api/app.py
@@ -123,6 +123,7 @@ def build_app(server: OctopServer) -> FastAPI:
         voice,
         workspace,
     )
+    from octop.api.routers.filesystem import router as filesystem_router
     from octop.api.routers.observability import router as observability_router
     from octop.api.routers.providers import admin_router as admin_providers_router
     from octop.api.routers.security import router as security_router
@@ -162,6 +163,7 @@ def build_app(server: OctopServer) -> FastAPI:
             _RouterMount(
                 storage_backends_user_router, "/api/storage-backends", ["storage-backends"]
             ),
+            _RouterMount(filesystem_router, "/api/filesystem", ["filesystem"]),
             _RouterMount(mbti.router, "/api", ["mbti"]),
             _RouterMount(experts.router, "/api", ["experts"]),
             _RouterMount(workspace.router, "/api", ["workspace"]),

--- a/src/octop/api/openapi_meta.py
+++ b/src/octop/api/openapi_meta.py
@@ -92,6 +92,10 @@ OPENAPI_TAGS: list[dict[str, str]] = [
     },
     {"name": "admin", "description": "Server-wide admin operations (audit log, storage, usage)."},
     {"name": "storage-backends", "description": "User-visible remote storage backend connections."},
+    {
+        "name": "filesystem",
+        "description": "Host filesystem directory browsing for dashboard forms.",
+    },
     {"name": "mbti", "description": "MBTI persona presets applied to agent personality."},
     {"name": "experts", "description": "Bundled expert templates for creating specialized agents."},
     {"name": "workspace", "description": "Agent workspace file tree: list, read, write, upload."},

--- a/src/octop/api/routers/filesystem.py
+++ b/src/octop/api/routers/filesystem.py
@@ -1,0 +1,53 @@
+"""Host filesystem browsing for dashboard forms (root_dir pickers).
+
+Security notes:
+- Authenticated users only (JWT).
+- Paths are resolved absolutely; ``..`` / symlinks cannot escape a denylist
+  of sensitive pseudo-fs mounts (``/proc``, ``/sys``, ``/dev``, ``/etc``, ``/root`` on POSIX).
+- Directory listing is capped and skips unreadable entries.
+- Write probe creates a short-lived dotfile only for non-``/`` selections.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from fastapi import APIRouter, Depends, Query
+from pydantic import BaseModel, Field
+
+from octop.api.deps import current_user
+from octop.infra.errors import ErrorCode, OctopError
+from octop.infra.utils.host_dirs import (
+    assert_safe_host_path,
+    list_host_subdirs,
+    probe_host_root_dir,
+)
+
+router = APIRouter()
+
+
+class ProbeBody(BaseModel):
+    path: str = Field("/", description="Host directory to verify read/write access")
+
+
+@router.get("/dirs")
+async def list_host_dirs(
+    path: str = Query("/", description="Absolute host directory to list"),
+    _: Any = Depends(current_user),
+) -> dict[str, Any]:
+    """Single-level directory listing for lazy folder pickers."""
+    try:
+        entries = await asyncio.to_thread(list_host_subdirs, path)
+    except ValueError as exc:
+        raise OctopError(ErrorCode.WORKSPACE_OP_UNSUPPORTED, str(exc)) from exc
+    return {"path": str(assert_safe_host_path(path)), "entries": entries}
+
+
+@router.post("/probe")
+async def probe_host_dir(
+    body: ProbeBody,
+    _: Any = Depends(current_user),
+) -> dict[str, Any]:
+    """Check whether Octop can use *path* as a local backend root_dir."""
+    return await asyncio.to_thread(probe_host_root_dir, body.path)

--- a/src/octop/infra/utils/host_dirs.py
+++ b/src/octop/infra/utils/host_dirs.py
@@ -1,0 +1,104 @@
+"""Host filesystem directory helpers for dashboard root_dir pickers."""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import uuid
+from pathlib import Path
+from typing import Any, Literal
+
+ProbeCode = Literal["not_directory", "permission_denied", "write_failed", "not_allowed"]
+
+_MAX_LIST_ENTRIES = 1000
+
+# Host paths that must not be browsed or used as workspace roots (POSIX).
+_DENIED_PREFIXES_POSIX = ("/proc", "/sys", "/dev", "/etc", "/root")
+
+
+def normalize_host_path(path: str) -> Path:
+    raw = path.strip() or "/"
+    return Path(raw).expanduser().resolve()
+
+
+def _is_denied_host_path(resolved: Path) -> bool:
+    if os.name != "posix":
+        return False
+    text = resolved.as_posix()
+    return any(text == denied or text.startswith(f"{denied}/") for denied in _DENIED_PREFIXES_POSIX)
+
+
+def assert_safe_host_path(path: str) -> Path:
+    """Resolve *path* and reject traversal tricks / disallowed host locations."""
+    if not path or "\0" in path:
+        raise ValueError("invalid path")
+    try:
+        resolved = normalize_host_path(path)
+    except OSError as exc:
+        raise ValueError("invalid path") from exc
+    if not resolved.is_absolute():
+        raise ValueError("path must be absolute")
+    if _is_denied_host_path(resolved):
+        raise ValueError("path not allowed")
+    return resolved
+
+
+def list_host_subdirs(path: str) -> list[dict[str, Any]]:
+    """List readable child directories under *path*."""
+    root = assert_safe_host_path(path)
+    if not root.is_dir():
+        raise ValueError(f"not a directory: {path}")
+
+    entries: list[dict[str, Any]] = []
+    try:
+        children = sorted(root.iterdir(), key=lambda p: p.name.lower())
+    except PermissionError as exc:
+        raise ValueError(f"permission denied: {path}") from exc
+
+    for child in children:
+        if len(entries) >= _MAX_LIST_ENTRIES:
+            break
+        if not child.is_dir():
+            continue
+        try:
+            resolved = child.resolve()
+            if not resolved.is_dir():
+                continue
+            if _is_denied_host_path(resolved):
+                continue
+            if not os.access(resolved, os.R_OK | os.X_OK):
+                continue
+        except OSError:
+            continue
+        entries.append({"path": str(resolved), "name": child.name})
+    return entries
+
+
+def probe_host_root_dir(path: str) -> dict[str, Any]:
+    """Verify *path* exists; write-probe only when not filesystem root ``/``."""
+    try:
+        root = assert_safe_host_path(path)
+    except ValueError as exc:
+        message = str(exc)
+        code: ProbeCode = "not_allowed" if "not allowed" in message else "not_directory"
+        return {"ok": False, "code": code, "detail": message}
+
+    if not root.is_dir():
+        return {"ok": False, "code": "not_directory"}
+
+    if os.name == "posix" and root.as_posix() == "/":
+        return {"ok": True, "path": "/"}
+
+    if not os.access(root, os.R_OK | os.W_OK | os.X_OK):
+        return {"ok": False, "code": "permission_denied"}
+
+    probe_file = root / f".octop-root-probe-{uuid.uuid4().hex}"
+    try:
+        probe_file.write_text("", encoding="utf-8")
+    except OSError as exc:
+        return {"ok": False, "code": "write_failed", "detail": str(exc)}
+    finally:
+        with contextlib.suppress(OSError):
+            probe_file.unlink(missing_ok=True)
+
+    return {"ok": True, "path": str(root)}

--- a/tests/integration/test_filesystem_api.py
+++ b/tests/integration/test_filesystem_api.py
@@ -1,0 +1,120 @@
+"""Integration tests for /api/filesystem (host root_dir pickers)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_list_host_dirs_requires_auth(
+    env: tuple[httpx.AsyncClient, Any, dict[str, str]],
+) -> None:
+    client, _srv, _auth = env
+    r = await client.get("/api/filesystem/dirs")
+    assert r.status_code == 401, r.text
+
+
+@pytest.mark.asyncio
+async def test_list_host_dirs_lists_children(
+    env_admin_client: tuple[httpx.AsyncClient, dict[str, str]],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, auth = env_admin_client
+    (tmp_path / "alpha").mkdir()
+    (tmp_path / "beta").mkdir()
+    (tmp_path / "notes.txt").write_text("x", encoding="utf-8")
+
+    monkeypatch.setattr(
+        "octop.infra.utils.host_dirs.normalize_host_path",
+        lambda path: Path(path).resolve(),
+    )
+
+    r = await client.get(
+        f"/api/filesystem/dirs?path={tmp_path.as_posix()}",
+        headers=auth,
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["path"] == str(tmp_path.resolve())
+    names = [entry["name"] for entry in body["entries"]]
+    assert {"alpha", "beta"}.issubset(names)
+
+
+@pytest.mark.asyncio
+async def test_list_host_dirs_rejects_proc(
+    env_admin_client: tuple[httpx.AsyncClient, dict[str, str]],
+) -> None:
+    client, auth = env_admin_client
+    r = await client.get("/api/filesystem/dirs?path=/proc", headers=auth)
+    assert r.status_code == 400, r.text
+    assert r.json()["error"]["code"] == "WORKSPACE_OP_UNSUPPORTED"
+
+
+@pytest.mark.asyncio
+async def test_probe_host_dir_requires_auth(
+    env: tuple[httpx.AsyncClient, Any, dict[str, str]],
+) -> None:
+    client, _srv, _auth = env
+    r = await client.post("/api/filesystem/probe", json={"path": "/"})
+    assert r.status_code == 401, r.text
+
+
+@pytest.mark.asyncio
+async def test_probe_host_dir_ok_for_slash(
+    env_admin_client: tuple[httpx.AsyncClient, dict[str, str]],
+) -> None:
+    client, auth = env_admin_client
+    r = await client.post("/api/filesystem/probe", headers=auth, json={"path": "/"})
+    assert r.status_code == 200, r.text
+    assert r.json() == {"ok": True, "path": "/"}
+
+
+@pytest.mark.asyncio
+async def test_probe_host_dir_ok_for_writable_dir(
+    env_admin_client: tuple[httpx.AsyncClient, dict[str, str]],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, auth = env_admin_client
+    monkeypatch.setattr(
+        "octop.infra.utils.host_dirs.normalize_host_path",
+        lambda path: Path(path).resolve(),
+    )
+
+    r = await client.post(
+        "/api/filesystem/probe",
+        headers=auth,
+        json={"path": str(tmp_path)},
+    )
+    assert r.status_code == 200, r.text
+    assert r.json() == {"ok": True, "path": str(tmp_path.resolve())}
+
+
+@pytest.mark.asyncio
+async def test_probe_host_dir_rejects_file(
+    env_admin_client: tuple[httpx.AsyncClient, dict[str, str]],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, auth = env_admin_client
+    file_path = tmp_path / "notes.txt"
+    file_path.write_text("x", encoding="utf-8")
+    monkeypatch.setattr(
+        "octop.infra.utils.host_dirs.normalize_host_path",
+        lambda path: Path(path).resolve(),
+    )
+
+    r = await client.post(
+        "/api/filesystem/probe",
+        headers=auth,
+        json={"path": str(file_path)},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["ok"] is False
+    assert body["code"] == "not_directory"

--- a/tests/unit/infra/utils/test_host_dirs.py
+++ b/tests/unit/infra/utils/test_host_dirs.py
@@ -1,0 +1,72 @@
+"""Tests for host directory listing helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from octop.infra.utils.host_dirs import (
+    assert_safe_host_path,
+    list_host_subdirs,
+    normalize_host_path,
+    probe_host_root_dir,
+)
+
+
+def test_normalize_host_path_expands_user_home(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    assert normalize_host_path("~") == tmp_path.resolve()
+
+
+def test_list_host_subdirs_returns_child_directories(tmp_path: Path) -> None:
+    (tmp_path / "alpha").mkdir()
+    (tmp_path / "beta").mkdir()
+    (tmp_path / "notes.txt").write_text("x", encoding="utf-8")
+
+    entries = list_host_subdirs(str(tmp_path))
+
+    assert [item["name"] for item in entries] == ["alpha", "beta"]
+    assert all(
+        item["path"].endswith(name) for item, name in zip(entries, ["alpha", "beta"], strict=True)
+    )
+
+
+def test_list_host_subdirs_rejects_missing_path(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="not a directory"):
+        list_host_subdirs(str(tmp_path / "missing"))
+
+
+def test_assert_safe_host_path_rejects_proc() -> None:
+    with pytest.raises(ValueError, match="not allowed"):
+        assert_safe_host_path("/proc")
+
+
+def test_assert_safe_host_path_rejects_etc() -> None:
+    with pytest.raises(ValueError, match="not allowed"):
+        assert_safe_host_path("/etc/passwd")
+
+
+def test_assert_safe_host_path_rejects_root() -> None:
+    with pytest.raises(ValueError, match="not allowed"):
+        assert_safe_host_path("/root")
+
+
+def test_probe_host_root_dir_skips_write_for_slash() -> None:
+    result = probe_host_root_dir("/")
+    assert result == {"ok": True, "path": "/"}
+
+
+def test_probe_host_root_dir_ok(tmp_path: Path) -> None:
+    result = probe_host_root_dir(str(tmp_path))
+    assert result == {"ok": True, "path": str(tmp_path.resolve())}
+
+
+def test_probe_host_root_dir_rejects_file(tmp_path: Path) -> None:
+    file_path = tmp_path / "notes.txt"
+    file_path.write_text("x", encoding="utf-8")
+    result = probe_host_root_dir(str(file_path))
+    assert result["ok"] is False
+    assert result["code"] == "not_directory"


### PR DESCRIPTION
## Summary
- Add `/api/filesystem/dirs` and `/api/filesystem/probe` for dashboard root_dir pickers.
- Replace free-text root_dir input with lazy `RootDirSelect` tree browser in expert/agent forms.
- Probe read/write/execute access before saving non-`/` paths; document API in `docs/api.md`.

## Test plan
- [x] `uv run pytest tests/unit/infra/utils/test_host_dirs.py tests/integration/test_filesystem_api.py -q`
- [x] `make lint`

Made with [Cursor](https://cursor.com)