### PR TITLE
fix(browser): stop chmod on profiles; use shared ~/.octop/browser-profiles

### DIFF
--- a/src/octop/api/routers/browser/harness.py
+++ b/src/octop/api/routers/browser/harness.py
@@ -127,6 +127,7 @@ async def resolve_harness_session(
         resolve_browser_display,
     )
 
+    # Shared ~/.octop/browser-profiles (not per-agent workspace).
     await prepare_harness_profile_for_launch(profile)
     # Virtual desktop (Xvnc :99) → headed Chrome so the window shows on
     # remote desktop; otherwise force headless (do not use mode=auto — a

--- a/src/octop/api/routers/channels.py
+++ b/src/octop/api/routers/channels.py
@@ -327,12 +327,16 @@ def _sanitize_ip_address(value: str) -> str:
 
 def _resolve_profiles_root() -> _FsPath:
     """Resolve browser profile root; ignore unsafe env overrides."""
-    default = _FsPath.home() / ".harness-browser" / "profiles"
-    raw = os.environ.get("HARNESS_BROWSER_PROFILES_DIR")
+    from octop.infra.utils.browser_media import octop_browser_profiles_dir  # noqa: PLC0415
+
+    default = _FsPath(octop_browser_profiles_dir())
+    raw = os.environ.get("BROWSER_USE_PROFILES_DIR") or os.environ.get(
+        "HARNESS_BROWSER_PROFILES_DIR"
+    )
     if not raw:
         return default
     if len(raw) > _MAX_ARG_LEN or not _SAFE_ARG_RE.match(raw):
-        logger.warning("Ignoring unsafe HARNESS_BROWSER_PROFILES_DIR=%r", raw)
+        logger.warning("Ignoring unsafe browser profiles dir override=%r", raw)
         return default
     return _FsPath(raw).expanduser()
 

--- a/src/octop/infra/agents/manager.py
+++ b/src/octop/infra/agents/manager.py
@@ -1383,12 +1383,16 @@ class AgentManager:
     ) -> tuple[HarnessAgentConfig, dict[str, Any], list[str], str]:
         from octop.infra.utils.browser_media import (  # noqa: PLC0415
             agent_outbound_screenshots_dir,
+            configure_browser_profiles_dir,
             configure_browser_screenshots_dir,
+            octop_browser_profiles_dir,
         )
 
         configure_browser_screenshots_dir(
             agent_outbound_screenshots_dir(self._paths, row.agent_id),
         )
+        # Shared across agents — not under a single agent workspace.
+        configure_browser_profiles_dir(octop_browser_profiles_dir(self._paths))
         user_display = "User"
         if row.user_id is not None:
             owner = self._repos.user_repo.get(row.user_id)

--- a/src/octop/infra/browser/setup.py
+++ b/src/octop/infra/browser/setup.py
@@ -23,6 +23,18 @@ def _sse(event: dict[str, object]) -> str:
     return f"data: {json.dumps(event)}\n\n"
 
 
+def _runtime_dir_for_uid(uid: int | None = None) -> Path:
+    if uid is None:
+        uid = os.getuid() if hasattr(os, "getuid") else 0
+    return Path(f"/tmp/runtime-harness-browser-{uid}")
+
+
+def _relocated_profiles_root_for_uid(uid: int | None = None) -> Path:
+    if uid is None:
+        uid = os.getuid() if hasattr(os, "getuid") else 0
+    return Path(f"/tmp/harness-browser-profiles-{uid}")
+
+
 def ensure_chrome_runtime_env() -> Path:
     """Force a writable ``XDG_RUNTIME_DIR`` for Chrome on Linux.
 
@@ -30,9 +42,11 @@ def ensure_chrome_runtime_env() -> Path:
     unwritable on headless / root / container hosts (``mkdir: cannot create
     directory '/run/user/0': Permission denied``). Always point at a private
     ``/tmp`` directory owned by the current process.
+
+    Chrome expects ``XDG_RUNTIME_DIR`` mode ``0700``; set that only on the
+    directory we just created — never on profile trees or system paths.
     """
-    uid = os.getuid() if hasattr(os, "getuid") else 0
-    path = Path(f"/tmp/runtime-harness-browser-{uid}")
+    path = _runtime_dir_for_uid()
     path.mkdir(parents=True, exist_ok=True)
     with contextlib.suppress(OSError):
         os.chmod(path, 0o700)
@@ -104,9 +118,6 @@ def clear_profile_locks(profile_dir: Path) -> list[str]:
         lock_path = profile_dir / lock_name
         try:
             if lock_path.exists() or lock_path.is_symlink():
-                with contextlib.suppress(OSError):
-                    if not lock_path.is_symlink():
-                        lock_path.chmod(0o644)
                 lock_path.unlink()
                 cleared.append(lock_name)
         except FileNotFoundError:
@@ -133,43 +144,35 @@ def _probe_dir_writable(directory: Path) -> bool:
 
 
 def _under_root_home(path: Path) -> bool:
+    """True for paths under ``/root`` that are unsafe for Chrome (YunJing).
+
+    Octop home (``OCTOP_HOME`` / ``~/.octop``) is exempt so shared profiles
+    at ``~/.octop/browser-profiles`` stay put even when running as root.
+    """
+    if not sys.platform.startswith("linux"):
+        return False
     try:
-        path = path.resolve()
+        resolved = path.resolve()
         root_home = Path("/root").resolve()
-        return path == root_home or root_home in path.parents
+        if resolved != root_home and root_home not in resolved.parents:
+            return False
+        from octop.infra.utils.paths import PathLayout  # noqa: PLC0415
+
+        octop_root = PathLayout.from_env().root.resolve()
+        return not (resolved == octop_root or octop_root in resolved.parents)
     except OSError:
         return False
 
 
-def _try_fix_ownership(path: Path) -> None:
-    """Best-effort chmod/chown so the current uid can write *path*."""
-    from octop.infra.utils.posix_compat import chown, getuid  # noqa: PLC0415
-
-    uid = getuid()
-    # getuid returns -1 on non-POSIX; skip chown there.
-    if uid >= 0:
-        with contextlib.suppress(OSError):
-            chown(path, uid)
-    with contextlib.suppress(OSError):
-        path.chmod(0o700)
-
-
 def _relocate_profiles_root(profile_dir: Path) -> Path:
     """Move profiles off an unsafe root (e.g. ``/root/.harness-browser``)."""
-    uid = os.getuid() if hasattr(os, "getuid") else 0
-    alt_root = Path(f"/tmp/harness-browser-profiles-{uid}")
-    alt_root.mkdir(parents=True, exist_ok=True)
-    with contextlib.suppress(OSError):
-        os.chmod(alt_root, 0o700)
-    os.environ["BROWSER_USE_PROFILES_DIR"] = str(alt_root)
-    with contextlib.suppress(Exception):
-        from harness_browser.settings import settings as hb_settings  # noqa: PLC0415
+    from octop.infra.utils.browser_media import (  # noqa: PLC0415
+        configure_browser_profiles_dir,
+    )
 
-        hb_settings.profiles_dir = alt_root
+    alt_root = configure_browser_profiles_dir(_relocated_profiles_root_for_uid())
     alt = alt_root / profile_dir.name
     alt.mkdir(parents=True, exist_ok=True)
-    with contextlib.suppress(OSError):
-        alt.chmod(0o700)
     logger.warning(
         "Falling back to writable profiles dir %s (set BROWSER_USE_PROFILES_DIR)",
         alt_root,
@@ -180,15 +183,15 @@ def _relocate_profiles_root(profile_dir: Path) -> Path:
 def ensure_profile_writable(profile_dir: Path) -> Path:
     """Ensure *profile_dir* is writable by the current process and by Chrome.
 
-    Profiles under ``/root/...`` are relocated to ``/tmp`` proactively: host
-    security agents (e.g. YunJing) often allow Python writes but deny the
-    Chrome binary, which surfaces as ``SingletonLock: Permission denied``.
+    Does not chmod/chown existing trees (that previously broke ``/`` and
+    ``/tmp``). Strategy: probe → recreate empty → relocate under
+    ``/tmp/harness-browser-profiles-<uid>``.
+
+    Profiles under ``/root/...`` are relocated proactively: host security
+    agents (e.g. YunJing) often allow Python writes but deny the Chrome
+    binary, which surfaces as ``SingletonLock: Permission denied``.
     """
     profile_dir = Path(profile_dir)
-    parents = [profile_dir, *list(profile_dir.parents)[:3]]
-    for parent in reversed(parents):
-        if parent.exists():
-            _try_fix_ownership(parent)
 
     # Chrome on hardened CVM images cannot write under /root even as uid 0.
     if sys.platform.startswith("linux") and _under_root_home(profile_dir):
@@ -215,7 +218,6 @@ def ensure_profile_writable(profile_dir: Path) -> Path:
             with contextlib.suppress(OSError):
                 shutil.rmtree(profile_dir)
     profile_dir.mkdir(parents=True, exist_ok=True)
-    _try_fix_ownership(profile_dir)
     if not _probe_dir_writable(profile_dir):
         return _relocate_profiles_root(profile_dir)
     return profile_dir
@@ -225,7 +227,6 @@ def recover_stale_profile(profile_dir: Path) -> None:
     """Last-resort: move/wipe an unusable profile so Chrome can start fresh."""
     if not profile_dir.exists():
         profile_dir.mkdir(parents=True, exist_ok=True)
-        _try_fix_ownership(profile_dir)
         return
     stamp = int(time.time())
     stale = profile_dir.with_name(f"{profile_dir.name}.stale-{stamp}")
@@ -238,7 +239,6 @@ def recover_stale_profile(profile_dir: Path) -> None:
         with contextlib.suppress(OSError):
             shutil.rmtree(profile_dir)
     profile_dir.mkdir(parents=True, exist_ok=True)
-    _try_fix_ownership(profile_dir)
     ensure_profile_writable(profile_dir)
 
 
@@ -246,17 +246,25 @@ async def prepare_harness_profile_for_launch(
     profile_name: str,
     *,
     force_recover: bool = False,
+    profiles_root: Path | None = None,
 ) -> Path:
     """Make a harness-browser profile safe to (re)launch Chrome against.
 
     - Forces a writable ``XDG_RUNTIME_DIR``
     - Injects virtual-desktop ``DISPLAY`` when Xvnc is up
+    - Prefers shared ``~/.octop/browser-profiles`` (cross-agent)
     - If CDP is already listening, leaves the running browser alone
     - Otherwise kills leftover Chrome for this profile and clears Singleton locks
-    - Ensures the profile directory is writable (chmod / recreate if needed)
+    - Ensures the profile directory is writable (recreate / relocate if needed)
     """
     ensure_chrome_runtime_env()
     resolve_browser_display()
+
+    from octop.infra.utils.browser_media import (  # noqa: PLC0415
+        configure_browser_profiles_dir,
+    )
+
+    await asyncio.to_thread(configure_browser_profiles_dir, profiles_root)
 
     data_dir = await asyncio.to_thread(_profile_data_dir, profile_name)
     data_dir = await asyncio.to_thread(ensure_profile_writable, data_dir)
@@ -321,7 +329,9 @@ def _profiles_root() -> Path:
 
         return Path(_settings.profiles_dir)
     except Exception:  # noqa: BLE001
-        return Path.home() / ".harness-browser" / "profiles"
+        from octop.infra.utils.browser_media import octop_browser_profiles_dir  # noqa: PLC0415
+
+        return octop_browser_profiles_dir()
 
 
 def _playwright_cache_roots() -> list[Path]:

--- a/src/octop/infra/gateway/bot_creators/feishu_runner.py
+++ b/src/octop/infra/gateway/bot_creators/feishu_runner.py
@@ -29,13 +29,15 @@ def bot_creator_script(name: str) -> Path:
 
 
 def resolve_profiles_root() -> Path:
-    default = Path.home() / ".harness-browser" / "profiles"
-    raw = os.environ.get("HARNESS_BROWSER_PROFILES_DIR")
+    """Shared Octop profiles root; honor env overrides when present."""
+    raw = (os.environ.get("BROWSER_USE_PROFILES_DIR") or "").strip()
     if not raw:
-        return default
-    if len(raw) > 2048:
-        return default
-    return Path(raw).expanduser()
+        raw = (os.environ.get("HARNESS_BROWSER_PROFILES_DIR") or "").strip()
+    if raw and len(raw) <= 2048:
+        return Path(raw).expanduser()
+    from octop.infra.utils.browser_media import octop_browser_profiles_dir  # noqa: PLC0415
+
+    return octop_browser_profiles_dir()
 
 
 def feishu_profile_dir(platform: str) -> Path:

--- a/src/octop/infra/utils/browser_media.py
+++ b/src/octop/infra/utils/browser_media.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import os
+import shutil
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -13,6 +15,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 OUTBOUND_SCREENSHOTS_REL = "outbound/screenshots"
+BROWSER_PROFILES_REL = "browser-profiles"
 
 
 def agent_outbound_screenshots_dir(paths: PathLayout, agent_id: str) -> Path:
@@ -23,12 +26,84 @@ def agent_outbound_screenshots_dir(paths: PathLayout, agent_id: str) -> Path:
     return dest
 
 
+def legacy_harness_profiles_dir() -> Path:
+    """Pre-Octop default: ``~/.harness-browser/profiles``."""
+    return Path.home() / ".harness-browser" / "profiles"
+
+
+def _profile_dir_is_empty(directory: Path) -> bool:
+    if not directory.is_dir():
+        return True
+    for child in directory.iterdir():
+        if child.name.startswith("."):
+            continue
+        return False
+    return True
+
+
+def _maybe_migrate_legacy_profiles(dest: Path) -> None:
+    """One-shot move from ``~/.harness-browser/profiles`` when *dest* is empty."""
+    legacy = legacy_harness_profiles_dir()
+    if not _profile_dir_is_empty(dest):
+        return
+    if not legacy.is_dir() or _profile_dir_is_empty(legacy):
+        return
+    logger.info("Migrating browser profiles %s → %s", legacy, dest)
+    try:
+        for child in legacy.iterdir():
+            target = dest / child.name
+            if target.exists():
+                continue
+            shutil.move(str(child), str(target))
+    except OSError as exc:
+        logger.warning("Legacy browser profile migration skipped: %s", exc)
+
+
+def octop_browser_profiles_dir(paths: PathLayout | None = None) -> Path:
+    """Shared Chrome profiles root: ``~/.octop/browser-profiles``.
+
+    Profiles are shared across agents (one headed ``default`` profile for
+    dashboard + ``browser_use``). Prefer this Octop-owned directory over
+    ``~/.harness-browser/profiles`` or system ``/tmp``.
+
+    When the Octop dir is empty and a legacy harness-browser profiles tree
+    exists, contents are moved once so login cookies survive the cutover.
+    """
+    if paths is None:
+        from octop.infra.utils.paths import PathLayout  # noqa: PLC0415
+
+        paths = PathLayout.from_env()
+    dest = paths.root / BROWSER_PROFILES_REL
+    dest.mkdir(parents=True, exist_ok=True)
+    _maybe_migrate_legacy_profiles(dest)
+    return dest
+
+
 def configure_browser_screenshots_dir(screenshots_dir: Path) -> None:
     """Point harness-browser screenshot actions at an agent workspace directory."""
     resolved = screenshots_dir.resolve()
     resolved.mkdir(parents=True, exist_ok=True)
     os.environ["BROWSER_USE_SCREENSHOTS_DIR"] = str(resolved)
     logger.debug("BROWSER_USE_SCREENSHOTS_DIR=%s", resolved)
+
+
+def configure_browser_profiles_dir(profiles_dir: Path | None = None) -> Path:
+    """Point harness-browser at a profiles directory; return the resolved root.
+
+    When *profiles_dir* is omitted, uses :func:`octop_browser_profiles_dir`
+    (including legacy migration). Also updates ``BROWSER_USE_PROFILES_DIR``
+    and in-process harness-browser settings.
+    """
+    root = Path(profiles_dir) if profiles_dir is not None else octop_browser_profiles_dir()
+    root.mkdir(parents=True, exist_ok=True)
+    resolved = root.resolve()
+    os.environ["BROWSER_USE_PROFILES_DIR"] = str(resolved)
+    with contextlib.suppress(Exception):
+        from harness_browser.settings import settings as hb_settings  # noqa: PLC0415
+
+        hb_settings.profiles_dir = resolved
+    logger.debug("BROWSER_USE_PROFILES_DIR=%s", resolved)
+    return resolved
 
 
 def harness_settings_for_screenshots_dir(screenshots_dir: Path) -> Any | None:

--- a/tests/unit/browser/test_browser_setup.py
+++ b/tests/unit/browser/test_browser_setup.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import os
 from pathlib import Path
+from stat import S_IMODE
 
 import pytest
 
@@ -116,6 +117,7 @@ def test_ensure_chrome_runtime_env_forces_tmp_dir(
     assert os.environ["XDG_RUNTIME_DIR"] == str(path)
     assert path.is_dir()
     assert os.access(path, os.W_OK | os.X_OK)
+    assert S_IMODE(path.stat().st_mode) == 0o700
 
 
 @posix_only
@@ -181,22 +183,14 @@ def test_ensure_profile_writable_recreates_when_not_writable(
     profile.mkdir()
     (profile / "Preferences").write_text("{}")
 
-    # Simulate unwritable dir by making probe always fail once, then succeed
-    # after recreate — easier: chmod 0 if posix.
     if os.name == "posix":
         os.chmod(profile, 0o000)
-        monkeypatch.setattr(
-            browser_setup,
-            "_try_fix_ownership",
-            lambda _p: None,
-        )
         monkeypatch.setattr(browser_setup, "_under_root_home", lambda _p: False)
         try:
             result = ensure_profile_writable(profile)
             assert result == profile or "harness-browser-profiles" in str(result)
             assert _probe_dir_writable(result)
         finally:
-            os.chmod(profile, 0o700)
             if profile.exists():
                 os.chmod(profile, 0o700)
     else:
@@ -223,3 +217,103 @@ def test_ensure_profile_writable_relocates_root_home(
 
     result = ensure_profile_writable(profile)
     assert result == tmp_path / "relocated" / "default"
+
+
+@posix_only
+def test_ensure_profile_writable_never_chmods_system_paths(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression for #84: profile prep must not chmod / or /tmp."""
+    from octop.infra.browser import setup as browser_setup
+
+    chmod_targets: list[str] = []
+    real_chmod = os.chmod
+
+    def tracking_chmod(path: str | bytes | os.PathLike[str], mode: int) -> None:
+        text = os.fspath(path)
+        chmod_targets.append(text)
+        if text in ("/", "/tmp"):
+            raise AssertionError(f"must not chmod system path {path}")
+        return real_chmod(path, mode)
+
+    monkeypatch.setattr(os, "chmod", tracking_chmod)
+    monkeypatch.setattr(browser_setup, "_under_root_home", lambda _p: False)
+    monkeypatch.setattr(browser_setup, "_probe_dir_writable", lambda _p: True)
+
+    profile = Path(f"/tmp/harness-browser-profiles-{os.getuid()}") / "default"
+    ensure_profile_writable(profile)
+
+    # Profile prep no longer chmod/chown at all — recreate/relocate only.
+    assert chmod_targets == []
+
+
+def test_octop_browser_profiles_dir_shared(tmp_path: Path) -> None:
+    from octop.infra.utils.browser_media import (
+        BROWSER_PROFILES_REL,
+        octop_browser_profiles_dir,
+    )
+    from octop.infra.utils.paths import PathLayout
+
+    paths = PathLayout(root=tmp_path / "octop")
+    dest = octop_browser_profiles_dir(paths)
+    assert dest == paths.root / BROWSER_PROFILES_REL
+    assert dest.is_dir()
+    # Shared root — not under any agent workspace.
+    assert "agents" not in dest.parts
+
+
+def test_configure_browser_profiles_dir_sets_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from octop.infra.utils.browser_media import configure_browser_profiles_dir
+
+    monkeypatch.delenv("BROWSER_USE_PROFILES_DIR", raising=False)
+    root = tmp_path / "browser-profiles"
+    result = configure_browser_profiles_dir(root)
+    assert result == root.resolve()
+    assert root.is_dir()
+    assert os.environ["BROWSER_USE_PROFILES_DIR"] == str(root.resolve())
+
+
+def test_legacy_profiles_migrated_once(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from octop.infra.utils import browser_media as media
+    from octop.infra.utils.paths import PathLayout
+
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    # Path.home() reads HOME on Unix.
+    legacy = home / ".harness-browser" / "profiles" / "default"
+    legacy.mkdir(parents=True)
+    (legacy / "Preferences").write_text("{}")
+
+    paths = PathLayout(root=tmp_path / "octop")
+    dest = media.octop_browser_profiles_dir(paths)
+    assert (dest / "default" / "Preferences").read_text() == "{}"
+    assert not legacy.exists()
+
+    # Second call must not fail when legacy is empty/gone.
+    media.octop_browser_profiles_dir(paths)
+    assert (dest / "default" / "Preferences").exists()
+
+
+@posix_only
+def test_under_root_home_exempts_octop_home(monkeypatch: pytest.MonkeyPatch) -> None:
+    from octop.infra.browser import setup as browser_setup
+    from octop.infra.utils.paths import PathLayout
+
+    if not Path("/root").is_dir():
+        pytest.skip("/root not available")
+
+    monkeypatch.setattr(browser_setup.sys, "platform", "linux")
+
+    def _fake_from_env() -> PathLayout:
+        return PathLayout(root=Path("/root/.octop"))
+
+    monkeypatch.setattr(
+        "octop.infra.utils.paths.PathLayout.from_env",
+        staticmethod(_fake_from_env),
+    )
+
+    assert browser_setup._under_root_home(Path("/root/.octop/browser-profiles/default")) is False
+    assert browser_setup._under_root_home(Path("/root/.harness-browser/profiles/default")) is True

--- a/tests/unit/browser/test_browser_setup.py
+++ b/tests/unit/browser/test_browser_setup.py
@@ -279,17 +279,16 @@ def test_legacy_profiles_migrated_once(tmp_path: Path, monkeypatch: pytest.Monke
     from octop.infra.utils import browser_media as media
     from octop.infra.utils.paths import PathLayout
 
-    home = tmp_path / "home"
-    home.mkdir()
-    monkeypatch.setenv("HOME", str(home))
-    # Path.home() reads HOME on Unix.
-    legacy = home / ".harness-browser" / "profiles" / "default"
+    # Do not rely on HOME/USERPROFILE — Path.home() differs on Windows.
+    legacy_root = tmp_path / "legacy-profiles"
+    legacy = legacy_root / "default"
     legacy.mkdir(parents=True)
-    (legacy / "Preferences").write_text("{}")
+    (legacy / "Preferences").write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(media, "legacy_harness_profiles_dir", lambda: legacy_root)
 
     paths = PathLayout(root=tmp_path / "octop")
     dest = media.octop_browser_profiles_dir(paths)
-    assert (dest / "default" / "Preferences").read_text() == "{}"
+    assert (dest / "default" / "Preferences").read_text(encoding="utf-8") == "{}"
     assert not legacy.exists()
 
     # Second call must not fail when legacy is empty/gone.

--- a/tests/unit/gateway/test_channels_qr.py
+++ b/tests/unit/gateway/test_channels_qr.py
@@ -97,9 +97,7 @@ def test_wecom_qrcode_poll_returns_status(mock_server_and_user):
     assert data["status"] == "pending"
 
 
-def test_pkill_chrome_profile_accepts_resolved_path(
-    monkeypatch: pytest.MonkeyPatch, tmp_path
-):
+def test_pkill_chrome_profile_accepts_resolved_path(monkeypatch: pytest.MonkeyPatch, tmp_path):
     """pkill pattern must not fail validation on the '=' separator."""
     from octop.api.routers.channels import _pkill_chrome_profile, _safe_profile_directory
 

--- a/tests/unit/gateway/test_channels_qr.py
+++ b/tests/unit/gateway/test_channels_qr.py
@@ -99,12 +99,11 @@ def test_wecom_qrcode_poll_returns_status(mock_server_and_user):
 
 def test_pkill_chrome_profile_accepts_resolved_path():
     """pkill pattern must not fail validation on the '=' separator."""
-    from pathlib import Path
-
     from octop.api.routers.channels import _pkill_chrome_profile, _safe_profile_directory
+    from octop.infra.utils.browser_media import octop_browser_profiles_dir
 
     profile_dir = _safe_profile_directory("feishu")
-    assert profile_dir == Path.home() / ".harness-browser" / "profiles" / "octop-feishu-bot"
+    assert profile_dir == octop_browser_profiles_dir() / "octop-feishu-bot"
 
     with patch("octop.api.routers.channels.asyncio.to_thread", new_callable=AsyncMock):
         import asyncio

--- a/tests/unit/gateway/test_channels_qr.py
+++ b/tests/unit/gateway/test_channels_qr.py
@@ -97,13 +97,20 @@ def test_wecom_qrcode_poll_returns_status(mock_server_and_user):
     assert data["status"] == "pending"
 
 
-def test_pkill_chrome_profile_accepts_resolved_path():
+def test_pkill_chrome_profile_accepts_resolved_path(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+):
     """pkill pattern must not fail validation on the '=' separator."""
     from octop.api.routers.channels import _pkill_chrome_profile, _safe_profile_directory
-    from octop.infra.utils.browser_media import octop_browser_profiles_dir
+
+    # Isolate from BROWSER_USE_PROFILES_DIR left by earlier agent/browser tests.
+    root = (tmp_path / "browser-profiles").resolve()
+    root.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("BROWSER_USE_PROFILES_DIR", str(root))
+    monkeypatch.delenv("HARNESS_BROWSER_PROFILES_DIR", raising=False)
 
     profile_dir = _safe_profile_directory("feishu")
-    assert profile_dir == octop_browser_profiles_dir() / "octop-feishu-bot"
+    assert profile_dir == root / "octop-feishu-bot"
 
     with patch("octop.api.routers.channels.asyncio.to_thread", new_callable=AsyncMock):
         import asyncio


### PR DESCRIPTION
## Summary
- Stop walking parents / chmod/chown of Chrome profile trees (root cause of #84: `/` and `/tmp` mode broken).
- Prefer shared `~/.octop/browser-profiles` (with one-shot migrate from `~/.harness-browser/profiles`); fallback `/tmp/harness-browser-profiles-<uid>` only when needed.
- Only self-created `XDG_RUNTIME_DIR` (`/tmp/runtime-harness-browser-<uid>`) still gets `chmod 0700`. Octop home under `/root` is exempt from YunJing relocate. Feishu/channels use the same shared root.

## Test plan
- [x] `uv run pytest tests/unit/browser -q`
- [x] `make lint`
- [ ] Manual: open remote desktop browser; confirm DNS/outbound still works; profiles land under `~/.octop/browser-profiles/`
- [ ] Manual (optional): with legacy `~/.harness-browser/profiles`, restart once and confirm migration

Closes #84