### PR TITLE
fix(desktop): reject unsupported EL10 installs

### DIFF
--- a/src/octop/i18n/en.json
+++ b/src/octop/i18n/en.json
@@ -349,6 +349,7 @@
     "error_vnc_exposed": "VNC port is exposed on the network; restart with -localhost yes (only 127.0.0.1).",
     "error_apt_locked": "Another apt/dpkg process is using the package manager. Wait for it to finish, then retry.",
     "error_apt_failed": "System package installation failed. Check apt logs and retry.",
+    "error_el10_unsupported": "Remote desktop installation does not support Enterprise Linux 10 or later because the required X11 desktop packages are unavailable. Use Enterprise Linux 9 or Debian/Ubuntu.",
     "error_subprocess_stream": "Install output was interrupted. The install may still be running on the server."
   },
   "tls": {

--- a/src/octop/i18n/zh.json
+++ b/src/octop/i18n/zh.json
@@ -349,6 +349,7 @@
     "error_vnc_exposed": "VNC 端口暴露在网络上，请使用 -localhost yes 仅监听 127.0.0.1 后重启。",
     "error_apt_locked": "另一个 apt/dpkg 进程正在占用软件包管理器，请等待其结束后再重试。",
     "error_apt_failed": "系统软件包安装失败，请检查 apt 日志后重试。",
+    "error_el10_unsupported": "远程桌面安装暂不支持 Enterprise Linux 10 及更高版本，因为系统仓库缺少所需的 X11 桌面软件包。请使用 Enterprise Linux 9 或 Debian/Ubuntu。",
     "error_subprocess_stream": "安装输出读取中断，服务端可能仍在后台安装，请稍后刷新状态。"
   },
   "tls": {

--- a/src/octop/infra/desktop/scripts/linux/v1.0/install.sh
+++ b/src/octop/infra/desktop/scripts/linux/v1.0/install.sh
@@ -72,6 +72,23 @@ detect_distro() {
     fi
 }
 
+detect_enterprise_linux_major() {
+    [ -f /etc/os-release ] || return 1
+    # shellcheck disable=SC1091
+    . /etc/os-release
+    local lineage=" ${ID:-} ${ID_LIKE:-} "
+    case "$lineage" in
+        *" almalinux "*|*" centos "*|*" ol "*|*" rhel "*|*" rocky "*) ;;
+        *) return 1 ;;
+    esac
+    local version_id="${VERSION_ID:-}"
+    local major="${version_id%%.*}"
+    case "$major" in
+        ""|*[!0-9]*) return 1 ;;
+    esac
+    echo "$major"
+}
+
 detect_xvnc_bin() {
     local p
     for p in /usr/bin/Xvnc /usr/libexec/Xvnc /usr/bin/Xtigervnc /usr/libexec/Xtigervnc; do
@@ -1105,6 +1122,14 @@ main() {
         install_python_build_deps "$family"
         echo '{"installed": true, "build_deps_only": true}'
         exit 0
+    fi
+
+    if [ "$family" = rhel ]; then
+        local enterprise_linux_major
+        enterprise_linux_major=$(detect_enterprise_linux_major || true)
+        if [ -n "$enterprise_linux_major" ] && [ "$enterprise_linux_major" -ge 10 ]; then
+            fail "EL10_UNSUPPORTED: Enterprise Linux 10 and later do not provide the required TigerVNC, Openbox, and XFCE packages. Use Enterprise Linux 9 or Debian/Ubuntu."
+        fi
     fi
 
     install_packages "$family"

--- a/src/octop/infra/desktop/setup.py
+++ b/src/octop/infra/desktop/setup.py
@@ -25,6 +25,8 @@ _APT_LOCK_RE = re.compile(r"lock-frontend|dpkg.*lock", re.I)
 _SCRIPT_LOG_RE = re.compile(
     r"(install\.sh|start\.sh|stop\.sh|Running /|Starting desktop services via /|Stopping desktop services via /)",
 )
+_OS_RELEASE_PATH = Path("/etc/os-release")
+_ENTERPRISE_LINUX_IDS = frozenset({"almalinux", "centos", "ol", "rhel", "rocky"})
 
 
 def _install_log(locale: str, key: str, **kwargs: object) -> str:
@@ -74,10 +76,43 @@ def _friendly_install_log_line(text: str, locale: str) -> str | None:
             return t
         err = str(payload.get("error") or "").strip()
         if payload.get("installed") is False and err:
+            if err.startswith("EL10_UNSUPPORTED:"):
+                return _install_log(locale, "error_el10_unsupported")
             if "apt" in err.lower():
                 return _install_log(locale, "error_apt_failed")
             return err
     return t
+
+
+def _read_os_release() -> dict[str, str]:
+    try:
+        text = _OS_RELEASE_PATH.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return {}
+    release: dict[str, str] = {}
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        release[key] = value.strip().strip("\"'")
+    return release
+
+
+def _enterprise_linux_major_version(release: dict[str, str]) -> int | None:
+    distro_id = release.get("ID", "").lower()
+    distro_like = set(release.get("ID_LIKE", "").lower().split())
+    if distro_id not in _ENTERPRISE_LINUX_IDS and not distro_like.intersection({"rhel", "centos"}):
+        return None
+    match = re.match(r"\d+", release.get("VERSION_ID", ""))
+    return int(match.group()) if match else None
+
+
+def _unsupported_linux_desktop_reason(locale: str) -> str:
+    major = _enterprise_linux_major_version(_read_os_release())
+    if major is not None and major >= 10:
+        return _install_log(locale, "error_el10_unsupported")
+    return ""
 
 
 async def _iter_subprocess_lines(stream: asyncio.StreamReader) -> AsyncIterator[str]:
@@ -576,6 +611,25 @@ def _mac_permissions() -> tuple[str, ...]:
 def desktop_status(*, locale: str = "en") -> DesktopStatus:
     system = platform.system().lower()
     geometry = read_geometry()
+    linux_setup: tuple[SetupState, str | None, str, bool | None] | None = None
+
+    if system == "linux":
+        unsupported_reason = _unsupported_linux_desktop_reason(locale)
+        if unsupported_reason:
+            linux_setup = _resolve_linux_setup(locale=locale)
+            if linux_setup[0] == "needs_install":
+                return DesktopStatus(
+                    ok=False,
+                    desktop_supported=False,
+                    setup_state="unsupported",
+                    platform=system,
+                    display=None,
+                    reason=unsupported_reason,
+                    install_script="",
+                    start_command="",
+                    geometry=geometry,
+                    vnc_localhost_only=linux_setup[3],
+                )
 
     if not _python_deps_available():
         return DesktopStatus(
@@ -593,7 +647,7 @@ def desktop_status(*, locale: str = "en") -> DesktopStatus:
         )
 
     if system == "linux":
-        setup_state, display, reason, vnc_local = _resolve_linux_setup(locale=locale)
+        setup_state, display, reason, vnc_local = linux_setup or _resolve_linux_setup(locale=locale)
         supported = setup_state in {"ready", "needs_start"}
         return DesktopStatus(
             ok=setup_state == "ready",

--- a/tests/unit/desktop/test_setup.py
+++ b/tests/unit/desktop/test_setup.py
@@ -37,6 +37,47 @@ def test_friendly_install_log_line_maps_install_json() -> None:
     assert friendly == tr("desktop.error_apt_failed", "en")
 
 
+def test_friendly_install_log_line_localizes_el10_error() -> None:
+    from octop.infra.desktop.setup import _friendly_install_log_line
+
+    raw = '{"installed": false, "error": "EL10_UNSUPPORTED: package stack unavailable"}'
+    friendly = _friendly_install_log_line(raw, "zh")
+    assert friendly == tr("desktop.error_el10_unsupported", "zh")
+
+
+@pytest.mark.parametrize(
+    ("release", "expected"),
+    [
+        ({"ID": "almalinux", "VERSION_ID": "10.2"}, 10),
+        ({"ID": "rocky", "VERSION_ID": "10"}, 10),
+        ({"ID": "custom", "ID_LIKE": "rhel centos fedora", "VERSION_ID": "11.1"}, 11),
+        ({"ID": "rhel", "VERSION_ID": "9.7"}, 9),
+        ({"ID": "fedora", "VERSION_ID": "42"}, None),
+    ],
+)
+def test_enterprise_linux_major_version(release: dict[str, str], expected: int | None) -> None:
+    from octop.infra.desktop.setup import _enterprise_linux_major_version
+
+    assert _enterprise_linux_major_version(release) == expected
+
+
+def test_desktop_status_rejects_fresh_el10_before_python_deps() -> None:
+    reason = tr("desktop.error_el10_unsupported", "en")
+    with (
+        patch("octop.infra.desktop.setup.platform.system", return_value="Linux"),
+        patch("octop.infra.desktop.setup._python_deps_available", return_value=False),
+        patch("octop.infra.desktop.setup._unsupported_linux_desktop_reason", return_value=reason),
+        patch(
+            "octop.infra.desktop.setup._resolve_linux_setup",
+            return_value=("needs_install", None, "", None),
+        ),
+    ):
+        status = desktop_status()
+    assert status.setup_state == "unsupported"
+    assert status.desktop_supported is False
+    assert status.reason == reason
+
+
 @pytest.mark.asyncio
 async def test_iter_subprocess_lines_handles_long_line_without_newline() -> None:
     from octop.infra.desktop.setup import _iter_subprocess_lines

--- a/tests/unit/i18n/test_desktop.py
+++ b/tests/unit/i18n/test_desktop.py
@@ -11,6 +11,7 @@ def test_desktop_keys_parity() -> None:
     assert en_keys == zh_keys
     assert "desktop.install_log_system" in en_keys
     assert "desktop.install_log_build_deps" in en_keys
+    assert "desktop.error_el10_unsupported" in en_keys
 
 
 def test_desktop_error_interpolation() -> None:


### PR DESCRIPTION
## Summary

- detect Enterprise Linux 10+ before a fresh remote-desktop installation
- report the unsupported platform through the desktop status API with localized English and Chinese guidance
- keep an independent guard in the bundled installer so direct script execution also fails before desktop package installation
- preserve existing ready or restartable desktop stacks and avoid treating Fedora as Enterprise Linux solely by version number

## Root cause

The RHEL-family installer unconditionally requested TigerVNC, Openbox, and XFCE packages. Those X11 desktop packages are not available from EL10 repositories, so AlmaLinux/Rocky/RHEL 10 users received a long `dnf` failure instead of an actionable compatibility message.

This implements the explicit unsupported-platform fallback requested in #38. Full EL10 support remains future work and will require a different desktop stack.

Closes #38

## Validation

- `pytest tests/unit/desktop/test_setup.py tests/unit/i18n -q` (69 passed)
- `ruff check src tests`
- `ruff format --check src tests`
- `mypy src/octop` (334 source files)
- `bash -n src/octop/infra/desktop/scripts/linux/v1.0/install.sh`
- full unit suite: 1055 passed, 74 skipped, 2 unrelated Windows-only environment failures

The two full-suite failures are pre-existing Windows host issues: browser profile writability falls back to a POSIX `/tmp` path, and a DB fixture reads UTF-8 SQL with the system GBK locale. All desktop and i18n tests pass.
