### PR TITLE
ci: auto-tag when release PRs merge into main

### DIFF
--- a/.cursor/skills/publish/SKILL.md
+++ b/.cursor/skills/publish/SKILL.md
@@ -218,7 +218,7 @@ git push -u {REMOTE} {RELEASE_BRANCH_PREFIX}{version}
 
 推送失败则中止。
 
-### 步骤 5 — 创建合入 main 的 Pull Request（先合，后 tag）
+### 步骤 5 — 创建合入 main 的 Pull Request（先合，后自动 tag）
 
 使用 `gh` CLI：
 
@@ -233,44 +233,32 @@ gh pr create \
 ## Release checklist
 - [ ] CI green
 - [ ] Merge this PR into main
-- [ ] Then tag v{version} on main tip (publish skill step 6)
+- [ ] After merge, GitHub Action auto-pushes v{version} tag on main tip
 EOF
 )"
 ```
 
-- 成功时展示 PR URL，并明确告知：**在 PR 合并前不要打 tag。**
+- 成功时展示 PR URL，并明确告知：
+  - 合并前不要手动打 tag；
+  - 合并后会自动发版（自动打 tag）。
 - 若 `gh` 失败：中止（此时尚未发版），提示手动创建 PR：
   `{RELEASE_BRANCH_PREFIX}{version}` → `{TARGET_BRANCH}`
 
-### 步骤 6 — 等待合入后，在 main tip 打 tag
+### 步骤 6 — 等待合入后，由 Action 在 main tip 打 tag
 
 1. 询问用户 PR 是否已合并，或轮询：
    ```bash
    gh pr view {pr_url} --json state,mergedAt
    ```
-   未合并则**不要**打 tag；可暂停并提示用户合并后再说「继续」。
+   未合并则等待；无需本地执行打 tag。
 
 2. 合并后：
-   ```bash
-   git fetch {REMOTE} {TARGET_BRANCH}
-   git checkout {TARGET_BRANCH}
-   git pull {REMOTE} {TARGET_BRANCH}
-   ```
-   确认 `pyproject.toml` 版本已是目标版本（合入结果在 main 上）。
+   - `auto-tag-on-release.yml` 会读取合并后 `main` 的 `pyproject.toml` 版本并推送 `{TAG_PREFIX}{version}`。
+   - 若 tag 已存在，Action 会跳过并输出日志。
 
-3. 打 tag 并推送（触发 GitHub Action）：
-
-   - `release.yml`：`build` → PyPI `publish` → `github-release`
-   - `docker-publish.yml`：推送 Docker Hub
-
-   ```bash
-   git tag {TAG_PREFIX}{version}
-   git push {REMOTE} {TAG_PREFIX}{version}
-   ```
-
-   若 tag 已存在：中止并给出删除指令（仅在确认该 tag 未用于错误发布时）。
-
-4. 提示用户到 Actions 确认 `Release` 与 `Docker Publish` 通过。
+3. 提示用户到 Actions 确认：
+   - `Auto Tag On Release Merge` 成功；
+   - `Release` 与 `Docker Publish` 随 `v*` tag 触发并通过。
 
 ### 步骤 7 — 删除 release 分支并同步 develop
 
@@ -311,7 +299,7 @@ git checkout {original_branch}
 | Release 分支已存在 | 中止并给出删除指令 |
 | 步骤 4 推送失败 | 中止：文件已在本地更新但未推送 |
 | 步骤 5 PR 创建失败 | 中止（尚未打 tag / 未发版） |
-| 步骤 6 在未合入时打 tag | **禁止** — 硬红线 |
+| 步骤 6 在未合入时手动打 tag | **禁止** — 硬红线 |
 | 步骤 6 tag 已存在 | 中止并给出删除指令 |
 | 步骤 6 tag 推送成功但 Action 失败 | 非致命：提示到 Actions Re-run |
 | 步骤 7 删分支或 sync PR 失败 | 警告并给出手动命令 |
@@ -330,7 +318,7 @@ git checkout {original_branch}
 
 **始终：**
 - 从最新 `{REMOTE}/{INTEGRATION_BRANCH}` 切 release
-- 先合入 `{TARGET_BRANCH}`，再在 main tip 打 tag
+- 先合入 `{TARGET_BRANCH}`，再由 Action 在 main tip 打 tag
 - 发版后删除 `release/*`，并在需要时同步回 `develop`
 - 中止前展示完整错误输出
 - 插入新版本条目后保持 `[Unreleased]` 为空

--- a/.github/workflows/auto-tag-on-release.yml
+++ b/.github/workflows/auto-tag-on-release.yml
@@ -1,0 +1,63 @@
+name: Auto Tag On Release Merge
+
+on:
+  pull_request_target:
+    types:
+      - closed
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    name: Tag merged release PR
+    if: >-
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.base.ref == 'main' &&
+      (startsWith(github.event.pull_request.head.ref, 'release/') ||
+      startsWith(github.event.pull_request.head.ref, 'hotfix/')) &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout merged main tip
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Extract version from pyproject.toml
+        id: version
+        run: |
+          version=$(python - <<'PY'
+          import tomllib
+          with open("pyproject.toml", "rb") as f:
+              data = tomllib.load(f)
+          print(data["project"]["version"])
+          PY
+          )
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "tag=v$version" >> "$GITHUB_OUTPUT"
+
+      - name: Validate tag does not already exist
+        id: check_tag
+        run: |
+          tag="${{ steps.version.outputs.tag }}"
+          if git rev-parse "$tag" >/dev/null 2>&1; then
+            echo "Tag $tag already exists locally, skip."
+            echo "should_publish=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if git ls-remote --tags origin "$tag" | grep -q "$tag"; then
+            echo "Tag $tag already exists on origin, skip."
+            echo "should_publish=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "should_publish=true" >> "$GITHUB_OUTPUT"
+          echo "Tag $tag is available."
+
+      - name: Create and push tag
+        if: steps.check_tag.outputs.should_publish == 'true'
+        run: |
+          tag="${{ steps.version.outputs.tag }}"
+          git tag "$tag"
+          git push origin "$tag"


### PR DESCRIPTION
Remove the manual post-merge tagging step from /publish by letting GitHub Actions push v* on main after release/* or hotfix/* merges.

## Summary

<!-- What does this PR change and why? -->

## Target branch

- [ ] Base is **`develop`** (feature / fix — default)
- [ ] Base is **`main`** (`release/*` or `hotfix/*` only)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / chore
- [ ] Release / hotfix

## Test plan

<!-- How did you verify this? Include commands run (e.g. `make all`). -->

- [ ] `make all` passes locally
- [ ] Added/updated tests

## Checklist

- [ ] Updated `CHANGELOG.md` (if user-facing)
- [ ] README / docs updated (if needed)
