### PR TITLE
docs: adopt develop integration and main-first release flow

### DIFF
--- a/.cursor/skills/publish/SKILL.md
+++ b/.cursor/skills/publish/SKILL.md
@@ -1,9 +1,10 @@
 ---
 name: publish
 description: >-
-  Publish the Octop Python package: create a release branch, bump version,
-  update CHANGELOG, push tag (triggers GitHub Actions for PyPI / Docker Hub),
-  and open a PR to main. Use when the user asks to publish, release, bump
+  Publish the Octop Python package: cut a release branch from develop, bump
+  version, update CHANGELOG, open a PR to main, wait for merge, then tag on
+  main (triggers GitHub Actions for PyPI / Docker Hub), delete the release
+  branch, and sync develop. Use when the user asks to publish, release, bump
   version, cut a release, or run /publish.
 disable-model-invocation: true
 ---
@@ -27,7 +28,8 @@ disable-model-invocation: true
 | `INIT_VERSION_FILE` | `src/octop/__init__.py` | 含运行时常量 `__version__` 的文件（缺失则跳过并提示） |
 | `TAG_PREFIX` | `v` | Git tag 前缀；工作流监听 `v*`，生成 `v0.1.14` 风格标签 |
 | `REMOTE` | `origin` | Git 远程仓库名 |
-| `TARGET_BRANCH` | `main` | 合并请求的目标分支 |
+| `INTEGRATION_BRANCH` | `develop` | 日常集成分支；release 必须从最新 tip 切出 |
+| `TARGET_BRANCH` | `main` | 合并请求的目标分支（生产真源） |
 | `RELEASE_BRANCH_PREFIX` | `release/` | release 分支名前缀 |
 
 ## 调用方式
@@ -40,55 +42,59 @@ disable-model-invocation: true
 
 ## 发布流程
 
+> **顺序硬约束：** 先 PR 合入 `main`，再在 **main tip** 打并推送 `v*` tag。  
+> **禁止**在 release 分支未合入 `main` 前推送生产 tag。
+
 ### 步骤 1 — 读取配置并确认版本
 
 1. 获取仓库根目录：`git rev-parse --show-toplevel`
-2. 从 `VERSION_FILE` 读取当前版本：
+2. 记录当前分支为 `{original_branch}`。
+3. `git fetch {REMOTE} {INTEGRATION_BRANCH} {TARGET_BRANCH}`
+4. 从 `VERSION_FILE` 读取当前版本（在即将基于的 integration tip 上）：
    ```bash
-   grep -E '^\s*version\s*=\s*"[^"]+"' pyproject.toml
+   git show {REMOTE}/{INTEGRATION_BRANCH}:pyproject.toml | grep -E '^\s*version\s*=\s*"[^"]+"'
    ```
-3. 检查未提交的更改：
+5. 检查未提交的更改：
    ```bash
    git status --short
    ```
-   如果存在未提交的更改，它们将被包含在步骤 4 的发布提交中。这是有意为之 — 所有待处理的工作随版本一起发布。
-4. 查找最近的 git tag：
+   若工作树不干净：**中止**并要求用户先提交或 stash。发布不得夹带无关脏文件。
+6. 查找最近的 git tag：
    ```bash
    git tag --sort=-creatordate | head -1
    ```
    如果没有 tag，视为首次发布（在步骤 3 中使用从仓库初始到 HEAD 的所有提交）。
-5. 展示确认信息：
+7. 展示确认信息：
 
 ```
-当前版本 (pyproject.toml): X.Y.Z
-目标版本:                   A.B.C
-上次发布 tag:               X.Y.Z (YYYY-MM-DD)
-Release 分支:               release/A.B.C
-目标分支 (PR):              main
+当前版本 (pyproject.toml @ develop): X.Y.Z
+目标版本:                           A.B.C
+上次发布 tag:                       vX.Y.Z (YYYY-MM-DD)
+Release 分支:                       release/A.B.C
+集成起点:                           develop
+合入目标:                           main
+Tag 时机:                           main 合并之后（不会在 release 上先打 tag）
 
 确认发布 X.Y.Z → A.B.C？[y/N]
 ```
 
 如果用户未输入 `y` 确认，立即中止。
 
-### 步骤 2 — 创建 release 分支
-
-从当前 HEAD 创建并切换到新的 release 分支：
+### 步骤 2 — 从 develop 创建 release 分支
 
 ```bash
-git checkout -b {RELEASE_BRANCH_PREFIX}{version}
+git checkout -B {RELEASE_BRANCH_PREFIX}{version} {REMOTE}/{INTEGRATION_BRANCH}
 ```
 
-如果分支已存在，中止：
+如果本地或远程已存在同名 release 分支，中止：
 ```
 ✗ 分支 {RELEASE_BRANCH_PREFIX}{version} 已存在。
-请手动删除：git branch -D {RELEASE_BRANCH_PREFIX}{version}
-然后重新运行 /publish。
+请手动删除后再运行 /publish。
 ```
 
 ### 步骤 3 — 分析变更并生成 CHANGELOG 草稿
 
-1. 获取上次 tag 以来的提交：
+1. 获取上次 tag 以来的提交（相对当前 release HEAD，即 develop tip）：
    ```bash
    git log {last_tag}..HEAD --oneline
    # 首次发布时：
@@ -194,12 +200,11 @@ git checkout -b {RELEASE_BRANCH_PREFIX}{version}
 
 **4c. 提交：**
 
-检查工作树状态：
 ```bash
 git status --short
 ```
 
-- 如果有更改（已暂存或未暂存）：暂存所有文件并提交：
+- 如果有更改：暂存并提交：
   ```bash
   git add -A
   git commit -m "chore: release {version}"
@@ -213,32 +218,9 @@ git push -u {REMOTE} {RELEASE_BRANCH_PREFIX}{version}
 
 推送失败则中止。
 
-### 步骤 5 — 打 tag 并推送（触发 GitHub Action 发布）
+### 步骤 5 — 创建合入 main 的 Pull Request（先合，后 tag）
 
-推送 tag 到远程后，**GitHub Actions 会自动完成发布**，本步骤**不再直接上传 PyPI**：
-
-- `release.yml` 的 `build` job 执行 `make build`（重建前端 + 生成 `README.pypi.md` + 打 wheel），随后 `publish` job 用 `PYPI_API_TOKEN` secret 上传 PyPI；
-- `docker-publish.yml` 构建并推送镜像到 Docker Hub；
-- `github-release` job 用 CHANGELOG 生成 GitHub Release。
-
-```bash
-git tag {TAG_PREFIX}{version}
-git push {REMOTE} {TAG_PREFIX}{version}
-```
-
-如果 `git tag` 因 tag 已存在而失败：
-```
-✗ Tag {TAG_PREFIX}{version} 已存在。
-请手动删除：git tag -d {TAG_PREFIX}{version}
-然后重新运行 /publish 从此步骤重试。
-```
-中止。
-
-推送成功后，提示用户到仓库 Actions 页面确认 `Release` 与 `Docker Publish` 两个工作流均通过（失败可在对应 run 上 Re-run jobs，无需重新打 tag）。
-
-### 步骤 6 — 创建合并请求（GitHub）
-
-使用 `gh` CLI 从 release 分支创建到 `TARGET_BRANCH` 的 Pull Request：
+使用 `gh` CLI：
 
 ```bash
 gh pr create \
@@ -247,31 +229,75 @@ gh pr create \
   --title "chore: release {version}" \
   --body "$(cat <<'EOF'
 {步骤 3 生成的 CHANGELOG 条目}
+
+## Release checklist
+- [ ] CI green
+- [ ] Merge this PR into main
+- [ ] Then tag v{version} on main tip (publish skill step 6)
 EOF
 )"
 ```
 
-- 若 `gh` 未登录或命令失败，展示警告（非致命 — tag 已推送，发布将由 GitHub Action 完成），并提示手动创建 PR：
-  ```
-  ⚠ tag 已推送、发布将由 GitHub Action 完成，但 Pull Request 创建失败（可能 gh 未登录）。
-  请手动创建 PR：{RELEASE_BRANCH_PREFIX}{version} → {TARGET_BRANCH}
-  ```
-- 成功时展示 PR URL：
-  ```
-  ✓ 已推送 tag {TAG_PREFIX}{version} 到 {REMOTE}（PyPI / Docker 由 GitHub Action 自动发布）
-  ✓ 已创建 Pull Request：{RELEASE_BRANCH_PREFIX}{version} → {TARGET_BRANCH}
-    链接：{pr_url}
-  ```
+- 成功时展示 PR URL，并明确告知：**在 PR 合并前不要打 tag。**
+- 若 `gh` 失败：中止（此时尚未发版），提示手动创建 PR：
+  `{RELEASE_BRANCH_PREFIX}{version}` → `{TARGET_BRANCH}`
 
-### 步骤 7 — 切回原分支
+### 步骤 6 — 等待合入后，在 main tip 打 tag
 
-返回创建 release 分支之前所在的分支：
+1. 询问用户 PR 是否已合并，或轮询：
+   ```bash
+   gh pr view {pr_url} --json state,mergedAt
+   ```
+   未合并则**不要**打 tag；可暂停并提示用户合并后再说「继续」。
+
+2. 合并后：
+   ```bash
+   git fetch {REMOTE} {TARGET_BRANCH}
+   git checkout {TARGET_BRANCH}
+   git pull {REMOTE} {TARGET_BRANCH}
+   ```
+   确认 `pyproject.toml` 版本已是目标版本（合入结果在 main 上）。
+
+3. 打 tag 并推送（触发 GitHub Action）：
+
+   - `release.yml`：`build` → PyPI `publish` → `github-release`
+   - `docker-publish.yml`：推送 Docker Hub
+
+   ```bash
+   git tag {TAG_PREFIX}{version}
+   git push {REMOTE} {TAG_PREFIX}{version}
+   ```
+
+   若 tag 已存在：中止并给出删除指令（仅在确认该 tag 未用于错误发布时）。
+
+4. 提示用户到 Actions 确认 `Release` 与 `Docker Publish` 通过。
+
+### 步骤 7 — 删除 release 分支并同步 develop
+
+1. 删除远程与本地 release 分支：
+   ```bash
+   git push {REMOTE} --delete {RELEASE_BRANCH_PREFIX}{version}
+   git branch -D {RELEASE_BRANCH_PREFIX}{version}
+   ```
+   删除失败则警告（非致命），提示手动删除。
+
+2. 若 `main` 与 `develop` 有差异（merge commit 或仅在 main 上的修复），创建同步 PR：
+   ```bash
+   gh pr create \
+     --base {INTEGRATION_BRANCH} \
+     --head {TARGET_BRANCH} \
+     --title "chore: sync main into develop after {version}" \
+     --body "Post-release sync so develop contains the shipped main tip."
+   ```
+   若已快进无差异，跳过并说明。
+
+### 步骤 8 — 切回原分支
 
 ```bash
 git checkout {original_branch}
 ```
 
-确保流程结束后用户不会停留在 release 分支上。
+确保流程结束后用户不会停留在 release / 临时检出上。
 
 ## 错误处理参考
 
@@ -279,26 +305,33 @@ git checkout {original_branch}
 |------|------|
 | `VERSION_FILE` 未找到 | 中止："找不到 VERSION_FILE：{path}" |
 | 文件中未匹配到版本号 | 中止："在 {VERSION_FILE} 中找不到匹配 {VERSION_PATTERN} 的版本行" |
-| 没有 git tag（首次发布） | 使用从仓库初始到 HEAD 的所有提交；提示"首次发布 — 使用完整 git 历史" |
+| 工作树不干净 | 中止：先清理再发布 |
+| 没有 git tag（首次发布） | 使用完整历史；提示"首次发布" |
 | 上次 tag 以来无提交 | 警告并询问是否继续 |
 | Release 分支已存在 | 中止并给出删除指令 |
 | 步骤 4 推送失败 | 中止：文件已在本地更新但未推送 |
-| 步骤 5 tag 已存在 | 中止并给出删除指令 |
-| 步骤 5 tag 推送成功但 GitHub Action 发布失败 | 非致命：提示用户到 Actions 页面查看失败日志并 Re-run 对应 job（无需重新打 tag） |
-| 步骤 6 PR 创建失败 | 仅警告（tag 已推送，发布将由 GitHub Action 完成） |
+| 步骤 5 PR 创建失败 | 中止（尚未打 tag / 未发版） |
+| 步骤 6 在未合入时打 tag | **禁止** — 硬红线 |
+| 步骤 6 tag 已存在 | 中止并给出删除指令 |
+| 步骤 6 tag 推送成功但 Action 失败 | 非致命：提示到 Actions Re-run |
+| 步骤 7 删分支或 sync PR 失败 | 警告并给出手动命令 |
 
 ## 红线规则
 
 **绝不：**
+- 在 release / feature 分支上、于合入 `main` **之前**推送生产 `v*` tag
 - 在推送 tag 前直接上传 PyPI（发布由 GitHub Action 负责）
+- 将 `develop` 直接 push / merge 进 `main`（必须走 PR）
 - 跳过步骤 1 的用户确认
 - 跳过步骤 3 的 CHANGELOG 确认
-- 在任何步骤失败后继续执行（步骤 6 PR 失败除外）
+- 在任何步骤失败后继续执行（步骤 7 的清理/同步警告除外）
 - 流程结束后让用户留在 release 分支
+- 保留已发完的 `release/*` 作为长期分支
 
 **始终：**
-- 任何失败立即中止（步骤 6 PR 失败除外）
+- 从最新 `{REMOTE}/{INTEGRATION_BRANCH}` 切 release
+- 先合入 `{TARGET_BRANCH}`，再在 main tip 打 tag
+- 发版后删除 `release/*`，并在需要时同步回 `develop`
 - 中止前展示完整错误输出
 - 插入新版本条目后保持 `[Unreleased]` 为空
-- 流程结束时切回原分支
 - 推送 tag 后提示用户关注 GitHub Actions 的发布结果

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,6 +2,11 @@
 
 <!-- What does this PR change and why? -->
 
+## Target branch
+
+- [ ] Base is **`develop`** (feature / fix — default)
+- [ ] Base is **`main`** (`release/*` or `hotfix/*` only)
+
 ## Type of change
 
 - [ ] Bug fix
@@ -9,6 +14,7 @@
 - [ ] Breaking change
 - [ ] Documentation
 - [ ] Refactor / chore
+- [ ] Release / hotfix
 
 ## Test plan
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -334,6 +334,7 @@ Boundary rules are in [§5](#5-module-boundaries). Additionally:
 | OpenAPI tags and API intro | `api/openapi_meta.py` |
 | Human-readable API reference | `docs/api.md` |
 | SharedServices / RepoBundle | `infra/db/services.py` |
+| Branching & release | [§10](#10-change-workflow) Branching & release; `CONTRIBUTING.md`; `.cursor/skills/publish` |
 
 ## 10. Change workflow
 
@@ -341,6 +342,28 @@ Boundary rules are in [§5](#5-module-boundaries). Additionally:
 2. **Minimal implementation** — change only task-related files; dashboard source is in `dashboard/`, build output in `src/octop/dashboard/` (run `make build-frontend` after UI changes).
 3. **Verify** — backend: `make all` (`lint` + `typecheck` + `test`). After `dashboard/` changes, also run `cd dashboard && npx tsc --noEmit` (and `npm run lint` when appropriate). After API route changes, glance at `/api/docs` for readable summaries and schemas. After i18n JSON changes, run `uv run pytest tests/unit/i18n -q`.
 4. **Wrap up** — remove orphan symbols introduced in this change; do not commit or push unless asked.
+
+### Branching & release
+
+```
+feature/* ──PR──► develop ──► release/x.y.z ──PR──► main ──tag v*──► publish
+hotfix/* ──PR──► main (+ tag) and ──PR──► develop
+```
+
+| Branch | Role |
+|--------|------|
+| `main` | Production source of truth; **default branch**; only release / hotfix merges; **only `v*` tags on `main` are production** |
+| `develop` | Daily integration; **base for feature PRs** |
+| `release/x.y.z` | Temporary freeze (version bump / CHANGELOG / bugfixes); **delete after ship** |
+
+**Rules**
+
+- Never push `develop` directly onto `main` — all merges via PR.
+- Release sequence: cut `release/*` from latest `develop` → PR into `main` → **tag `v*` on main tip only after merge** → delete `release/*` → sync `main` → `develop` when needed.
+- Do **not** push a production tag from a release/feature branch before it is on `main`.
+- Hotfix: branch from `main`, PR to `main` (and tag if shipping), then PR into `develop`.
+- Day-to-day feature work: branch from `develop`, open PR **into `develop`** (not `main`).
+- Human detail: `CONTRIBUTING.md`. Agent publish flow: `.cursor/skills/publish`.
 
 ## 11. Communication
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,19 +33,45 @@ make check-all        # full stack quality gate
 | `make build` | Build dashboard + Python wheel |
 | `make docs-cli` | Regenerate CLI documentation |
 
+## Branching
+
+| Branch | Role |
+|--------|------|
+| `main` | Production source of truth; GitHub default branch; only release / hotfix merges |
+| `develop` | Daily integration; **open feature PRs against `develop`** |
+| `release/x.y.z` | Temporary release snapshot; deleted after the version ships |
+| `hotfix/*` | Emergency fix from `main`; merge to `main` and back to `develop` |
+
+```
+feature/* ──PR──► develop ──► release/x.y.z ──PR──► main ──tag v*──► publish
+hotfix/* ──PR──► main (+ tag) and ──PR──► develop
+```
+
+**Rules:** never push `develop` directly to `main` (PR only). Production `v*` tags are created **on `main` after** the release PR merges — not on the release branch before merge.
+
 ## Pull requests
 
-1. Fork the repository and create a feature branch from `main`
-2. Add or update tests for behavior changes
-3. Run `make all` (backend) or `make check-all` (full stack) before submitting
-4. Update `CHANGELOG.md` when user-facing behavior changes
-5. Open a PR with a clear description and test plan
+1. Fork (if needed) and create a feature branch from **`develop`**
+2. Open the PR with base **`develop`** (not `main`, unless it is a release or hotfix)
+3. Add or update tests for behavior changes
+4. Run `make all` (backend) or `make check-all` (full stack) before submitting
+5. Update `CHANGELOG.md` when user-facing behavior changes
+6. Open a PR with a clear description and test plan
 
 See [AGENTS.md](AGENTS.md) for module boundaries and coding conventions.
 
 ## Releases
 
-Tag `v<version>` to trigger build, PyPI publish, and GitHub Release.
+1. Cut `release/x.y.z` from latest `develop` (version bump + CHANGELOG on that branch)
+2. Open PR: `release/x.y.z` → `main` and merge when green
+3. Tag `v<version>` on **main tip** and push — GitHub Actions builds, publishes to PyPI, and creates the GitHub Release
+4. Delete `release/x.y.z`; if needed, open PR `main` → `develop` to sync
+
+Agent-assisted publish: `.cursor/skills/publish` (`/publish <version>`).
+
+### Hotfix
+
+Branch from `main` → PR into `main` (tag if shipping a patch) → PR into `develop`.
 
 ---
 
@@ -71,13 +97,32 @@ make dev-frontend
 make check-all        # 全栈质量门禁
 ```
 
+## 分支策略
+
+| 分支 | 角色 |
+|------|------|
+| `main` | 生产真源；GitHub 默认分支；仅合入 release / hotfix |
+| `develop` | 日常集成；**特性 PR 请打向 `develop`** |
+| `release/x.y.z` | 临时发版分支；发版完成后删除 |
+| `hotfix/*` | 从 `main` 紧急修复；合入 `main` 后再合回 `develop` |
+
+**规则：** 禁止将 `develop` 直接推送到 `main`（必须走 PR）。生产 `v*` tag 仅在 release PR **合入 `main` 之后**打在 main tip 上。
+
 ## 提交流程
 
-1. Fork 仓库，从 `main` 创建特性分支
-2. 补充测试，运行 `make all` 或 `make check-all`
-3. 更新 `CHANGELOG.md`
-4. 提交 Pull Request
+1. 从 **`develop`** 创建特性分支
+2. PR 的 base 选 **`develop`**（release / hotfix 除外）
+3. 补充测试，运行 `make all` 或 `make check-all`
+4. 用户可见变更时更新 `CHANGELOG.md`
+5. 提交 Pull Request
 
 模块边界与编码规范见 [AGENTS.md](AGENTS.md)。
 
-推送 `v<version>` 标签后自动构建并发布。
+## 发版
+
+1. 从最新 `develop` 切 `release/x.y.z`（在该分支 bump 版本与 CHANGELOG）
+2. PR：`release/x.y.z` → `main`，合并通过后
+3. 在 **main tip** 打并推送 `v<version>`，由 Actions 构建并发布
+4. 删除 `release/x.y.z`；必要时再开 `main` → `develop` 同步 PR
+
+Hotfix：从 `main` 拉分支 → 合入 `main`（需发补丁则打 tag）→ 再合入 `develop`。


### PR DESCRIPTION
## Summary
- Document `develop` as the daily integration branch and `main` as production truth (feature PRs → `develop`; release/hotfix → `main`).
- Align `AGENTS.md`, `CONTRIBUTING.md`, and the publish skill so production `v*` tags are cut **on main after** the release PR merges; temporary `release/*` branches are deleted after ship.
- Update the PR template to call out the correct base branch.

## Test plan
- [ ] Confirm PR base is `develop`
- [ ] Skim `AGENTS.md` §10 Branching & release and `CONTRIBUTING.md` branching sections for accuracy
- [ ] Spot-check `.cursor/skills/publish/SKILL.md`: release from `develop` → PR to `main` → tag after merge → delete release / sync develop


Made with [Cursor](https://cursor.com)