### PR TITLE
fix(dashboard): restore Memory page scroll on mobile

### DIFF
--- a/dashboard/src/pages/Agent/Memory/index.tsx
+++ b/dashboard/src/pages/Agent/Memory/index.tsx
@@ -25,6 +25,7 @@ import MemorySettings from "./MemorySettings";
 
 import PageShell from "../../../layouts/PageShell";
 import { useAgent } from "../../../context/AgentContext";
+import { useIsMobile } from "../../../hooks/useIsMobile";
 import memoryDashboardApi from "../../../api/modules/memoryDashboard";
 import styles from "./index.module.less";
 
@@ -75,6 +76,7 @@ const TABS: TabDef[] = [
 export default function MemoryPage() {
   const { t } = useTranslation();
   const { activeAgentId } = useAgent();
+  const isMobile = useIsMobile();
 
   const [activeTab, setActiveTab] = useState<MemoryTab>("overview");
   const [libraryView, setLibraryView] = useState<LibraryView>("tree");
@@ -249,7 +251,8 @@ export default function MemoryPage() {
       title={t("pageShell.memory.title")}
       subtitle={t("pageShell.memory.subtitle")}
       agentScoped
-      fill
+      // Mobile CSS lets tab panes grow (overflow:visible); PageShell must scroll.
+      fill={!isMobile}
     >
       <Tabs
         className={styles.memoryTabs}


### PR DESCRIPTION
PageShell fill hid overflow while mobile tab panes used overflow:visible, so long Memory content was clipped with no way to scroll.

## Summary

<!-- What does this PR change and why? -->

## Target branch

- [ ] Base is **`develop`** (feature / fix — default)
- [ ] Base is **`main`** (`release/*` or `hotfix/*` only)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / chore
- [ ] Release / hotfix

## Test plan

<!-- How did you verify this? Include commands run (e.g. `make all`). -->

- [ ] `make all` passes locally
- [ ] Added/updated tests

## Checklist

- [ ] Updated `CHANGELOG.md` (if user-facing)
- [ ] README / docs updated (if needed)
