### PR TITLE
fix(skills): avoid user-derived CLI install paths

### DIFF
--- a/src/octop/api/routers/skills.py
+++ b/src/octop/api/routers/skills.py
@@ -49,7 +49,7 @@ from octop.infra.agents.manager import skills_disabled_set as _disabled_set
 from octop.infra.agents.skill_packages import (
     SkillPackageError,
     SkillPackageTooLarge,
-    read_skill_directory,
+    read_cli_skill_install,
     resolve_skill_package,
     resolve_workspace_uploads,
     validate_skill_slug,
@@ -799,10 +799,7 @@ async def _download_skillhub_package_via_cli(
                 detail=_skillhub_cli_failure_detail("install", err_msg, locale="en"),
             )
 
-        skill_dir = Path(tmpdir) / skill_name
-        if not skill_dir.is_dir():
-            skill_dir = Path(tmpdir)
-        return read_skill_directory(skill_dir)
+        return read_cli_skill_install(Path(tmpdir))
 
 
 def _parse_skillhub_search_output(text: str) -> list[dict[str, Any]]:

--- a/src/octop/infra/agents/skill_packages.py
+++ b/src/octop/infra/agents/skill_packages.py
@@ -156,6 +156,39 @@ def read_skill_directory(skill_dir: Path) -> list[tuple[str, bytes]]:
     return list(normalize_skill_files(files))
 
 
+def read_cli_skill_install(install_root: Path) -> list[tuple[str, bytes]]:
+    """Read one CLI-installed skill without deriving a path from its requested slug."""
+    root_manifest = install_root / "SKILL.md"
+    try:
+        root_manifest_mode = root_manifest.lstat().st_mode
+    except FileNotFoundError:
+        root_manifest_mode = 0
+    if stat.S_ISREG(root_manifest_mode):
+        return read_skill_directory(install_root)
+
+    candidates: list[Path] = []
+    for entry in install_root.iterdir():
+        try:
+            entry_mode = entry.lstat().st_mode
+        except FileNotFoundError:
+            continue
+        if not stat.S_ISDIR(entry_mode):
+            continue
+        manifest = entry / "SKILL.md"
+        try:
+            manifest_mode = manifest.lstat().st_mode
+        except FileNotFoundError:
+            continue
+        if stat.S_ISREG(manifest_mode):
+            candidates.append(entry)
+
+    if not candidates:
+        raise SkillPackageError("CLI install did not produce a skill package")
+    if len(candidates) > 1:
+        raise SkillPackageError("CLI install produced multiple skill packages")
+    return read_skill_directory(candidates[0])
+
+
 __all__ = [
     "MAX_SKILL_BYTES",
     "MAX_SKILL_FILES",
@@ -163,6 +196,7 @@ __all__ = [
     "SkillPackageError",
     "SkillPackageTooLarge",
     "normalize_skill_files",
+    "read_cli_skill_install",
     "read_skill_directory",
     "resolve_skill_package",
     "resolve_workspace_uploads",

--- a/tests/integration/test_skills_hub.py
+++ b/tests/integration/test_skills_hub.py
@@ -251,7 +251,8 @@ async def test_hub_install_falls_back_to_cli_on_http_failure(
         timeout: float,
     ) -> tuple[int, str, str]:
         assert timeout == 120
-        install_dir = Path(args[1]) / args[-1]
+        assert args[-1] == "fallback-skill"
+        install_dir = Path(args[1]) / "cli-output"
         install_dir.mkdir(parents=True)
         (install_dir / "SKILL.md").write_text(
             "---\nname: fallback-skill\n---\n\n# Body\n",

--- a/tests/unit/agents/test_skill_packages.py
+++ b/tests/unit/agents/test_skill_packages.py
@@ -110,3 +110,38 @@ def test_read_skill_directory_rejects_symlink(tmp_path: Path) -> None:
 
     with pytest.raises(skill_packages.SkillPackageError, match="file type"):
         skill_packages.read_skill_directory(tmp_path)
+
+
+def test_read_cli_skill_install_accepts_files_at_install_root(tmp_path: Path) -> None:
+    (tmp_path / "SKILL.md").write_text("# root skill", encoding="utf-8")
+
+    assert skill_packages.read_cli_skill_install(tmp_path) == [("SKILL.md", b"# root skill")]
+
+
+def test_read_cli_skill_install_discovers_single_wrapper_directory(tmp_path: Path) -> None:
+    wrapper = tmp_path / "cli-generated-directory"
+    wrapper.mkdir()
+    (wrapper / "SKILL.md").write_text("# wrapped skill", encoding="utf-8")
+
+    assert skill_packages.read_cli_skill_install(tmp_path) == [("SKILL.md", b"# wrapped skill")]
+
+
+def test_read_cli_skill_install_rejects_ambiguous_packages(tmp_path: Path) -> None:
+    for name in ("one", "two"):
+        wrapper = tmp_path / name
+        wrapper.mkdir()
+        (wrapper / "SKILL.md").write_text(f"# {name}", encoding="utf-8")
+
+    with pytest.raises(skill_packages.SkillPackageError, match="multiple"):
+        skill_packages.read_cli_skill_install(tmp_path)
+
+
+@pytest.mark.skipif(os.name != "posix", reason="symlink semantics are POSIX-specific")
+def test_read_cli_skill_install_does_not_follow_wrapper_symlink(tmp_path: Path) -> None:
+    outside = tmp_path.parent / "outside-skill"
+    outside.mkdir()
+    (outside / "SKILL.md").write_text("# outside", encoding="utf-8")
+    (tmp_path / "wrapper").symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(skill_packages.SkillPackageError, match="did not produce"):
+        skill_packages.read_cli_skill_install(tmp_path)


### PR DESCRIPTION
## What changed

- Stop deriving the SkillHub CLI output directory from the user-provided skill slug.
- Discover a package only from the trusted temporary install root.
- Accept either a root `SKILL.md` or exactly one real wrapper directory containing `SKILL.md`.
- Reject missing, ambiguous, and symlink-backed package layouts.
- Keep the existing package path, file type, file count, size, and UTF-8 validation.

## Why

The CLI compatibility fallback previously joined `skill_name` from the request body into a local filesystem path. Runtime slug validation rejected common traversal forms, but the path sink still depended on user input and was reported by CodeQL. The directory name is also unnecessary: the CLI install runs in a fresh temporary directory, so the package can be discovered from that trusted root without using the requested slug.

## Impact

- Normal HTTP SkillHub installs are unchanged.
- CLI fallback remains compatible with packages written directly to the install root or inside one wrapper directory.
- Unexpected CLI output fails closed instead of selecting a user-derived path.

## Validation

- `17 passed` — source-neutral package tests plus SkillHub CLI fallback integration tests
- Ruff check passed
- Ruff format check passed
- `mypy src/octop` — no issues in 337 source files
- Full non-live suite was sampled to 14% without failures, then stopped because of runtime; it is not claimed as complete
