### PR TITLE
fix(chat): align empty context legend

### DIFF
--- a/dashboard/src/pages/Chat/chatInputCore.partial.less
+++ b/dashboard/src/pages/Chat/chatInputCore.partial.less
@@ -405,6 +405,10 @@
 
 .contextUsageLegendLabel {
   min-width: 0;
+
+  &:only-child {
+    grid-column: 1 / -1;
+  }
 }
 
 .contextUsageLegendValue {


### PR DESCRIPTION
## Summary

- let the empty context-window legend label span the full three-column grid
- prevent the empty-state text from being squeezed into the swatch column in Safari

## Root cause

The populated legend renders swatch, label, and value cells, but the empty state renders only the label. The grid still assigned that sole child to column one, producing the broken layout reported in #23.

Closes #23

## Validation

- `npx tsc --noEmit`
- `npm run lint`
- `npm test -- --run` (97 passed)
- `npm run build:prod`
- `uv run ruff check src tests`
- `uv run ruff format --check src tests`
- `uv run mypy src/octop`

The full non-live backend pytest suite was also attempted on Windows. After redirecting pytest's temp directory to resolve a host permission error, it exceeded the 5-minute local command limit before producing a final result.
