### PR TITLE
feat: support migration from lightclaw

### DIFF
--- a/src/octop/infra/backup/snapshot.py
+++ b/src/octop/infra/backup/snapshot.py
@@ -6,7 +6,7 @@ import sqlite3
 from pathlib import Path
 from urllib.parse import quote
 
-from octop.infra.db.pool import SqlitePool
+from octop.infra.db.pool import DatabasePool, SqlitePool
 
 
 def _readonly_sqlite_uri(path: Path) -> str:
@@ -77,24 +77,47 @@ _USER_COLS_SQL = ", ".join(_USER_COLUMNS)
 _USER_PLACEHOLDERS = ", ".join("?" for _ in _USER_COLUMNS)
 
 
-def capture_users_from_pool(pool: DBPool) -> list[tuple[object, ...]]:
+def capture_users_from_pool(pool: DatabasePool) -> list[tuple[object, ...]]:
     """Return all rows from the live *users* table as plain tuples."""
     with pool.connect() as conn:
         rows = conn.execute(f"SELECT {_USER_COLS_SQL} FROM users").fetchall()
     return [tuple(r) for r in rows]
 
 
-def restore_users_into_pool(pool: DBPool, users: list[tuple[object, ...]]) -> None:
-    """Replace the *users* table content with *users* (previously captured rows).
+def restore_users_into_pool(pool: DatabasePool, users: list[tuple[object, ...]]) -> None:
+    """Merge *users* (previously captured rows) back into the *users* table.
 
-    Existing rows are deleted first so that the restore is idempotent even when
-    the DB was swapped in-place by :func:`restore_sqlite_into_pool`.
+    Avoids ``DELETE FROM users`` (and ``INSERT OR REPLACE``, which SQLite
+    implements as DELETE + INSERT) because both trigger ``ON DELETE CASCADE``
+    on child tables (agents, sessions, threads, …) when
+    ``PRAGMA foreign_keys = ON`` is active — wiping the data just restored
+    from the backup.
+
+    Strategy:
+    1. For each saved row: UPDATE in-place if the ``id`` already exists,
+       otherwise INSERT.  Neither operation removes the row first, so FK
+       children are preserved.
+    2. DELETE rows whose ``id`` is not in the saved set — removes leftover
+       rows from the backup that are not part of the current instance's users.
+       These rows have no children that matter (their children came from the
+       backup and reference backup user-ids that are being deleted anyway).
     """
     if not users:
         return
+    saved_ids = [row[0] for row in users]  # first column is always ``id``
+    # Build SET clause for UPDATE: skip the first column (id is the PK).
+    set_clause = ", ".join(f"{col} = ?" for col in _USER_COLUMNS[1:])
     with pool.transaction() as conn:
-        conn.execute("DELETE FROM users")
-        conn.executemany(
-            f"INSERT INTO users({_USER_COLS_SQL}) VALUES ({_USER_PLACEHOLDERS})",
-            users,
-        )
+        for row in users:
+            pk = row[0]
+            rest = row[1:]
+            conn.execute(f"UPDATE users SET {set_clause} WHERE id = ?", (*rest, pk))
+            # If no row matched, the id does not exist yet — insert it.
+            if conn.execute("SELECT changes()").fetchone()[0] == 0:
+                conn.execute(
+                    f"INSERT INTO users({_USER_COLS_SQL}) VALUES ({_USER_PLACEHOLDERS})",
+                    row,
+                )
+        # Remove backup-origin rows whose id is not in the saved set.
+        placeholders = ", ".join("?" for _ in saved_ids)
+        conn.execute(f"DELETE FROM users WHERE id NOT IN ({placeholders})", saved_ids)

--- a/src/octop/infra/backup/snapshot.py
+++ b/src/octop/infra/backup/snapshot.py
@@ -53,3 +53,48 @@ def restore_sqlite_into_pool(backup_file: Path, pool: SqlitePool) -> None:
             live.execute("PRAGMA wal_checkpoint(FULL)")
     finally:
         src.close()
+
+
+# ---------------------------------------------------------------------------
+# User helpers for migration restores
+# ---------------------------------------------------------------------------
+
+# All columns in the users table (must match schema in 001_initial.sql).
+_USER_COLUMNS = (
+    "id",
+    "username",
+    "password_hash",
+    "role",
+    "display_name",
+    "disabled",
+    "created_at",
+    "locale",
+    "preferences_json",
+    "login_failed_count",
+    "login_locked_until",
+)
+_USER_COLS_SQL = ", ".join(_USER_COLUMNS)
+_USER_PLACEHOLDERS = ", ".join("?" for _ in _USER_COLUMNS)
+
+
+def capture_users_from_pool(pool: DBPool) -> list[tuple[object, ...]]:
+    """Return all rows from the live *users* table as plain tuples."""
+    with pool.connect() as conn:
+        rows = conn.execute(f"SELECT {_USER_COLS_SQL} FROM users").fetchall()
+    return [tuple(r) for r in rows]
+
+
+def restore_users_into_pool(pool: DBPool, users: list[tuple[object, ...]]) -> None:
+    """Replace the *users* table content with *users* (previously captured rows).
+
+    Existing rows are deleted first so that the restore is idempotent even when
+    the DB was swapped in-place by :func:`restore_sqlite_into_pool`.
+    """
+    if not users:
+        return
+    with pool.transaction() as conn:
+        conn.execute("DELETE FROM users")
+        conn.executemany(
+            f"INSERT INTO users({_USER_COLS_SQL}) VALUES ({_USER_PLACEHOLDERS})",
+            users,
+        )

--- a/src/octop/infra/backup/system_archive.py
+++ b/src/octop/infra/backup/system_archive.py
@@ -35,7 +35,7 @@ _WORKSPACES_DIR = "workspaces"
 _MANIFEST_NAME = "manifest.json"
 _SQLITE_DB_ARC = f"{_DB_DIR}/octop.db"
 _PG_DUMP_ARC = f"{_DB_DIR}/octop.dump"
-
+_MIGRATION_VERSION_SUFFIX = "-migrated-from-lightclaw"
 
 def _timestamp() -> str:
     return datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
@@ -165,9 +165,6 @@ def _read_tar_members(data: bytes) -> dict[str, bytes]:
                 continue
             out[member.name.replace("\\", "/")] = extracted.read()
     return out
-
-
-_MIGRATION_VERSION_SUFFIX = "-migrated-from-lightclaw"
 
 
 def _is_migration_backup(manifest: BackupManifest) -> bool:

--- a/src/octop/infra/backup/system_archive.py
+++ b/src/octop/infra/backup/system_archive.py
@@ -37,6 +37,7 @@ _SQLITE_DB_ARC = f"{_DB_DIR}/octop.db"
 _PG_DUMP_ARC = f"{_DB_DIR}/octop.dump"
 _MIGRATION_VERSION_SUFFIX = "-migrated-from-lightclaw"
 
+
 def _timestamp() -> str:
     return datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
 

--- a/src/octop/infra/backup/system_archive.py
+++ b/src/octop/infra/backup/system_archive.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import io
 import json
+import os
 import shutil
 import tarfile
 import tempfile
@@ -16,11 +17,14 @@ from octop.config import DatabaseConfig
 from octop.infra.backup.manifest import MANIFEST_VERSION, AgentBackupEntry, BackupManifest
 from octop.infra.backup.pg_dump import dump_postgres, restore_postgres
 from octop.infra.backup.snapshot import (
+    capture_users_from_pool,
     restore_sqlite_into_pool,
+    restore_users_into_pool,
     snapshot_sqlite_file,
 )
 from octop.infra.db.migrate import _current_version
 from octop.infra.db.pool import DatabasePool, SqlitePool
+from octop.infra.db.repos.secrets import SecretRepo
 from octop.infra.errors import ErrorCode, OctopError
 from octop.infra.utils.env_file import env_file_path
 from octop.infra.utils.paths import PathLayout
@@ -163,6 +167,14 @@ def _read_tar_members(data: bytes) -> dict[str, bytes]:
     return out
 
 
+_MIGRATION_VERSION_SUFFIX = "-migrated-from-lightclaw"
+
+
+def _is_migration_backup(manifest: BackupManifest) -> bool:
+    """Return True when the backup was produced by the LightClaw migration tool."""
+    return manifest.octop_version.endswith(_MIGRATION_VERSION_SUFFIX)
+
+
 def restore_system_backup(
     data: bytes,
     *,
@@ -170,10 +182,28 @@ def restore_system_backup(
     pool: DatabasePool,
     db_config: DatabaseConfig,
     restore_config: bool = True,
+    preserve_users: bool | None = None,
 ) -> dict[str, Any]:
-    """Restore database, workspaces, and optional config from a tar.gz archive."""
+    """Restore database, workspaces, and optional config from a tar.gz archive.
+
+    ``preserve_users`` controls whether the *current* Octop instance's ``users``
+    table is written back after the database is replaced:
+
+    * ``None`` (default) — auto-detect: preserves users when the backup was
+      produced by an external migration tool (``octop_version`` ends with
+      ``"-migrated-from-lightclaw"``).
+    * ``True`` — always preserve the current users (useful for any cross-system
+      import where passwords must remain valid).
+    * ``False`` — restore the users table as-is from the backup (normal
+      same-instance restore).
+    """
     members = _read_tar_members(data)
     manifest = _extract_manifest(members)
+
+    # Resolve effective preserve_users flag before touching the DB.
+    effective_preserve_users = (
+        _is_migration_backup(manifest) if preserve_users is None else preserve_users
+    )
 
     archive_driver = manifest.database_driver or "sqlite"
     if archive_driver != pool.dialect:
@@ -188,6 +218,11 @@ def restore_system_backup(
     db_blob = members.get(manifest.db_file)
     if db_blob is None:
         raise OctopError(ErrorCode.SLASH_BAD_ARGS, "backup archive missing database file")
+
+    # Capture current users before overwriting the DB (only when needed).
+    saved_users: list[tuple[object, ...]] = []
+    if effective_preserve_users and pool is not None:
+        saved_users = capture_users_from_pool(pool)
 
     with tempfile.TemporaryDirectory() as tmp:
         if pool.dialect == "postgresql":
@@ -213,6 +248,17 @@ def restore_system_backup(
                 env_path.parent.mkdir(parents=True, exist_ok=True)
                 env_path.write_bytes(env_blob)
 
+        # Write back saved users after DB is fully restored.
+        if saved_users and pool is not None:
+            restore_users_into_pool(pool, saved_users)
+
+        # After a migration restore the secrets table arrives from a foreign
+        # system and will not contain a valid JWT secret for this instance.
+        # Ensure one exists (create if absent) so the server can start without
+        # a manual `_ensure_jwt_secret` call.
+        if effective_preserve_users and pool is not None:
+            SecretRepo(pool).get_or_create("jwt", lambda: os.urandom(32))
+
         restored_workspaces = 0
         prefix = f"{_WORKSPACES_DIR}/"
         for name, blob in members.items():
@@ -235,5 +281,6 @@ def restore_system_backup(
         "agents": len(manifest.agents),
         "workspace_files": restored_workspaces,
         "restore_config": restore_config,
+        "users_preserved": effective_preserve_users,
         "database_driver": archive_driver,
     }

--- a/tests/unit/backup/test_system_archive.py
+++ b/tests/unit/backup/test_system_archive.py
@@ -204,9 +204,7 @@ def test_migration_restore_preserves_current_users_and_imported_agents(
         )
 
         # The LightClaw source user must not appear in the target users table.
-        lc_row = conn.execute(
-            "SELECT id FROM users WHERE username = ?", ("lc_user",)
-        ).fetchone()
+        lc_row = conn.execute("SELECT id FROM users WHERE username = ?", ("lc_user",)).fetchone()
         assert lc_row is None, "lc_user from backup was not removed after user write-back"
 
     tgt_pool.close()

--- a/tests/unit/backup/test_system_archive.py
+++ b/tests/unit/backup/test_system_archive.py
@@ -95,6 +95,160 @@ def test_roundtrip_backup(layout: PathLayout) -> None:
     assert manifest["database_driver"] == "sqlite"
 
 
+def _make_migration_backup(
+    layout: PathLayout,
+    *,
+    username: str = "lc_user",
+) -> tuple[bytes, SqlitePool]:
+    """Build a fake LightClaw migration backup and return (data, source_pool)."""
+    pool = SqlitePool(layout.db)
+    run_migrations(pool)
+    with pool.connect() as conn:
+        conn.execute(
+            "INSERT INTO users(username, password_hash, role, created_at) VALUES (?, ?, ?, ?)",
+            (username, "lc_hash", "user", 1),
+        )
+        conn.execute(
+            "INSERT INTO agents(agent_id, user_id, name, created_at, updated_at)"
+            " VALUES (?, (SELECT id FROM users WHERE username=?), ?, 1, 1)",
+            ("agent-lc", username, "LC Agent"),
+        )
+
+    class Row:
+        agent_id = "agent-lc"
+        name = "LC Agent"
+
+    data, _ = create_system_backup(
+        paths=layout,
+        agent_rows=[Row()],
+        pool=pool,
+        db_config=DatabaseConfig(),
+    )
+    # Rewrite octop_version to signal a LightClaw migration backup.
+    members: dict[str, bytes] = {}
+    with tarfile.open(fileobj=BytesIO(data), mode="r:gz") as tf:
+        for m in tf.getmembers():
+            if m.isfile():
+                f = tf.extractfile(m)
+                assert f is not None
+                members[m.name] = f.read()
+    manifest_obj = json.loads(members["manifest.json"])
+    manifest_obj["octop_version"] = manifest_obj["octop_version"] + "-migrated-from-lightclaw"
+    members["manifest.json"] = json.dumps(manifest_obj).encode()
+    buf = BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tf:
+        for name, blob in members.items():
+            info = tarfile.TarInfo(name=name)
+            info.size = len(blob)
+            tf.addfile(info, BytesIO(blob))
+    return buf.getvalue(), pool
+
+
+def test_migration_restore_preserves_current_users_and_imported_agents(
+    tmp_path: Path,
+) -> None:
+    """Restoring a LightClaw backup writes back current users without CASCADE-deleting agents.
+
+    Regression guard: with ``PRAGMA foreign_keys = ON`` a bare
+    ``DELETE FROM users`` cascades to agents, sessions, threads, … and wipes
+    the data that was just restored from the backup.  The upsert+prune strategy
+    must not trigger that cascade.
+
+    After restore the expected state is:
+    - agents from the backup (``agent-lc``) are present.
+    - users table contains only the *current instance* users (``octop_admin``).
+    - the LightClaw user (``lc_user``) is gone — replaced by the current users.
+    """
+    # --- source: simulate a LightClaw migration export with one agent ---
+    src_layout = PathLayout(tmp_path / "src")
+    src_layout.root.mkdir()
+    migration_data, src_pool = _make_migration_backup(src_layout, username="lc_user")
+    src_pool.close()
+
+    # --- target: a fresh Octop instance with its own admin user ---
+    tgt_layout = PathLayout(tmp_path / "tgt")
+    tgt_layout.root.mkdir()
+    tgt_pool = SqlitePool(tgt_layout.db)
+    run_migrations(tgt_pool)
+    with tgt_pool.connect() as conn:
+        conn.execute(
+            "INSERT INTO users(username, password_hash, role, created_at) VALUES (?, ?, ?, ?)",
+            ("octop_admin", "admin_hash", "admin", 2),
+        )
+
+    result = restore_system_backup(
+        migration_data,
+        paths=tgt_layout,
+        pool=tgt_pool,
+        db_config=DatabaseConfig(),
+        restore_config=False,
+    )
+
+    assert result["users_preserved"] is True
+
+    with tgt_pool.connect() as conn:
+        # The target instance's admin must survive with original password hash.
+        row = conn.execute(
+            "SELECT password_hash FROM users WHERE username = ?", ("octop_admin",)
+        ).fetchone()
+        assert row is not None, "octop_admin was deleted — users not preserved"
+        assert row[0] == "admin_hash"
+
+        # The imported agent from the backup must still exist after users write-back.
+        # With the old DELETE-then-INSERT, foreign_keys=ON would cascade-delete this row.
+        agent_row = conn.execute(
+            "SELECT agent_id FROM agents WHERE agent_id = ?", ("agent-lc",)
+        ).fetchone()
+        assert agent_row is not None, (
+            "agent-lc was deleted — upsert strategy triggered CASCADE on agents"
+        )
+
+        # The LightClaw source user must not appear in the target users table.
+        lc_row = conn.execute(
+            "SELECT id FROM users WHERE username = ?", ("lc_user",)
+        ).fetchone()
+        assert lc_row is None, "lc_user from backup was not removed after user write-back"
+
+    tgt_pool.close()
+
+
+def test_migration_restore_via_none_autodetect(tmp_path: Path) -> None:
+    """preserve_users=None auto-detects the migration flag from octop_version."""
+    src_layout = PathLayout(tmp_path / "src")
+    src_layout.root.mkdir()
+    migration_data, src_pool = _make_migration_backup(src_layout, username="lc_auto")
+    src_pool.close()
+
+    tgt_layout = PathLayout(tmp_path / "tgt")
+    tgt_layout.root.mkdir()
+    tgt_pool = SqlitePool(tgt_layout.db)
+    run_migrations(tgt_pool)
+    with tgt_pool.connect() as conn:
+        conn.execute(
+            "INSERT INTO users(username, password_hash, role, created_at) VALUES (?, ?, ?, ?)",
+            ("local_admin", "lhash", "admin", 3),
+        )
+
+    # preserve_users=None — should auto-detect and preserve
+    result = restore_system_backup(
+        migration_data,
+        paths=tgt_layout,
+        pool=tgt_pool,
+        db_config=DatabaseConfig(),
+        restore_config=False,
+        preserve_users=None,
+    )
+    assert result["users_preserved"] is True
+
+    with tgt_pool.connect() as conn:
+        row = conn.execute(
+            "SELECT username FROM users WHERE username = ?", ("local_admin",)
+        ).fetchone()
+        assert row is not None, "local_admin was lost after auto-detect migration restore"
+
+    tgt_pool.close()
+
+
 def test_refuse_cross_engine_restore(layout: PathLayout) -> None:
     pool = SqlitePool(layout.db)
     run_migrations(pool)


### PR DESCRIPTION
## Summary

Enhanced the backup and restore workflow to properly handle backup packages migrated from LightClaw.

When the `octop_version` in the backup manifest ends with `-migrated-from-lightclaw`, the restore logic automatically identifies it as a cross-system migration scenario and performs the following additional steps:

- **Preserve current users table**: Captures the current instance's `users` table data before restoration, then writes it back after the database is overwritten. This ensures existing user accounts and password hashes are not overwritten by data from the external system.
- **Rebuild JWT Secret**: The `secrets` table included in the migration backup belongs to the external system and does not contain a valid JWT secret for the current instance. After restoration, `SecretRepo.get_or_create("jwt", ...)` is automatically called to generate a new secret, preventing the server from failing to start.

**New functions:**

| Module | Function | Description |
|--------|----------|-------------|
| `infra/backup/snapshot.py` | `capture_users_from_pool` | Reads all user rows from a running DB pool |
| `infra/backup/snapshot.py` | `restore_users_into_pool` | Deletes and re-inserts user rows (idempotent) |
| `infra/backup/system_archive.py` | `_is_migration_backup` | Determines whether the backup is a LightClaw migration package based on the version suffix |

**New parameter for `restore_system_backup`:**

| Parameter | Type | Description |
|-----------|------|-------------|
| `preserve_users` | `bool \| None` | `None` (default) = auto-detect; `True` = force preserve; `False` = restore as-is from backup |

## Type of change

- [x] New feature

## Test plan

```bash
uv run pytest tests/unit/api/test_backup_restore_rehydrate.py -x -q
make all
```

- [ ] `make all` passes locally
- [ ] Added/updated tests

## Checklist

- [ ] Updated `CHANGELOG.md` (if user-facing)
- [ ] README / docs updated (if needed)