### PR TITLE
fix: prevent Notion OAuth popup blocking

### DIFF
--- a/dashboard/src/locales/en.json
+++ b/dashboard/src/locales/en.json
@@ -2898,6 +2898,7 @@
     "oauthSuccess": "Authorized — save the connection",
     "oauthFailed": "Failed to fetch OAuth result",
     "oauthStartFailed": "Could not start OAuth",
+    "oauthPopupBlocked": "The authorization window was blocked. Allow pop-ups for this site and try again.",
     "oauthCompleteHint": "Enter a display name and save",
     "chatPicker": "Connectors",
     "chatPickerSearch": "Search connectors",

--- a/dashboard/src/locales/zh.json
+++ b/dashboard/src/locales/zh.json
@@ -3062,6 +3062,7 @@
     "oauthSuccess": "授权成功，请保存连接",
     "oauthFailed": "获取授权结果失败",
     "oauthStartFailed": "无法启动 OAuth",
+    "oauthPopupBlocked": "授权窗口被浏览器拦截，请允许本站弹出窗口后重试",
     "oauthCompleteHint": "请填写显示名称并保存连接",
     "chatPicker": "连接器",
     "chatPickerSearch": "搜索连接器",

--- a/dashboard/src/pages/Agent/Connectors/index.tsx
+++ b/dashboard/src/pages/Agent/Connectors/index.tsx
@@ -194,6 +194,7 @@ function ConnectorConfigDrawer({
   const [form] = Form.useForm();
   const [saving, setSaving] = useState(false);
   const [probing, setProbing] = useState(false);
+  const [authorizing, setAuthorizing] = useState(false);
   const [showManual, setShowManual] = useState(false);
   const [authInfo, setAuthInfo] = useState<ConnectorAuthInfo | null>(null);
   const [instanceDetail, setInstanceDetail] =
@@ -313,22 +314,30 @@ function ConnectorConfigDrawer({
   };
 
   const handleOAuth = async () => {
-    if (!entry) return;
+    if (!entry || authorizing) return;
+    const popup = window.open("", "octop-oauth", "width=520,height=720");
+    if (!popup) {
+      message.error(
+        t(
+          "connectors.oauthPopupBlocked",
+          "授权窗口被浏览器拦截，请允许本站弹出窗口后重试",
+        ),
+      );
+      return;
+    }
+
+    setAuthorizing(true);
     try {
       const { authorize_url, state_id } = await connectorsApi.oauthStart(
         entry.kind,
         "/connectors",
       );
-      const popup = window.open(
-        authorize_url,
-        "octop-oauth",
-        "width=520,height=720",
-      );
       const onMessage = async (ev: MessageEvent) => {
+        if (ev.origin !== window.location.origin) return;
         if (ev.data?.type !== "octop:connector-oauth") return;
         if (ev.data.state_id !== state_id) return;
         window.removeEventListener("message", onMessage);
-        popup?.close();
+        popup.close();
         try {
           const pending = await connectorsApi.oauthPending(state_id);
           const tokens = pending.tokens ?? {};
@@ -347,11 +356,15 @@ function ConnectorConfigDrawer({
         }
       };
       window.addEventListener("message", onMessage);
+      popup.location.replace(authorize_url);
     } catch (e) {
+      popup.close();
       console.error(e);
       message.error(
         apiErrorMessage(e, t("connectors.oauthStartFailed", "无法启动 OAuth")),
       );
+    } finally {
+      setAuthorizing(false);
     }
   };
 
@@ -520,6 +533,7 @@ function ConnectorConfigDrawer({
             <Button
               type="primary"
               icon={<Sparkles size={14} />}
+              loading={authorizing}
               onClick={() => void handleOAuth()}
             >
               {t("connectors.oneClickOAuth", "一键授权")}


### PR DESCRIPTION
## Summary

- open the OAuth popup synchronously from the user's click, then navigate it after the authorization URL is ready
- show a localized error when the browser blocks the popup
- prevent duplicate authorization requests while OAuth startup is in progress
- validate the OAuth callback message origin and close the blank popup on startup failure

## Root cause

The connector UI awaited OAuth metadata discovery and dynamic client registration before calling `window.open()`. That delay detached popup creation from the original user gesture, so browsers could block the Notion authorization window. Repeated clicks could also create multiple pending OAuth states.

## User impact

Notion one-click authorization now opens reliably. If popups are disabled, users receive an actionable message instead of seeing an apparently unresponsive button.

## Validation

- `npm run lint` — passed; only pre-existing React Hook warnings
- `npx tsc --noEmit` — passed
- `uv run pytest tests/unit/i18n -q` — 37 passed on the v0.9.9 baseline
- production dashboard build completed successfully
