### PR TITLE
fix(dashboard): auto-reload once on stale chunk load failures

### DIFF
--- a/dashboard/src/components/ErrorBoundary/index.tsx
+++ b/dashboard/src/components/ErrorBoundary/index.tsx
@@ -1,5 +1,9 @@
 import { Component, type ReactNode } from "react";
 import { Result, Button, Space } from "antd";
+import {
+  isChunkLoadError,
+  tryReloadOnStaleChunk,
+} from "../../utils/reloadOnStaleChunk";
 
 interface Props {
   children: ReactNode;
@@ -25,6 +29,7 @@ export default class GlobalErrorBoundary extends Component<Props, State> {
   }
 
   componentDidCatch(error: Error, info: React.ErrorInfo) {
+    if (tryReloadOnStaleChunk(error)) return;
     console.error("[GlobalErrorBoundary]", error, info.componentStack);
   }
 
@@ -43,6 +48,10 @@ export default class GlobalErrorBoundary extends Component<Props, State> {
 
   render() {
     if (this.state.hasError) {
+      // Stale chunk → silent soft reload; avoid flashing the error page.
+      if (isChunkLoadError(this.state.error)) {
+        return null;
+      }
       const canRetry = this.state.retryCount < MAX_RETRIES;
       return (
         <div

--- a/dashboard/src/main.tsx
+++ b/dashboard/src/main.tsx
@@ -6,8 +6,17 @@ import "./pwa-prompt";
 import { createRoot } from "react-dom/client";
 import App from "./App.tsx";
 import { initI18n } from "./i18n";
+import {
+  clearChunkReloadFlag,
+  installChunkLoadRecovery,
+  isChunkLoadError,
+  tryReloadOnStaleChunk,
+} from "./utils/reloadOnStaleChunk";
 
 if (typeof window !== "undefined") {
+  // Recover from post-deploy stale hashed chunks (white screen → soft reload).
+  installChunkLoadRecovery();
+
   const originalError = console.error;
   const originalWarn = console.warn;
 
@@ -34,6 +43,8 @@ if (typeof window !== "undefined") {
   // Catch unhandled Promise rejections (e.g. uncaught async errors)
   window.addEventListener("unhandledrejection", (event) => {
     const reason = event.reason;
+    // Chunk recovery (installChunkLoadRecovery) already handles these.
+    if (isChunkLoadError(reason)) return;
     // Suppress common benign errors
     const msg = reason?.message || String(reason) || "";
     if (
@@ -47,9 +58,15 @@ if (typeof window !== "undefined") {
   });
 }
 
-void initI18n().then(() => {
-  createRoot(document.getElementById("root")!).render(<App />);
-});
+void initI18n()
+  .then(() => {
+    clearChunkReloadFlag();
+    createRoot(document.getElementById("root")!).render(<App />);
+  })
+  .catch((err: unknown) => {
+    if (tryReloadOnStaleChunk(err)) return;
+    console.error("[initI18n]", err);
+  });
 
 // Register SW as early as possible so beforeinstallprompt can fire before the
 // user clicks the header install button (deferring to "load" caused a race).

--- a/dashboard/src/utils/reloadOnStaleChunk.test.ts
+++ b/dashboard/src/utils/reloadOnStaleChunk.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearChunkReloadFlag,
+  isChunkLoadError,
+  tryReloadOnStaleChunk,
+} from "./reloadOnStaleChunk";
+
+describe("isChunkLoadError", () => {
+  it("matches Vite dynamic import failures", () => {
+    expect(
+      isChunkLoadError(
+        new Error(
+          "Failed to fetch dynamically imported module: http://x/assets/Foo.js",
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it("matches ChunkLoadError name", () => {
+    const err = new Error("Loading chunk 3 failed.");
+    err.name = "ChunkLoadError";
+    expect(isChunkLoadError(err)).toBe(true);
+  });
+
+  it("rejects unrelated errors", () => {
+    expect(isChunkLoadError(new Error("Network error"))).toBe(false);
+    expect(isChunkLoadError(null)).toBe(false);
+  });
+});
+
+describe("tryReloadOnStaleChunk", () => {
+  const reload = vi.fn();
+
+  beforeEach(() => {
+    sessionStorage.clear();
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { reload },
+    });
+    reload.mockClear();
+  });
+
+  afterEach(() => {
+    clearChunkReloadFlag();
+  });
+
+  it("reloads once on chunk error", () => {
+    const err = new Error("Failed to fetch dynamically imported module: /a.js");
+    expect(tryReloadOnStaleChunk(err)).toBe(true);
+    expect(reload).toHaveBeenCalledOnce();
+    expect(sessionStorage.getItem("octop:chunk-reload")).toBe("1");
+  });
+
+  it("does not loop on a second consecutive chunk error", () => {
+    const err = new Error("Failed to fetch dynamically imported module: /a.js");
+    expect(tryReloadOnStaleChunk(err)).toBe(true);
+    reload.mockClear();
+    expect(tryReloadOnStaleChunk(err)).toBe(false);
+    expect(reload).not.toHaveBeenCalled();
+    expect(sessionStorage.getItem("octop:chunk-reload")).toBeNull();
+  });
+
+  it("ignores non-chunk errors", () => {
+    expect(tryReloadOnStaleChunk(new Error("boom"))).toBe(false);
+    expect(reload).not.toHaveBeenCalled();
+  });
+});

--- a/dashboard/src/utils/reloadOnStaleChunk.ts
+++ b/dashboard/src/utils/reloadOnStaleChunk.ts
@@ -1,0 +1,79 @@
+/**
+ * One-shot soft reload when a Vite/webpack chunk fails to load after deploy.
+ * sessionStorage guards against infinite reload loops.
+ */
+
+const RELOAD_FLAG_KEY = "octop:chunk-reload";
+
+const CHUNK_ERROR_RE =
+  /Failed to fetch dynamically imported module|Importing a module script failed|Loading chunk [\w.-]+ failed|ChunkLoadError|error loading dynamically imported module/i;
+
+export function isChunkLoadError(error: unknown): boolean {
+  if (error == null) return false;
+  if (typeof error === "string") return CHUNK_ERROR_RE.test(error);
+  if (error instanceof Error) {
+    if (CHUNK_ERROR_RE.test(error.message)) return true;
+    if (error.name === "ChunkLoadError") return true;
+  }
+  // Some browsers put the URL on TypeError without a useful message prefix.
+  const text = String((error as { message?: unknown }).message ?? error);
+  return CHUNK_ERROR_RE.test(text);
+}
+
+/** @returns true when a reload was triggered (caller should stop further handling). */
+export function tryReloadOnStaleChunk(error: unknown): boolean {
+  if (typeof window === "undefined") return false;
+  if (!isChunkLoadError(error)) return false;
+
+  try {
+    if (sessionStorage.getItem(RELOAD_FLAG_KEY) === "1") {
+      sessionStorage.removeItem(RELOAD_FLAG_KEY);
+      return false;
+    }
+    sessionStorage.setItem(RELOAD_FLAG_KEY, "1");
+  } catch {
+    // Private mode / quota — still attempt a single reload without the guard.
+  }
+
+  console.warn("[Octop] Stale chunk detected; reloading once.", error);
+  window.location.reload();
+  return true;
+}
+
+/** Clear the one-shot flag after a successful boot so a later deploy can recover again. */
+export function clearChunkReloadFlag(): void {
+  if (typeof window === "undefined") return;
+  try {
+    sessionStorage.removeItem(RELOAD_FLAG_KEY);
+  } catch {
+    /* ignore */
+  }
+}
+
+/** Install window-level listeners for chunk failures before React mounts. */
+export function installChunkLoadRecovery(): void {
+  if (typeof window === "undefined") return;
+
+  window.addEventListener("unhandledrejection", (event) => {
+    if (tryReloadOnStaleChunk(event.reason)) {
+      event.preventDefault();
+    }
+  });
+
+  window.addEventListener(
+    "error",
+    (event) => {
+      const target = event.target;
+      if (
+        target instanceof HTMLScriptElement &&
+        typeof target.src === "string" &&
+        target.src.includes("/assets/")
+      ) {
+        tryReloadOnStaleChunk(
+          new Error(`Failed to fetch dynamically imported module: ${target.src}`),
+        );
+      }
+    },
+    true,
+  );
+}


### PR DESCRIPTION
## Summary
- After a deploy, stale hashed JS chunks (or PWA cache mismatch) can leave the dashboard on a white screen until a manual soft refresh.
- Detect Vite/dynamic-import chunk load failures and soft-reload once, guarded by `sessionStorage` to avoid reload loops.
- Wire recovery into boot (`main.tsx`), `ErrorBoundary`, and `initI18n` failure paths.

## Test plan
- [ ] `cd dashboard && npm test -- src/utils/reloadOnStaleChunk.test.ts`
- [ ] `cd dashboard && npx tsc --noEmit`
- [ ] Manually: open DevTools, block a lazy route chunk once → page should auto-reload once and recover; a second consecutive failure should not loop
- [ ] Confirm normal login / navigation still works with no unexpected reload


Made with [Cursor](https://cursor.com)