### PR TITLE
chore: release 0.9.4

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -271,6 +271,13 @@ Do **not** use gettext (`.po` files). Do **not** embed user-visible English in `
 - Document non-obvious fields with `Field(..., description="…")`; name models clearly.
 - Spot-check `/api/docs` after API changes — a route that renders as an empty card or untyped blob is unfinished.
 
+**Cross-platform tests:** Octop CI runs on both Linux and Windows, so tests must not assume a single platform:
+
+- Guard POSIX-only behavior with the repo convention `@pytest.mark.skipif(os.name != "posix", reason="…")`; prefer a module-level `posix_only = pytest.mark.skipif(os.name != "posix", reason="…")` alias.
+- Do not hard-code POSIX paths (`/`, `/proc`, `/etc`, `/root`, `~` → HOME) in assertions that run on every platform — they resolve differently on Windows (e.g. `/` → `D:\`).
+- Prefer `tmp_path` / `tmp_path_factory` and `pathlib` over OS-specific literals; use `Path.as_posix()` / `os.sep` when path string formatting matters.
+- When a feature's semantics are inherently POSIX-only (e.g. the host root_dir denied prefixes in `infra/utils/host_dirs.py`), keep the source guards (`os.name != "posix"` short-circuit) and mirror them in the tests.
+
 ## 8. Do not
 
 Boundary rules are in [§5](#5-module-boundaries). Additionally:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@
 
 格式遵循 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)，版本号遵循 [语义化版本规范](https://semver.org/spec/v2.0.0.html)。
 
+## [0.9.4] - 2026-07-11
+
+### 新增
+- 新增 agent backend 的主机 root_dir 浏览器与权限探测能力
+- 改进聊天流式滚动行为与思考计时器
+
+### 修复
+- 修复 Windows 下 sqlite 路径测试、媒体路径与 POSIX 专属测试导致的 CI 失败
+- 修复 Windows 测试收集问题（惰性导入 pwd 模块）
+- 修复 harness-memory Bridge 导入路径
+- 修复 CI 流水线并让测试套件通过，项目重命名为 Octop
+
+### 变更
+- Windows 兼容：默认 agent backend 限定到 workspace，并集中 POSIX 专属 stdlib 调用以适配 Windows mypy CI
+
 ## [0.9.1] - 2026-07-08
 
 ### 新增

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "octop"
-version = "0.9.3"
+version = "0.9.4"
 description = "Smarter self-hosted AI assistant for multiple users and agents, built on harness-agent"
 readme = "README.md"
 license = { text = "MIT" }

--- a/tests/integration/test_filesystem_api.py
+++ b/tests/integration/test_filesystem_api.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from typing import Any
 
 import httpx
 import pytest
+
+posix_only = pytest.mark.skipif(os.name != "posix", reason="POSIX root '/' probe behavior")
 
 
 @pytest.mark.asyncio
@@ -65,6 +68,7 @@ async def test_probe_host_dir_requires_auth(
 
 
 @pytest.mark.asyncio
+@posix_only
 async def test_probe_host_dir_ok_for_slash(
     env_admin_client: tuple[httpx.AsyncClient, dict[str, str]],
 ) -> None:

--- a/tests/unit/infra/utils/test_host_dirs.py
+++ b/tests/unit/infra/utils/test_host_dirs.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 import pytest
@@ -13,7 +14,12 @@ from octop.infra.utils.host_dirs import (
     probe_host_root_dir,
 )
 
+# These tests assert POSIX path semantics (/proc, /etc, /root, "/" root, "~" home).
+# The denied-prefix logic and "/" root probe are intentionally POSIX-only.
+posix_only = pytest.mark.skipif(os.name != "posix", reason="POSIX-only path semantics")
 
+
+@posix_only
 def test_normalize_host_path_expands_user_home(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -39,21 +45,25 @@ def test_list_host_subdirs_rejects_missing_path(tmp_path: Path) -> None:
         list_host_subdirs(str(tmp_path / "missing"))
 
 
+@posix_only
 def test_assert_safe_host_path_rejects_proc() -> None:
     with pytest.raises(ValueError, match="not allowed"):
         assert_safe_host_path("/proc")
 
 
+@posix_only
 def test_assert_safe_host_path_rejects_etc() -> None:
     with pytest.raises(ValueError, match="not allowed"):
         assert_safe_host_path("/etc/passwd")
 
 
+@posix_only
 def test_assert_safe_host_path_rejects_root() -> None:
     with pytest.raises(ValueError, match="not allowed"):
         assert_safe_host_path("/root")
 
 
+@posix_only
 def test_probe_host_root_dir_skips_write_for_slash() -> None:
     result = probe_host_root_dir("/")
     assert result == {"ok": True, "path": "/"}

--- a/uv.lock
+++ b/uv.lock
@@ -1963,7 +1963,7 @@ wheels = [
 
 [[package]]
 name = "octop"
-version = "0.9.3"
+version = "0.9.4"
 source = { editable = "." }
 dependencies = [
     { name = "acme" },


### PR DESCRIPTION
## [0.9.4] - 2026-07-11

### 新增
- 新增 agent backend 的主机 root_dir 浏览器与权限探测能力
- 改进聊天流式滚动行为与思考计时器

### 修复
- 修复 Windows 下 sqlite 路径测试、媒体路径与 POSIX 专属测试导致的 CI 失败
- 修复 Windows 测试收集问题（惰性导入 pwd 模块）
- 修复 harness-memory Bridge 导入路径
- 修复 CI 流水线并让测试套件通过，项目重命名为 Octop

### 变更
- Windows 兼容：默认 agent backend 限定到 workspace，并集中 POSIX 专属 stdlib 调用以适配 Windows mypy CI

已发布至 PyPI：https://pypi.org/project/octop/0.9.4/