### PR TITLE
fix: search probe, table pagination, chat icon, and install hardening

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,6 @@ logs/
 
 # Local monorepo dev helpers (not for upstream)
 scripts/dev-local-link.sh
+
+# Local agent planning docs (not for upstream)
+docs/superpowers/

--- a/dashboard/src/api/request.ts
+++ b/dashboard/src/api/request.ts
@@ -3,6 +3,9 @@ import i18n from "../i18n";
 
 const AUTH_TOKEN_KEY = "auth_token";
 
+/** Response header used by the server for JWT sliding renewal. */
+export const ACCESS_TOKEN_RESPONSE_HEADER = "X-Octop-Access-Token";
+
 /** Save JWT token to localStorage */
 export function setAuthToken(token: string) {
   localStorage.setItem(AUTH_TOKEN_KEY, token);
@@ -18,6 +21,14 @@ export function clearAuthToken() {
   localStorage.removeItem(AUTH_TOKEN_KEY);
   localStorage.removeItem("octop:active-agent");
   setActiveAgentId(null);
+}
+
+/** Persist a sliding-renewed access token from an API response, if present. */
+export function applyRenewedAccessToken(response: Response): void {
+  const renewed = response.headers.get(ACCESS_TOKEN_RESPONSE_HEADER);
+  if (renewed) {
+    setAuthToken(renewed);
+  }
 }
 
 let _redirectingToSetup = false;
@@ -221,6 +232,7 @@ export async function request<T = unknown>(
   }
 
   await throwIfUnauthorized(path, response);
+  applyRenewedAccessToken(response);
 
   if (!response.ok) {
     const text = await response.text().catch(() => "");
@@ -262,6 +274,7 @@ export async function requestBlob(
   }
 
   await throwIfUnauthorized(path, response);
+  applyRenewedAccessToken(response);
 
   if (!response.ok) {
     const text = await response.text().catch(() => "");
@@ -298,6 +311,7 @@ export async function requestUpload<T = unknown>(
   }
 
   await throwIfUnauthorized(path, response);
+  applyRenewedAccessToken(response);
 
   if (!response.ok) {
     const text = await response.text().catch(() => "");

--- a/dashboard/src/pages/Agent/Memory/ConversationRecords.tsx
+++ b/dashboard/src/pages/Agent/Memory/ConversationRecords.tsx
@@ -538,7 +538,7 @@ export default function ConversationRecords({
               scroll={{ x: 980 }}
               locale={{ emptyText: t("memory.noConversations") }}
               pagination={{
-                pageSize: THREAD_LIST_PAGE_SIZE,
+                defaultPageSize: THREAD_LIST_PAGE_SIZE,
                 showSizeChanger: true,
                 pageSizeOptions: THREAD_LIST_PAGE_SIZE_OPTIONS.map(String),
                 showTotal: threadPaginationTotal,

--- a/dashboard/src/pages/Chat/chatInputCore.partial.less
+++ b/dashboard/src/pages/Chat/chatInputCore.partial.less
@@ -275,15 +275,15 @@
   border-radius: var(--fn-radius-full);
   border: none;
   background: transparent;
-  color: var(--fn-text-tertiary);
+  color: var(--fn-text-quaternary);
   cursor: pointer;
   transition:
     color var(--fn-transition-fast),
     background var(--fn-transition-fast);
 
   &:hover {
-    color: var(--fn-text-primary);
-    background: var(--fn-bg-hover);
+    color: var(--fn-text-brand);
+    background: rgba(232, 93, 117, 0.08);
   }
 
   &:focus-visible {

--- a/dashboard/src/pages/Chat/components/ChatInputActionsRow.tsx
+++ b/dashboard/src/pages/Chat/components/ChatInputActionsRow.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next";
 import {
   Send,
   Square,
-  Plus,
+  MessageSquarePlus,
   Paperclip,
   Zap,
   Link2,
@@ -669,7 +669,7 @@ export default function ChatInputActionsRow({
               onClick={onNewChat}
               type="button"
             >
-              <Plus size={18} />
+              <MessageSquarePlus size={16} strokeWidth={1.75} />
             </button>
           </Tooltip>
         ) : (
@@ -680,7 +680,7 @@ export default function ChatInputActionsRow({
                 onClick={onNewChat}
                 type="button"
               >
-                <Plus size={18} />
+                <MessageSquarePlus size={16} strokeWidth={1.75} />
               </button>
             </Tooltip>
             <Tooltip title={t("chat.polish.tooltip")} mouseEnterDelay={0.4}>

--- a/dashboard/src/pages/Experts/components/AgentExpertsTable.tsx
+++ b/dashboard/src/pages/Experts/components/AgentExpertsTable.tsx
@@ -1,5 +1,11 @@
 // dashboard/src/pages/Experts/components/AgentExpertsTable.tsx
-import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 import { Popconfirm, Switch, Table, Tag, Tooltip, message } from "antd";
@@ -75,6 +81,30 @@ export default function AgentExpertsTable({
   const [mbtiCatalogOpen, setMbtiCatalogOpen] = useState(false);
   const [mbtiAgentId, setMbtiAgentId] = useState<string | null>(null);
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const tableWrapRef = useRef<HTMLDivElement>(null);
+  /** Keep pagination in view: body scrolls inside remaining viewport height. */
+  const [scrollY, setScrollY] = useState(360);
+
+  useLayoutEffect(() => {
+    const el = tableWrapRef.current;
+    if (!el) return;
+
+    const update = () => {
+      const top = el.getBoundingClientRect().top;
+      // Table header (~55) + pagination (~56) + bottom padding (~16).
+      const next = Math.floor(window.innerHeight - top - 127);
+      setScrollY(Math.max(200, next));
+    };
+
+    update();
+    const ro = new ResizeObserver(update);
+    ro.observe(document.documentElement);
+    window.addEventListener("resize", update);
+    return () => {
+      ro.disconnect();
+      window.removeEventListener("resize", update);
+    };
+  }, [agents.length]);
 
   const openMbtiCatalog = useCallback((agentId: string) => {
     setMbtiAgentId(agentId);
@@ -430,19 +460,20 @@ export default function AgentExpertsTable({
 
   return (
     <>
-      <Table<OctopAgent>
-        className={styles.expertsTable}
-        rowKey="agent_id"
-        dataSource={agents}
-        columns={columns}
-        scroll={{ x: 1304 }}
-        pagination={{
-          pageSize: 10,
-          showSizeChanger: true,
-          pageSizeOptions: ["10", "20", "50"],
-          showTotal: (total) => t("experts.totalAgents", { count: total }),
-        }}
-      />
+      <div ref={tableWrapRef} className={styles.expertsTable}>
+        <Table<OctopAgent>
+          rowKey="agent_id"
+          dataSource={agents}
+          columns={columns}
+          scroll={{ x: 1304, y: scrollY }}
+          pagination={{
+            defaultPageSize: 10,
+            showSizeChanger: true,
+            pageSizeOptions: ["10", "20", "50"],
+            showTotal: (total) => t("experts.totalAgents", { count: total }),
+          }}
+        />
+      </div>
       <WorkspaceDrawer
         agentId={workspaceAgentId ?? ""}
         open={workspaceAgentId !== null}

--- a/dashboard/src/pages/Experts/index.module.less
+++ b/dashboard/src/pages/Experts/index.module.less
@@ -1547,7 +1547,11 @@
 }
 
 .expertsTable {
-  margin: 12px 0 40px;
+  margin: 12px 0 0;
+
+  :global(.octop-table-pagination) {
+    margin: 12px 0 0 !important;
+  }
 }
 
 .tableNameCell {

--- a/dashboard/src/pages/Settings/SearchConfig/index.tsx
+++ b/dashboard/src/pages/Settings/SearchConfig/index.tsx
@@ -133,6 +133,7 @@ function ProviderPanel({ provider, envVars, onSaved }: ProviderPanelProps) {
       } else {
         message.error(
           t("setupWizard.search.testFailed", {
+            name: provider.name,
             error: result.error || result.error_type || "Unknown error",
           }),
         );
@@ -141,6 +142,7 @@ function ProviderPanel({ provider, envVars, onSaved }: ProviderPanelProps) {
       if (err && typeof err === "object" && "errorFields" in err) return;
       message.error(
         t("setupWizard.search.testFailed", {
+          name: provider.name,
           error: err instanceof Error ? err.message : String(err),
         }),
       );

--- a/dashboard/src/pages/Settings/octop/Agents.tsx
+++ b/dashboard/src/pages/Settings/octop/Agents.tsx
@@ -380,7 +380,7 @@ export default function OctopAgentsPage() {
             columns={columns}
             scroll={{ x: 1200 }}
             pagination={{
-              pageSize: 10,
+              defaultPageSize: 10,
               showSizeChanger: true,
               pageSizeOptions: ["10", "20", "50"],
               showTotal: (total) => t("adminAgents.total", { count: total }),

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -98,7 +98,8 @@ Octop 安装脚本 (macOS / Linux)
   HARNESS_AGENT_REPO      harness-agent 仓库（默认从 OCTOP_REPO 推导）
   HARNESS_GATEWAY_REPO    harness-gateway 仓库（默认从 OCTOP_REPO 推导）
   HARNESS_BROWSER_REPO    harness-browser 仓库（源码安装时使用）
-  PLAYWRIGHT_DOWNLOAD_HOST  Playwright 下载镜像（可选，用于加速）
+  PLAYWRIGHT_DOWNLOAD_HOST  Playwright 下载镜像（可选；未设时自动：npmmirror → 官方）
+  PLAYWRIGHT_INSTALL_TIMEOUT  单镜像下载超时秒数（默认 600）
 
 说明:
   本脚本在隔离虚拟环境（~/.octop/venv）中安装，不会影响系统 Python。
@@ -296,33 +297,75 @@ _ensure_rustc() {
     return 1
 }
 
+# 以 root 或免密 sudo 执行包管理命令（CentOS 常用 root 登录，不可强制 sudo）
+_sudo_nopass() {
+    command -v sudo &>/dev/null && sudo -n true 2>/dev/null
+}
+
+_run_as_root() {
+    if [ "$(id -u)" -eq 0 ]; then
+        "$@"
+    elif _sudo_nopass; then
+        sudo "$@"
+    else
+        return 1
+    fi
+}
+
+# 当前将用于编译扩展的 Python 是否带有 Python.h（uv 自带或系统 python3-dev）
+_python_dev_headers_ok() {
+    local py=""
+    if [ -x "${OCTOP_VENV:-}/bin/python" ]; then
+        py="$OCTOP_VENV/bin/python"
+    elif command -v python3 &>/dev/null; then
+        py="$(command -v python3)"
+    else
+        return 1
+    fi
+    "$py" -c 'import sysconfig, os
+p = sysconfig.get_path("include")
+raise SystemExit(0 if p and os.path.isfile(os.path.join(p, "Python.h")) else 1)' 2>/dev/null
+}
+
+# gcc + Python 头文件：evdev/pynput 等在无匹配 wheel 时需本地编译。
+# 注意：仅有 gcc、缺 python3-dev 时（常见于 Ubuntu 云镜像）也会失败，不可因已有 gcc 而跳过。
 _ensure_c_build_tools() {
+    local have_cc=0 have_pyh=0
     if command -v cc &>/dev/null || command -v gcc &>/dev/null; then
+        have_cc=1
+    fi
+    if _python_dev_headers_ok; then
+        have_pyh=1
+    fi
+    if [ "$have_cc" -eq 1 ] && [ "$have_pyh" -eq 1 ]; then
         return 0
     fi
-    info "正在安装 C 编译工具（gcc/make）..."
+
+    info "正在安装本地编译依赖（gcc / Python 开发头文件）..."
     if command -v apt-get &>/dev/null; then
-        if command -v sudo &>/dev/null && sudo -n true 2>/dev/null; then
-            sudo apt-get update -qq 2>/dev/null || true
-            sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq build-essential 2>/dev/null || true
-        elif [ "$(id -u)" -eq 0 ]; then
-            apt-get update -qq 2>/dev/null || true
-            DEBIAN_FRONTEND=noninteractive apt-get install -y -qq build-essential 2>/dev/null || true
-        fi
-    elif command -v yum &>/dev/null; then
-        if [ "$(id -u)" -eq 0 ]; then
-            yum install -y gcc gcc-c++ make openssl-devel 2>/dev/null || true
-        elif command -v sudo &>/dev/null && sudo -n true 2>/dev/null; then
-            sudo yum install -y gcc gcc-c++ make openssl-devel 2>/dev/null || true
-        fi
+        _run_as_root env DEBIAN_FRONTEND=noninteractive apt-get update -qq 2>/dev/null || true
+        _run_as_root env DEBIAN_FRONTEND=noninteractive apt-get install -y -qq \
+            build-essential python3-dev 2>/dev/null || true
     elif command -v dnf &>/dev/null; then
-        if [ "$(id -u)" -eq 0 ]; then
-            dnf install -y gcc gcc-c++ make openssl-devel 2>/dev/null || true
-        elif command -v sudo &>/dev/null && sudo -n true 2>/dev/null; then
-            sudo dnf install -y gcc gcc-c++ make openssl-devel 2>/dev/null || true
-        fi
+        _run_as_root dnf install -y \
+            gcc gcc-c++ make openssl-devel libffi-devel python3-devel 2>/dev/null || true
+    elif command -v yum &>/dev/null; then
+        _run_as_root yum install -y \
+            gcc gcc-c++ make openssl-devel libffi-devel python3-devel 2>/dev/null || true
     fi
-    command -v cc &>/dev/null || command -v gcc &>/dev/null
+
+    have_cc=0
+    if command -v cc &>/dev/null || command -v gcc &>/dev/null; then
+        have_cc=1
+    fi
+    have_pyh=0
+    if _python_dev_headers_ok; then
+        have_pyh=1
+    fi
+    [ "$have_cc" -eq 1 ] || return 1
+    # 系统 python3-devel 可能与 uv 拉取的 Python 小版本不一致；uv 自带解释器通常自带头文件。
+    # 若仍缺失，后续源码编译可能失败，由 pip 错误提示即可。
+    return 0
 }
 
 _cxx_major() {
@@ -345,48 +388,78 @@ _fix_centos7_scl_repos() {
 }
 
 _ensure_modern_cxx() {
-    # playwright → greenlet 等需较新 C++；CentOS 7 自带 gcc 4.8 不够
+    # playwright → greenlet、numpy 2.x 等需较新 C++；CentOS 7 自带 gcc 4.8 不够
+    # numpy>=2.5 要求 GCC >= 10.3，故优先 devtoolset-11
     local major
     major="$(_cxx_major)"
-    if [ -n "$major" ] && [ "$major" -ge 7 ] 2>/dev/null; then
+    if [ -n "$major" ] && [ "$major" -ge 10 ] 2>/dev/null; then
         info "C++ 编译器就绪: $(${CXX:-g++} --version 2>/dev/null | head -n1)"
         return 0
     fi
 
     if ! command -v yum &>/dev/null; then
-        warn "系统 gcc 过旧且无 yum，greenlet/playwright 源码编译可能失败"
+        warn "系统 gcc 过旧且无 yum，greenlet/numpy 源码编译可能失败"
         return 1
     fi
 
-    info "系统 gcc 过旧（需 >=7），正在安装 devtoolset-9..."
-    local yum_cmd=(yum)
-    if [ "$(id -u)" -ne 0 ]; then
-        if command -v sudo &>/dev/null && sudo -n true 2>/dev/null; then
-            yum_cmd=(sudo yum)
-        else
-            warn "需要 root/sudo 安装 devtoolset-9"
-            return 1
-        fi
+    if [ "$(id -u)" -ne 0 ] && ! _sudo_nopass; then
+        warn "需要 root/sudo 安装 devtoolset"
+        return 1
     fi
 
-    "${yum_cmd[@]}" install -y centos-release-scl 2>/dev/null || true
+    _run_as_root yum install -y centos-release-scl 2>/dev/null || true
     _fix_centos7_scl_repos
-    if ! "${yum_cmd[@]}" install -y devtoolset-9-gcc devtoolset-9-gcc-c++ make 2>/dev/null; then
-        warn "devtoolset-9 安装失败，greenlet/playwright 可能无法编译"
+
+    local dts enable_file=""
+    for dts in 11 10 9; do
+        info "系统 gcc 过旧（numpy 需 >=10.3），正在安装 devtoolset-${dts}..."
+        if _run_as_root yum install -y \
+            "devtoolset-${dts}-gcc" "devtoolset-${dts}-gcc-c++" make 2>/dev/null; then
+            if [ -f "/opt/rh/devtoolset-${dts}/enable" ]; then
+                enable_file="/opt/rh/devtoolset-${dts}/enable"
+                break
+            fi
+        fi
+        warn "devtoolset-${dts} 安装失败，尝试下一版本..."
+    done
+
+    if [ -z "$enable_file" ]; then
+        warn "未能安装可用的 devtoolset，greenlet/numpy 可能无法编译"
         return 1
     fi
 
-    if [ -f /opt/rh/devtoolset-9/enable ]; then
-        # enable 脚本会读未定义的 MANPATH；临时关闭 nounset
-        set +u
-        # shellcheck disable=SC1091
-        . /opt/rh/devtoolset-9/enable
-        set -u
-        export CC=gcc CXX=g++
-        info "已启用 devtoolset-9: $(g++ --version 2>/dev/null | head -n1)"
+    # enable 脚本会读未定义的 MANPATH；临时关闭 nounset
+    set +u
+    # shellcheck disable=SC1091
+    . "$enable_file"
+    set -u
+    export CC=gcc CXX=g++
+    info "已启用 $(basename "$(dirname "$enable_file")"): $(g++ --version 2>/dev/null | head -n1)"
+    major="$(_cxx_major)"
+    if [ -n "$major" ] && [ "$major" -ge 10 ] 2>/dev/null; then
         return 0
     fi
-    return 1
+    # gcc 9 仍可能编 greenlet，但编不了新版 numpy
+    warn "当前 g++ 主版本为 ${major:-?}（numpy 2.5+ 需 >=10）"
+    return 0
+}
+
+_ensure_old_glibc_image_libs() {
+    # Pillow 等在无 manylinux_2_28 wheel 时需源码编译，依赖 jpeg/zlib/freetype 头文件
+    info "正在安装图像库开发包（Pillow 源码编译需要）..."
+    if command -v apt-get &>/dev/null; then
+        _run_as_root env DEBIAN_FRONTEND=noninteractive apt-get install -y -qq \
+            libjpeg-dev zlib1g-dev libfreetype6-dev libtiff-dev libwebp-dev \
+            liblcms2-dev libopenjp2-7-dev 2>/dev/null || true
+    elif command -v dnf &>/dev/null; then
+        _run_as_root dnf install -y \
+            libjpeg-turbo-devel zlib-devel freetype-devel libtiff-devel \
+            libwebp-devel lcms2-devel openjpeg2-devel 2>/dev/null || true
+    elif command -v yum &>/dev/null; then
+        _run_as_root yum install -y \
+            libjpeg-turbo-devel zlib-devel freetype-devel libtiff-devel \
+            libwebp-devel lcms2-devel openjpeg2-devel 2>/dev/null || true
+    fi
 }
 
 _ensure_old_glibc_build_toolchain() {
@@ -398,6 +471,7 @@ _ensure_old_glibc_build_toolchain() {
     ver="$(_glibc_major_minor)"
     warn "检测到 glibc ${ver}（< 2.28，如 CentOS 7）：部分依赖需本地编译"
     _ensure_c_build_tools || warn "未找到 gcc，源码编译可能失败"
+    _ensure_old_glibc_image_libs
     _ensure_modern_cxx || warn "未启用新版 g++，playwright 依赖（greenlet）可能编译失败"
     if ! _ensure_rustc; then
         die "当前系统 glibc=$ver，无法使用预编译 wheel，且 Rust 安装失败。请升级到 CentOS/RHEL 8+、Ubuntu 20.04+，或手动安装 rustup 后重试。"
@@ -414,6 +488,10 @@ fi
 [ -x "$OCTOP_VENV/bin/python" ] || die "虚拟环境创建失败"
 info "Python 环境就绪 ($("$OCTOP_VENV/bin/python" --version))"
 
+# Linux 上始终确保可编译本地扩展（Ubuntu 缺 python3-dev、CentOS 缺 python3-devel 等）
+if [ "$OS" = "Linux" ]; then
+    _ensure_c_build_tools || warn "未完整安装 gcc/Python 头文件，若依赖需源码编译可能失败"
+fi
 _ensure_old_glibc_build_toolchain
 
 # ── 步骤 3: 安装 Octop ───────────────────────────────────────────────────────
@@ -550,11 +628,7 @@ _install_playwright_system_deps() {
             return
         fi
         # 回退：手动安装（Ubuntu 24+ 部分包名为 *t64）
-        local _apt="apt-get"
-        if command -v sudo &>/dev/null && [ "$(id -u)" -ne 0 ]; then
-            _apt="sudo apt-get"
-        fi
-        $_apt update 2>/dev/null || true
+        _run_as_root apt-get update 2>/dev/null || true
         # 逐包尝试，兼容 Ubuntu 22/24 包名差异
         local pkg
         for pkg in \
@@ -567,7 +641,7 @@ _install_playwright_system_deps() {
             libatk-bridge2.0-0t64 libatk-bridge2.0-0 \
             libgdk-pixbuf-2.0-0 libgdk-pixbuf2.0-0 \
             ; do
-            $_apt install -y "$pkg" 2>/dev/null || true
+            _run_as_root apt-get install -y "$pkg" 2>/dev/null || true
         done
         return
     fi
@@ -575,7 +649,7 @@ _install_playwright_system_deps() {
     if command -v dnf &>/dev/null; then
         info "检测到 dnf 包管理器 (Fedora/RHEL)..."
         info "正在安装 Playwright 系统依赖..."
-        sudo dnf install -y \
+        _run_as_root dnf install -y \
             alsa-lib atk at-spi2-atk cups-libs libdrm libgbm \
             libX11 libXcomposite libXdamage libXext libXfixes libXrandr \
             libxkbcommon nss pango \
@@ -586,7 +660,7 @@ _install_playwright_system_deps() {
     if command -v yum &>/dev/null; then
         info "检测到 yum 包管理器 (CentOS/RHEL)..."
         info "正在安装 Playwright 系统依赖..."
-        sudo yum install -y \
+        _run_as_root yum install -y \
             alsa-lib atk at-spi2-atk cups-libs libdrm libgbm \
             libX11 libXcomposite libXdamage libXext libXfixes libXrandr \
             libxkbcommon nss pango \
@@ -597,7 +671,7 @@ _install_playwright_system_deps() {
     if command -v pacman &>/dev/null; then
         info "检测到 pacman 包管理器 (Arch/Manjaro)..."
         info "正在安装 Playwright 系统依赖..."
-        sudo pacman -S --noconfirm --needed \
+        _run_as_root pacman -S --noconfirm --needed \
             alsa-lib atk at-spi2-atk cups libdrm mesa \
             libx11 libxcomposite libxdamage libxext libxfixes libxrandr \
             libxkbcommon nss pango \
@@ -608,7 +682,7 @@ _install_playwright_system_deps() {
     if command -v zypper &>/dev/null; then
         info "检测到 zypper 包管理器 (openSUSE)..."
         info "正在安装 Playwright 系统依赖..."
-        sudo zypper install -y \
+        _run_as_root zypper install -y \
             alsa libatk-1_0-0 libatk-bridge-2_0-0 libcups2 libdrm2 \
             Mesa-libgbm1 libX11-6 libXcomposite1 libXdamage1 libXext6 \
             libXfixes3 libXrandr2 libxkbcommon0 libnspr4 libnss3 \
@@ -627,13 +701,54 @@ _install_playwright_browsers() {
         warn "已安装 playwright Python 包，但跳过 Chromium；建议使用 Ubuntu 20.04+ / CentOS/RHEL 8+"
         return 1
     fi
-    info "正在安装 Playwright Chromium 浏览器..."
-    if "$OCTOP_VENV/bin/python" -m playwright install chromium; then
-        info "✓ Playwright Chromium 安装成功"
-        return 0
+
+    # 镜像分层（对齐 finnie TencentOS 策略）：
+    #   1. 用户指定 PLAYWRIGHT_DOWNLOAD_HOST
+    #   2. npmmirror（国内最快）
+    #   3. 官方 CDN（失败兜底）
+    # 单源超时避免 GCS 卡住拖死整次安装；可用 PLAYWRIGHT_INSTALL_TIMEOUT 覆盖（秒）
+    local _pw_timeout="${PLAYWRIGHT_INSTALL_TIMEOUT:-600}"
+    _run_playwright_chromium_install() {
+        if command -v timeout &>/dev/null; then
+            timeout "$_pw_timeout" "$OCTOP_VENV/bin/python" -m playwright install chromium
+        else
+            "$OCTOP_VENV/bin/python" -m playwright install chromium
+        fi
+    }
+
+    local -a _pw_hosts=()
+    local _h
+    if [ -n "${PLAYWRIGHT_DOWNLOAD_HOST:-}" ]; then
+        _pw_hosts+=("$PLAYWRIGHT_DOWNLOAD_HOST")
     fi
+    _pw_hosts+=("https://cdn.npmmirror.com/binaries/playwright")
+    _pw_hosts+=("")  # 官方：清空 PLAYWRIGHT_DOWNLOAD_HOST
+
+    local _seen="|"
+    for _h in "${_pw_hosts[@]}"; do
+        case "$_seen" in
+            *"|${_h}|"*) continue ;;
+        esac
+        _seen="${_seen}${_h}|"
+
+        if [ -n "$_h" ]; then
+            export PLAYWRIGHT_DOWNLOAD_HOST="$_h"
+            info "尝试 Playwright 镜像: $_h"
+        else
+            unset PLAYWRIGHT_DOWNLOAD_HOST || true
+            info "尝试 Playwright 官方 CDN..."
+        fi
+
+        if _run_playwright_chromium_install; then
+            info "✓ Playwright Chromium 安装成功"
+            return 0
+        fi
+        warn "该源失败或超时，尝试下一镜像..."
+    done
+
     warn "⚠ Playwright Chromium 安装失败，可稍后运行:"
-    warn "  $OCTOP_VENV/bin/python -m playwright install chromium"
+    warn "  PLAYWRIGHT_DOWNLOAD_HOST=https://cdn.npmmirror.com/binaries/playwright \\"
+    warn "    $OCTOP_VENV/bin/python -m playwright install chromium"
     return 1
 }
 
@@ -724,10 +839,6 @@ info "包装脚本已创建: $OCTOP_BIN/octop"
 _can_write_dir() {
     local dir="$1"
     [ -d "$dir" ] && [ -w "$dir" ]
-}
-
-_sudo_nopass() {
-    command -v sudo &>/dev/null && sudo -n true 2>/dev/null
 }
 
 _try_symlink() {

--- a/src/octop/api/app.py
+++ b/src/octop/api/app.py
@@ -66,12 +66,15 @@ def build_app(server: OctopServer) -> FastAPI:
     _install_exception_handlers(app)
 
     if cfg and cfg.cors_origins:
+        from octop.api.deps import ACCESS_TOKEN_RESPONSE_HEADER
+
         app.add_middleware(
             CORSMiddleware,
             allow_origins=cfg.cors_origins,
             allow_credentials=True,
             allow_methods=["*"],
             allow_headers=["*"],
+            expose_headers=[ACCESS_TOKEN_RESPONSE_HEADER],
         )
 
     install_jwt_auth(app, server)
@@ -112,6 +115,7 @@ def build_app(server: OctopServer) -> FastAPI:
         preferences,
         proactive_care,
         providers,
+        search,
         setup,
         skills,
         slash,
@@ -151,6 +155,7 @@ def build_app(server: OctopServer) -> FastAPI:
             _RouterMount(channels.router, "/api", ["channels"]),
             _RouterMount(cron.router, "/api", ["cron"]),
             _RouterMount(envs.router, "/api", ["envs"]),
+            _RouterMount(search.router, "/api", ["search"]),
             _RouterMount(providers.router, "/api/providers", ["providers"]),
             _RouterMount(voice.router, "/api/voice", ["voice"]),
             _RouterMount(admin.router, "/api/admin", ["admin"]),

--- a/src/octop/api/deps.py
+++ b/src/octop/api/deps.py
@@ -52,6 +52,12 @@ def decode_token(secret: bytes, token: str) -> dict[str, Any]:
         raise InvalidToken(str(exc)) from exc
 
 
+# Sliding renew: when remaining life is below this fraction of configured TTL,
+# middleware issues a fresh access token via ACCESS_TOKEN_RESPONSE_HEADER.
+ACCESS_TOKEN_RESPONSE_HEADER = "X-Octop-Access-Token"
+_SLIDING_RENEW_REMAINING_FRACTION = 1 / 3
+
+
 # Paths that bypass JWT middleware (setup wizard, health, login).
 _JWT_EXEMPT_PREFIXES = (
     "/api/setup/",
@@ -116,6 +122,31 @@ def resolve_user_from_token(server: OctopServer, token: str) -> User:
     if user is None:
         raise OctopError(ErrorCode.USER_DISABLED, "user not active")
     return user
+
+
+def maybe_sliding_renew_token(server: OctopServer, token: str, user: User) -> str | None:
+    """Return a fresh access token when ``token`` is past the sliding renew threshold.
+
+    Threshold is one-third of ``access_token_ttl_seconds`` remaining. Active clients
+    that pick up ``ACCESS_TOKEN_RESPONSE_HEADER`` stay signed in without re-login.
+    """
+    assert server.services is not None
+    payload = _decode(server, token)
+    ttl = int(server.services.config.access_token_ttl_seconds)
+    remaining = int(payload["exp"]) - int(time.time())
+    threshold = max(1, int(ttl * _SLIDING_RENEW_REMAINING_FRACTION))
+    if remaining >= threshold:
+        return None
+    secret = server.services.secret_repo.get("jwt")
+    if secret is None:
+        raise OctopError(ErrorCode.INTERNAL_ERROR, "jwt secret missing")
+    return sign_token(
+        secret,
+        sub=user.id,
+        uname=user.username,
+        role=user.role.value,
+        ttl_seconds=ttl,
+    )
 
 
 def authenticate_request(request: Request, server: OctopServer) -> User:

--- a/src/octop/api/middleware/jwt_auth.py
+++ b/src/octop/api/middleware/jwt_auth.py
@@ -2,6 +2,9 @@
 
 Validated users are cached on ``request.state.octop_user`` so route-level
 ``Depends(current_user)`` can reuse the result without re-decoding.
+
+When the access token is past the sliding-renew threshold, a fresh token is
+attached as ``X-Octop-Access-Token`` on the response.
 """
 
 from __future__ import annotations
@@ -12,7 +15,13 @@ from typing import Any
 from fastapi import Request
 from fastapi.responses import JSONResponse
 
-from octop.api.deps import authenticate_request, is_jwt_exempt_request
+from octop.api.deps import (
+    ACCESS_TOKEN_RESPONSE_HEADER,
+    authenticate_request,
+    extract_raw_token,
+    is_jwt_exempt_request,
+    maybe_sliding_renew_token,
+)
 from octop.infra.errors import OctopError
 
 _INSTALL_ATTR = "_octop_jwt_auth_installed"
@@ -32,9 +41,21 @@ def install(app: Any, server: Any) -> None:
         if not path.startswith("/api/") or is_jwt_exempt_request(request):
             return await call_next(request)
 
+        raw = extract_raw_token(
+            authorization=request.headers.get("authorization"),
+            access_token=request.query_params.get("access_token"),
+        )
         try:
             request.state.octop_user = authenticate_request(request, server)
         except OctopError as exc:
             return JSONResponse(status_code=exc.status, content=exc.to_envelope())
 
-        return await call_next(request)
+        response = await call_next(request)
+        if raw is not None:
+            try:
+                renewed = maybe_sliding_renew_token(server, raw, request.state.octop_user)
+            except OctopError:
+                renewed = None
+            if renewed:
+                response.headers[ACCESS_TOKEN_RESPONSE_HEADER] = renewed
+        return response

--- a/src/octop/api/openapi_meta.py
+++ b/src/octop/api/openapi_meta.py
@@ -20,6 +20,11 @@ Most endpoints require a JWT bearer token:
 2. `POST /api/auth/login` with `username` and `password`.
 3. Send `Authorization: Bearer <access_token>` on subsequent requests.
 
+Access tokens use sliding renewal: when less than one-third of
+`access_token_ttl_seconds` remains, authenticated responses may include a fresh
+token in the `X-Octop-Access-Token` header. Clients should replace the stored
+token when present.
+
 Public endpoints (no token): `/api/docs`, `/api/openapi.json`, `/api/health`,
 `/api/setup/*`, `/api/auth/login`, `/api/connectors/oauth/callback`, and
 `/api/internal/mcp/*`.
@@ -76,6 +81,10 @@ OPENAPI_TAGS: list[dict[str, str]] = [
         "description": "Scheduled prompts that run against an agent on a cron trigger.",
     },
     {"name": "envs", "description": "Environment variable presets for agents and workspaces."},
+    {
+        "name": "search",
+        "description": "Web-search provider API key probes (Tavily, Brave, Google, Kimi).",
+    },
     {"name": "providers", "description": "LLM provider configuration and active model selection."},
     {"name": "voice", "description": "Speech-to-text and text-to-speech provider configuration."},
     {

--- a/src/octop/api/routers/chat/routes.py
+++ b/src/octop/api/routers/chat/routes.py
@@ -26,9 +26,17 @@ router = APIRouter()
 logger = logging.getLogger(__name__)
 
 _POLISH_SYSTEM_PROMPT = (
-    "You refine user prompts for AI assistants. Improve clarity, specificity, and "
-    "structure while preserving the user's intent and language. Output only the "
-    "refined prompt text — no preamble, labels, thinking blocks, or XML tags."
+    "You are a prompt editor, not an assistant that answers questions.\n"
+    "The user message is a DRAFT PROMPT they will later send to another AI. "
+    "Your only job is to rewrite that draft so another AI can understand it more "
+    "clearly — improve clarity, specificity, structure, and actionable detail.\n"
+    "Hard rules:\n"
+    "- Do NOT answer the draft, solve the task, or provide the requested content.\n"
+    "- Do NOT add explanations, greetings, or meta commentary.\n"
+    "- Preserve the user's original intent and language (e.g. keep Chinese if the "
+    "draft is Chinese).\n"
+    "- Output ONLY the rewritten prompt text — no preamble, labels, quotes, "
+    "thinking blocks, or XML tags."
 )
 
 
@@ -117,7 +125,12 @@ async def polish_prompt(
             llm,
             [
                 SystemMessage(content=_POLISH_SYSTEM_PROMPT),
-                HumanMessage(content=draft),
+                HumanMessage(
+                    content=(
+                        "Rewrite the following draft prompt. Do not answer it.\n\n"
+                        f"---\n{draft}\n---"
+                    ),
+                ),
             ],
             timeout=30.0,
         )

--- a/src/octop/api/routers/search.py
+++ b/src/octop/api/routers/search.py
@@ -1,0 +1,52 @@
+"""Search-provider connectivity API (Settings → Advanced → Search)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel, Field
+
+from octop.api.deps import current_admin
+from octop.infra.utils.search_probe import probe_search_provider
+
+router = APIRouter(prefix="/search", tags=["search"])
+
+
+class TestSearchRequest(BaseModel):
+    env_vars: dict[str, str] = Field(
+        ...,
+        description="Provider env vars to use for this probe (not persisted).",
+    )
+
+
+class TestSearchResponse(BaseModel):
+    success: bool
+    provider_id: str
+    response_time_ms: int
+    result_count: int | None = None
+    message: str | None = None
+    error: str | None = None
+    error_type: str | None = Field(
+        None,
+        description="auth_error | timeout | network_error | invalid_config | unknown",
+    )
+
+
+@router.post(
+    "/{provider_id}/test",
+    response_model=TestSearchResponse,
+    summary="Test search provider API key",
+    description=(
+        "Run a one-shot query against a web-search provider using the supplied "
+        "env vars (TAVILY_API_KEY, BRAVE_API_KEY, GOOGLE_API_KEY + GOOGLE_CSE_ID, "
+        "or MOONSHOT_API_KEY). Credentials are not written to ~/.octop/env."
+    ),
+)
+async def test_search_provider(
+    provider_id: str,
+    body: TestSearchRequest,
+    _: Any = Depends(current_admin),
+) -> TestSearchResponse:
+    result = await probe_search_provider(provider_id, body.env_vars)
+    return TestSearchResponse(**result)

--- a/src/octop/infra/utils/search_probe.py
+++ b/src/octop/infra/utils/search_probe.py
@@ -1,0 +1,221 @@
+"""Probe web-search provider API keys via direct HTTP (no env mutation).
+
+Used by ``POST /api/search/{provider_id}/test``. Credentials come from the
+request body and are never written to ``os.environ``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import Mapping
+from typing import Any, Literal
+
+import httpx
+
+ErrorType = Literal["auth_error", "timeout", "network_error", "invalid_config", "unknown"]
+
+_TIMEOUT_S = 30.0
+_TEST_QUERY = "octop connectivity probe"
+_KNOWN: frozenset[str] = frozenset({"tavily", "brave", "google", "kimi"})
+_REQUIRED: dict[str, tuple[str, ...]] = {
+    "tavily": ("TAVILY_API_KEY",),
+    "brave": ("BRAVE_API_KEY",),
+    "google": ("GOOGLE_API_KEY", "GOOGLE_CSE_ID"),
+    "kimi": ("MOONSHOT_API_KEY",),
+}
+
+
+async def probe_search_provider(
+    provider_id: str,
+    env_vars: Mapping[str, str],
+) -> dict[str, Any]:
+    """Run a one-shot search against ``provider_id`` using ``env_vars``.
+
+    Returns a dict matching the dashboard ``TestSearchResponse`` shape.
+    """
+    started = time.perf_counter()
+    try:
+        outcome = await asyncio.wait_for(
+            _probe(provider_id, env_vars),
+            timeout=_TIMEOUT_S,
+        )
+    except TimeoutError:
+        outcome = {
+            "success": False,
+            "error": f"probe timed out after {_TIMEOUT_S:.0f}s",
+            "error_type": "timeout",
+        }
+    except Exception as exc:  # noqa: BLE001 — surface as probe failure
+        outcome = {"success": False, "error": str(exc), "error_type": "unknown"}
+
+    return {
+        "provider_id": provider_id,
+        "response_time_ms": int((time.perf_counter() - started) * 1000),
+        **outcome,
+    }
+
+
+async def _probe(provider_id: str, env_vars: Mapping[str, str]) -> dict[str, Any]:
+    if provider_id not in _KNOWN:
+        return {
+            "success": False,
+            "error": f"Unknown search provider: {provider_id}",
+            "error_type": "invalid_config",
+        }
+
+    missing = [k for k in _REQUIRED[provider_id] if not str(env_vars.get(k, "")).strip()]
+    if missing:
+        return {
+            "success": False,
+            "error": f"missing environment variable(s): {', '.join(missing)}",
+            "error_type": "invalid_config",
+        }
+
+    creds = {k: str(env_vars[k]).strip() for k in _REQUIRED[provider_id]}
+    async with httpx.AsyncClient(timeout=_TIMEOUT_S) as client:
+        if provider_id == "tavily":
+            return await _tavily(client, creds["TAVILY_API_KEY"])
+        if provider_id == "brave":
+            return await _brave(client, creds["BRAVE_API_KEY"])
+        if provider_id == "google":
+            return await _google(client, creds["GOOGLE_API_KEY"], creds["GOOGLE_CSE_ID"])
+        return await _kimi(client, creds["MOONSHOT_API_KEY"])
+
+
+async def _tavily(client: httpx.AsyncClient, api_key: str) -> dict[str, Any]:
+    response = await client.post(
+        "https://api.tavily.com/search",
+        headers={"Authorization": f"Bearer {api_key}"},
+        json={"query": _TEST_QUERY, "max_results": 1, "search_depth": "basic"},
+    )
+    return _from_response(response, provider="Tavily", results_key="results")
+
+
+async def _brave(client: httpx.AsyncClient, api_key: str) -> dict[str, Any]:
+    response = await client.get(
+        "https://api.search.brave.com/res/v1/web/search",
+        headers={
+            "Accept": "application/json",
+            "X-Subscription-Token": api_key,
+        },
+        params={"q": _TEST_QUERY, "count": 1},
+    )
+    return _from_brave(response)
+
+
+async def _google(client: httpx.AsyncClient, api_key: str, cse_id: str) -> dict[str, Any]:
+    response = await client.get(
+        "https://www.googleapis.com/customsearch/v1",
+        params={"key": api_key, "cx": cse_id, "q": _TEST_QUERY, "num": 1},
+    )
+    return _from_google(response)
+
+
+async def _kimi(client: httpx.AsyncClient, api_key: str) -> dict[str, Any]:
+    response = await client.post(
+        "https://api.moonshot.cn/v1/chat/completions",
+        headers={"Authorization": f"Bearer {api_key}"},
+        json={
+            "model": "moonshot-v1-128k",
+            "messages": [{"role": "user", "content": _TEST_QUERY}],
+            "tools": [{"type": "web_search"}],
+            "temperature": 0.3,
+        },
+    )
+    return _from_kimi(response)
+
+
+def _from_response(
+    response: httpx.Response,
+    *,
+    provider: str,
+    results_key: str,
+) -> dict[str, Any]:
+    fail = _http_failure(response)
+    if fail is not None:
+        return fail
+    try:
+        payload = response.json()
+    except ValueError:
+        return {"success": False, "error": "invalid JSON response", "error_type": "unknown"}
+    count = 0
+    if isinstance(payload, dict):
+        raw = payload.get(results_key)
+        count = len(raw) if isinstance(raw, list) else 1
+    return {
+        "success": True,
+        "result_count": count,
+        "message": f"{provider} search test successful",
+    }
+
+
+def _from_brave(response: httpx.Response) -> dict[str, Any]:
+    fail = _http_failure(response)
+    if fail is not None:
+        return fail
+    try:
+        payload = response.json()
+    except ValueError:
+        return {"success": False, "error": "invalid JSON response", "error_type": "unknown"}
+    web = payload.get("web") if isinstance(payload, dict) else None
+    results = web.get("results") if isinstance(web, dict) else None
+    count = len(results) if isinstance(results, list) else 1
+    return {
+        "success": True,
+        "result_count": count,
+        "message": "Brave search test successful",
+    }
+
+
+def _from_google(response: httpx.Response) -> dict[str, Any]:
+    fail = _http_failure(response)
+    if fail is not None:
+        return fail
+    try:
+        payload = response.json()
+    except ValueError:
+        return {"success": False, "error": "invalid JSON response", "error_type": "unknown"}
+    items = payload.get("items") if isinstance(payload, dict) else None
+    count = len(items) if isinstance(items, list) else 0
+    return {
+        "success": True,
+        "result_count": count,
+        "message": "Google search test successful",
+    }
+
+
+def _from_kimi(response: httpx.Response) -> dict[str, Any]:
+    fail = _http_failure(response)
+    if fail is not None:
+        return fail
+    try:
+        payload = response.json()
+    except ValueError:
+        return {"success": False, "error": "invalid JSON response", "error_type": "unknown"}
+    choices = payload.get("choices") if isinstance(payload, dict) else None
+    content = None
+    if isinstance(choices, list) and choices:
+        message = choices[0].get("message") if isinstance(choices[0], dict) else None
+        if isinstance(message, dict):
+            content = message.get("content")
+    return {
+        "success": True,
+        "result_count": 1 if content else 0,
+        "message": "Kimi search test successful",
+    }
+
+
+def _http_failure(response: httpx.Response) -> dict[str, Any] | None:
+    if response.status_code < 400:
+        return None
+    body = (response.text or "").strip()
+    detail = body[:300] if body else response.reason_phrase
+    error = f"HTTP {response.status_code}: {detail}"
+    if response.status_code in {401, 403}:
+        error_type: ErrorType = "auth_error"
+    elif response.status_code == 429:
+        error_type = "auth_error"
+    else:
+        error_type = "network_error" if response.status_code >= 500 else "unknown"
+    return {"success": False, "error": error, "error_type": error_type}

--- a/tests/integration/test_search_api.py
+++ b/tests/integration/test_search_api.py
@@ -1,0 +1,51 @@
+"""Integration tests for POST /api/search/{provider_id}/test."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+
+async def test_search_test_requires_auth(env: Any) -> None:
+    c, _srv, _auth = env
+    r = await c.post("/api/search/tavily/test", json={"env_vars": {}})
+    assert r.status_code == 401
+
+
+async def test_search_test_unknown_provider(env: Any) -> None:
+    c, _srv, auth = env
+    r = await c.post(
+        "/api/search/nope/test",
+        headers=auth,
+        json={"env_vars": {}},
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["success"] is False
+    assert body["provider_id"] == "nope"
+    assert body["error_type"] == "invalid_config"
+
+
+async def test_search_test_tavily_ok(env: Any) -> None:
+    c, _srv, auth = env
+    with patch(
+        "octop.infra.utils.search_probe._tavily",
+        new=AsyncMock(
+            return_value={
+                "success": True,
+                "result_count": 1,
+                "message": "ok",
+            }
+        ),
+    ):
+        r = await c.post(
+            "/api/search/tavily/test",
+            headers=auth,
+            json={"env_vars": {"TAVILY_API_KEY": "tvly-x"}},
+        )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["success"] is True
+    assert body["provider_id"] == "tavily"
+    assert body["result_count"] == 1
+    assert isinstance(body["response_time_ms"], int)

--- a/tests/unit/api/test_jwt_auth_middleware.py
+++ b/tests/unit/api/test_jwt_auth_middleware.py
@@ -7,10 +7,16 @@ from pathlib import Path
 import httpx
 import pytest
 from tests.support.app import write_octop_config
-from tests.support.auth import bootstrap_admin
+from tests.support.auth import bearer, bootstrap_admin, login
 
 from octop.api.app import build_app
-from octop.api.deps import is_jwt_exempt_path
+from octop.api.deps import (
+    ACCESS_TOKEN_RESPONSE_HEADER,
+    decode_token,
+    is_jwt_exempt_path,
+    maybe_sliding_renew_token,
+    sign_token,
+)
 from octop.infra.server import OctopServer
 
 
@@ -68,3 +74,60 @@ async def test_middleware_allows_api_docs_without_token(tmp_path: Path) -> None:
             assert spec.status_code == 200
     finally:
         await srv.stop()
+
+
+async def test_fresh_token_does_not_sliding_renew(client) -> None:
+    c, _srv, home = client
+    await bootstrap_admin(c, home)
+    token = await login(c)
+    r = await c.get("/api/auth/me", headers=bearer(token))
+    assert r.status_code == 200
+    assert ACCESS_TOKEN_RESPONSE_HEADER not in r.headers
+
+
+async def test_near_expiry_token_gets_sliding_renew(client) -> None:
+    c, srv, home = client
+    await bootstrap_admin(c, home)
+    assert srv.user_manager is not None
+    assert srv.services is not None
+    user = srv.user_manager.get("admin")
+    assert user is not None
+    secret = srv.services.secret_repo.get("jwt")
+    assert secret is not None
+    # Remaining life (~60s) is far below default TTL/3 (~8h) → renew.
+    short = sign_token(
+        secret,
+        sub=user.id,
+        uname=user.username,
+        role=user.role.value,
+        ttl_seconds=60,
+    )
+    r = await c.get("/api/auth/me", headers=bearer(short))
+    assert r.status_code == 200
+    renewed = r.headers.get(ACCESS_TOKEN_RESPONSE_HEADER)
+    assert renewed
+    assert renewed != short
+    payload = decode_token(secret, renewed)
+    assert int(payload["exp"]) - int(payload["iat"]) == srv.services.config.access_token_ttl_seconds
+
+
+async def test_maybe_sliding_renew_helper_threshold(client) -> None:
+    _c, srv, home = client
+    await bootstrap_admin(_c, home)
+    assert srv.user_manager is not None
+    assert srv.services is not None
+    user = srv.user_manager.get("admin")
+    assert user is not None
+    secret = srv.services.secret_repo.get("jwt")
+    assert secret is not None
+    ttl = srv.services.config.access_token_ttl_seconds
+    fresh = sign_token(
+        secret, sub=user.id, uname=user.username, role=user.role.value, ttl_seconds=ttl
+    )
+    assert maybe_sliding_renew_token(srv, fresh, user) is None
+    short = sign_token(
+        secret, sub=user.id, uname=user.username, role=user.role.value, ttl_seconds=60
+    )
+    renewed = maybe_sliding_renew_token(srv, short, user)
+    assert renewed is not None
+    assert renewed != short

--- a/tests/unit/utils/test_search_probe.py
+++ b/tests/unit/utils/test_search_probe.py
@@ -1,0 +1,92 @@
+"""Unit tests for search-provider HTTP probes."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from octop.infra.utils import search_probe
+
+
+def _patch_client(monkeypatch: pytest.MonkeyPatch, handler: httpx.MockTransport) -> None:
+    real = httpx.AsyncClient
+
+    def factory(*args: object, **kwargs: object) -> httpx.AsyncClient:
+        kwargs = dict(kwargs)
+        kwargs["transport"] = handler
+        return real(*args, **kwargs)
+
+    monkeypatch.setattr(search_probe.httpx, "AsyncClient", factory)
+
+
+@pytest.mark.asyncio
+async def test_unknown_provider() -> None:
+    result = await search_probe.probe_search_provider("nope", {})
+    assert result["success"] is False
+    assert result["error_type"] == "invalid_config"
+    assert result["provider_id"] == "nope"
+
+
+@pytest.mark.asyncio
+async def test_tavily_missing_key() -> None:
+    result = await search_probe.probe_search_provider("tavily", {})
+    assert result["success"] is False
+    assert result["error_type"] == "invalid_config"
+    assert "TAVILY_API_KEY" in (result.get("error") or "")
+
+
+@pytest.mark.asyncio
+async def test_google_missing_cse() -> None:
+    result = await search_probe.probe_search_provider("google", {"GOOGLE_API_KEY": "gk"})
+    assert result["success"] is False
+    assert "GOOGLE_CSE_ID" in (result.get("error") or "")
+
+
+@pytest.mark.asyncio
+async def test_tavily_ok(monkeypatch: pytest.MonkeyPatch) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.host == "api.tavily.com"
+        assert request.headers.get("Authorization") == "Bearer tvly-test"
+        return httpx.Response(200, json={"results": [{"url": "https://example.com"}]})
+
+    _patch_client(monkeypatch, httpx.MockTransport(handler))
+    result = await search_probe.probe_search_provider(
+        "tavily",
+        {"TAVILY_API_KEY": "tvly-test"},
+    )
+    assert result["success"] is True
+    assert result["result_count"] == 1
+    assert result["provider_id"] == "tavily"
+
+
+@pytest.mark.asyncio
+async def test_tavily_auth_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(401, text="invalid api key")
+
+    _patch_client(monkeypatch, httpx.MockTransport(handler))
+    result = await search_probe.probe_search_provider(
+        "tavily",
+        {"TAVILY_API_KEY": "bad"},
+    )
+    assert result["success"] is False
+    assert result["error_type"] == "auth_error"
+
+
+@pytest.mark.asyncio
+async def test_brave_ok(monkeypatch: pytest.MonkeyPatch) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.host == "api.search.brave.com"
+        assert request.headers.get("X-Subscription-Token") == "brave-key"
+        return httpx.Response(
+            200,
+            json={"web": {"results": [{"url": "https://example.com"}]}},
+        )
+
+    _patch_client(monkeypatch, httpx.MockTransport(handler))
+    result = await search_probe.probe_search_provider(
+        "brave",
+        {"BRAVE_API_KEY": "brave-key"},
+    )
+    assert result["success"] is True
+    assert result["result_count"] == 1


### PR DESCRIPTION
## Summary
- Add `POST /api/search/{provider_id}/test` with direct HTTP probes (Tavily/Brave/Google/Kimi) so Advanced Search key testing no longer 405s
- Fix Ant Design table `pageSize` changers that stayed stuck at 10 (`defaultPageSize`), and keep experts table pagination visible via body scroll
- Soften the new-chat icon styling; JWT sliding renew via `X-Octop-Access-Token`; tighten chat polish system prompt; harden `install.sh` for python-dev / Playwright mirrors; ignore `docs/superpowers/`

## Test plan
- [ ] Advanced → Search: save + test Tavily/Brave/Google/Kimi keys (valid and invalid)
- [ ] Experts table view: change page size 10/20/50 and confirm row count updates; pagination stays in view
- [ ] Chat composer: new-chat icon is visually lighter and still creates a session
- [ ] Stay signed in across long sessions (JWT renew header applied by dashboard)
- [ ] Chat polish: draft is rewritten, not answered
- [ ] `uv run pytest tests/unit/utils/test_search_probe.py tests/integration/test_search_api.py tests/unit/api/test_jwt_auth_middleware.py -q`


Made with [Cursor](https://cursor.com)