### PR TITLE
Fix voice input STT fallback handling

### DIFF
--- a/dashboard/src/api/modules/voice.ts
+++ b/dashboard/src/api/modules/voice.ts
@@ -27,6 +27,14 @@ export interface ActiveVoice {
   tts: string;
 }
 
+function recordingFilename(type: string): string {
+  const lower = type.toLowerCase();
+  if (lower.includes("mp4")) return "recording.m4a";
+  if (lower.includes("ogg")) return "recording.ogg";
+  if (lower.includes("wav")) return "recording.wav";
+  return "recording.webm";
+}
+
 export const voiceApi = {
   getPresets: () => request<VoicePreset[]>("/voice/presets"),
   getProviders: () => request<VoiceProviderRow[]>("/voice/providers"),
@@ -38,14 +46,11 @@ export const voiceApi = {
       method: "PUT",
       body: JSON.stringify(body),
     }),
-  transcribe: (audio: Blob, language = "zh-CN") => {
+  transcribe: (audio: Blob, language = "zh-CN", provider?: string) => {
     const form = new FormData();
-    form.append(
-      "audio",
-      audio,
-      audio.type.includes("webm") ? "recording.webm" : "recording.wav",
-    );
+    form.append("audio", audio, recordingFilename(audio.type));
     form.append("language", language);
+    if (provider) form.append("provider", provider);
     return requestUpload<{ text: string; confidence?: number | null }>(
       "/voice/stt",
       form,

--- a/dashboard/src/hooks/useVoiceInput.ts
+++ b/dashboard/src/hooks/useVoiceInput.ts
@@ -16,9 +16,11 @@ interface BrowserSpeechRecognition {
   onerror: (() => void) | null;
   onend: (() => void) | null;
   start: () => void;
+  stop?: () => void;
 }
 
 type SpeechRecognitionCtor = new () => BrowserSpeechRecognition;
+const BROWSER_STT_TIMEOUT_MS = 15000;
 
 function getSpeechRecognition(): SpeechRecognitionCtor | null {
   const w = window as Window & {
@@ -53,22 +55,47 @@ async function transcribeWithBrowser(language: string): Promise<string> {
   }
   return new Promise((resolve, reject) => {
     const rec = new Ctor();
+    let settled = false;
+    let timer = 0;
+    const settle = (fn: () => void) => {
+      if (settled) return;
+      settled = true;
+      if (timer) window.clearTimeout(timer);
+      rec.onresult = null;
+      rec.onerror = null;
+      rec.onend = null;
+      fn();
+    };
     rec.lang = language;
     rec.interimResults = false;
     rec.maxAlternatives = 1;
     rec.onresult = (event) => {
       const text = event.results[0]?.[0]?.transcript?.trim() ?? "";
-      resolve(text);
+      settle(() => resolve(text));
     };
-    rec.onerror = () => reject(new Error("browser STT failed"));
-    rec.onend = () => {};
-    rec.start();
+    rec.onerror = () => settle(() => reject(new Error("browser STT failed")));
+    rec.onend = () => settle(() => resolve(""));
+    timer = window.setTimeout(() => {
+      try {
+        rec.stop?.();
+      } catch {
+        // Browser implementations differ; the timeout still settles below.
+      }
+      settle(() => reject(new Error("browser STT timed out")));
+    }, BROWSER_STT_TIMEOUT_MS);
+    try {
+      rec.start();
+    } catch (err) {
+      settle(() =>
+        reject(err instanceof Error ? err : new Error("browser STT failed")),
+      );
+    }
   });
 }
 
 /** Check whether the browser can record audio (requires secure context). */
 export function canRecordAudio(): boolean {
-  return !!navigator.mediaDevices?.getUserMedia;
+  return !!navigator.mediaDevices?.getUserMedia && "MediaRecorder" in window;
 }
 
 /** Check whether any STT method is available. */
@@ -120,6 +147,9 @@ export function useVoiceInput(onText: (text: string) => void) {
           if (msg.includes("VOICE_BROWSER_ONLY") || msg.includes("422")) {
             if (browserSttAvailable()) {
               text = await transcribeWithBrowser(language);
+            } else {
+              antMessage.error(t("voice.sttProviderRequired"));
+              return;
             }
           } else {
             // Server STT failed — try browser fallback if available.

--- a/dashboard/src/locales/en.json
+++ b/dashboard/src/locales/en.json
@@ -1372,6 +1372,7 @@
     "sttEmpty": "No speech detected",
     "sttFailed": "Speech recognition failed",
     "sttFallback": "Server STT failed — switched to browser recognition",
+    "sttProviderRequired": "This browser does not support native speech recognition. Configure Tencent Cloud or OpenAI STT.",
     "ttsFailed": "Text-to-speech failed",
     "nothingToRead": "No readable prose in this message (code blocks are skipped)",
     "browserNoChineseVoice": "Chrome has no Chinese voice — using Edge TTS instead",

--- a/dashboard/src/locales/zh.json
+++ b/dashboard/src/locales/zh.json
@@ -1370,6 +1370,7 @@
     "sttEmpty": "未识别到语音内容",
     "sttFailed": "语音识别失败",
     "sttFallback": "服务端识别失败，已切换浏览器识别",
+    "sttProviderRequired": "当前浏览器不支持原生语音识别，请配置腾讯云或 OpenAI STT",
     "ttsFailed": "语音合成失败",
     "nothingToRead": "没有可朗读的正文（代码块等内容已跳过）",
     "browserNoChineseVoice": "Chrome 没有中文语音，已改用 Edge TTS 朗读",

--- a/dashboard/src/pages/Settings/Voice/index.tsx
+++ b/dashboard/src/pages/Settings/Voice/index.tsx
@@ -134,6 +134,15 @@ export function VoiceSettingsPanel() {
       } else {
         await voiceApi.createProvider(payload);
       }
+      if (
+        preset.kind !== "browser" &&
+        (preset.capability === "stt" || preset.capability === "both") &&
+        active.stt === "browser"
+      ) {
+        const next = await voiceApi.setActive({ stt: preset.id });
+        setActive(next);
+        invalidateVoiceConfigCache();
+      }
       message.success(t("voice.saved"));
       setConfigure(null);
       await fetchAll();


### PR DESCRIPTION
## Summary

Fix voice input STT fallback handling.

This PR prevents Browser Native speech recognition from getting stuck in the “transcribing” state when the browser ends recognition without returning a result. It now resolves cleanly on `onend`, times out after 15 seconds, and handles `SpeechRecognition.start()` errors.

It also improves cross-browser recording handling by checking `MediaRecorder` support, using better uploaded audio filenames for WebM/MP4/Ogg/WAV, and automatically switching to a newly configured server-side STT provider when the active STT is still Browser Native.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / chore

## Test plan

- [ ] `make all` passes locally
- [ ] Added/updated tests

Verified with:

- [x] `make lint`
- [x] `./node_modules/.bin/tsc -b`
- [x] `./node_modules/.bin/eslint src/hooks/useVoiceInput.ts`
- [x] Manual voice input check: Browser Native no longer stays stuck in “识别中”

## Checklist

- [ ] Updated `CHANGELOG.md` (if user-facing)
- [ ] README / docs updated (if needed)
