### PR TITLE
fix: .dockerignore excludes uv.lock, breaking Docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,7 +12,6 @@ __pycache__
 *$py.class
 .venv
 venv
-uv.lock
 .pytest_cache
 .coverage
 htmlcov


### PR DESCRIPTION
## Problem

The Dockerfile copies `uv.lock` into the image (line 95):

```dockerfile
COPY pyproject.toml uv.lock README.md LICENSE ./
```

However, `.dockerignore` excludes `uv.lock`:

```
.venv
venv
uv.lock        ← this line
```

This causes the Docker build to fail immediately:

```
#15 [runtime  5/13] COPY pyproject.toml uv.lock README.md LICENSE ./
#15 ERROR: failed to calculate checksum: "/uv.lock": not found
```

The image cannot be built from source without working around this.

## Fix

Remove `uv.lock` from `.dockerignore` so it is available to the `COPY` instruction.

`uv.lock` is a lockfile that should be version-controlled and present in the Docker build context — it is required by `uv sync --frozen` in the Dockerfile.

## Verification

```bash
# Before fix: build fails
docker compose -f docker/docker-compose.yml up -d --build
# → ERROR: "/uv.lock": not found

# After fix: build succeeds
docker compose -f docker/docker-compose.yml up -d --build
# → ✅ 构建完成: octop:latest
# → Container octop  Started (healthy)
```