### PR TITLE
fix(connectors): NetEase IMAP host resolution and IMAP ID

### DIFF
--- a/dashboard/src/pages/Agent/Connectors/connectorDefs.tsx
+++ b/dashboard/src/pages/Agent/Connectors/connectorDefs.tsx
@@ -15,7 +15,7 @@ export const MAIL_PROVIDERS = [
     id: "netease",
     label: "网易邮箱",
     guideUrl: "https://mail.163.com/",
-    emailPlaceholder: "you@163.com",
+    emailPlaceholder: "you@163.com / you@126.com",
   },
   {
     id: "gmail",

--- a/src/octop/infra/connectors/builder.py
+++ b/src/octop/infra/connectors/builder.py
@@ -9,12 +9,7 @@ from urllib.parse import quote
 
 from octop.config import OctopConfig
 from octop.infra.connectors.catalog import ConnectorCatalogEntry, get_catalog_entry
-
-_MAIL_PROVIDER_PRESETS: dict[str, tuple[str, int, str, int]] = {
-    "qq": ("imap.qq.com", 993, "smtp.qq.com", 587),
-    "netease": ("imap.163.com", 993, "smtp.163.com", 587),
-    "gmail": ("imap.gmail.com", 993, "smtp.gmail.com", 587),
-}
+from octop.infra.connectors.mail_servers import resolve_mail_servers
 
 # MCP Streamable HTTP transport (Notion, etc.) requires both content types.
 _MCP_STREAMABLE_HTTP_ACCEPT = "application/json, text/event-stream"
@@ -36,28 +31,6 @@ def normalize_weiyun_mcp_token(raw: str) -> str:
     if match:
         return match.group(1).strip()
     return text
-
-
-def _resolve_mail_servers(credentials: dict[str, Any]) -> tuple[str, int, str, int]:
-    provider = str(credentials.get("mail_provider") or "").strip().lower()
-    if provider in _MAIL_PROVIDER_PRESETS:
-        return _MAIL_PROVIDER_PRESETS[provider]
-
-    email = str(credentials.get("email") or "").strip().lower()
-    domain = email.rsplit("@", 1)[-1] if "@" in email else ""
-    if domain in ("qq.com", "foxmail.com"):
-        return _MAIL_PROVIDER_PRESETS["qq"]
-    if domain in ("163.com", "126.com", "yeah.net"):
-        return _MAIL_PROVIDER_PRESETS["netease"]
-    if domain == "gmail.com":
-        return _MAIL_PROVIDER_PRESETS["gmail"]
-
-    return (
-        str(credentials.get("imap_host") or "imap.qq.com"),
-        int(credentials.get("imap_port") or 993),
-        str(credentials.get("smtp_host") or "smtp.qq.com"),
-        int(credentials.get("smtp_port") or 587),
-    )
 
 
 def mcp_server_name(kind: str, instance_id: str) -> str:
@@ -292,7 +265,7 @@ def validate_create_credentials(
         password = str(credentials.get("password") or "").strip()
         if not email or not password:
             raise ValueError("email and password (authorization code) are required")
-        imap_host, imap_port, smtp_host, smtp_port = _resolve_mail_servers(credentials)
+        imap_host, imap_port, smtp_host, smtp_port = resolve_mail_servers(credentials)
         internal_token = new_internal_token()
         out = {
             "email": email,

--- a/src/octop/infra/connectors/gateway/adapters/qq_mail.py
+++ b/src/octop/infra/connectors/gateway/adapters/qq_mail.py
@@ -10,6 +10,13 @@ import smtplib
 from email.mime.text import MIMEText
 from typing import Any
 
+from octop.infra.connectors.mail_servers import (
+    IMAP_CONNECT_TIMEOUT,
+    NETEASE_IMAP_HOSTS,
+    correct_netease_imap_host,
+    correct_netease_smtp_host,
+)
+
 TOOLS: list[dict[str, Any]] = [
     {
         "name": "search_emails",
@@ -51,6 +58,13 @@ TOOLS: list[dict[str, Any]] = [
     },
 ]
 
+_IMAP_ID_ARGS = (
+    '("name" "Octop" "version" "1.0.0" "vendor" "Octop" "support-email" "support@octop.local")'
+)
+
+# imaplib 默认未注册 ID 命令。
+imaplib.Commands["ID"] = ("AUTH", "NONAUTH", "SELECTED")
+
 
 def list_tools() -> list[dict[str, Any]]:
     return TOOLS
@@ -72,7 +86,8 @@ def _email_search(creds: dict[str, Any], args: dict[str, Any]) -> str:
     imap = _imap_login(creds)
     try:
         imap.select("INBOX")
-        _typ, data = imap.uid("search", "UTF-8", query)
+        # NetEase rejects CHARSET UTF-8 on UID SEARCH; omit charset for compatibility.
+        _typ, data = imap.uid("search", query)
         uids = (data[0] or b"").split()
         uids = uids[-limit:]
         out: list[dict[str, str]] = []
@@ -136,30 +151,50 @@ def _email_send(creds: dict[str, Any], args: dict[str, Any]) -> str:
     msg["Subject"] = subject
     msg["From"] = from_addr
     msg["To"] = to_addr
-    host = str(creds.get("smtp_host") or "smtp.qq.com")
+    host = correct_netease_smtp_host(from_addr, creds.get("smtp_host"))
     port = int(creds.get("smtp_port") or 587)
-    with smtplib.SMTP(host, port, timeout=30) as smtp:
+    with smtplib.SMTP(host, port, timeout=IMAP_CONNECT_TIMEOUT) as smtp:
         smtp.starttls()
         smtp.login(from_addr, str(creds.get("password") or ""))
         smtp.send_message(msg)
     return json.dumps({"ok": True, "to": to_addr}, ensure_ascii=False)
 
 
+def _should_send_imap_id(imap: imaplib.IMAP4_SSL, host: str) -> bool:
+    if host in NETEASE_IMAP_HOSTS:
+        return True
+    caps = {str(c).upper() for c in (imap.capabilities or ())}
+    return "ID" in caps
+
+
+def _imap_send_id(imap: imaplib.IMAP4_SSL) -> None:
+    typ, _data = imap._simple_command("ID", _IMAP_ID_ARGS)
+    if typ != "OK":
+        raise imaplib.IMAP4.error(f"IMAP ID failed: {typ}")
+
+
 def _imap_login(creds: dict[str, Any]) -> imaplib.IMAP4_SSL:
-    host = str(creds.get("imap_host") or "imap.qq.com")
-    port = int(creds.get("imap_port") or 993)
     user = str(creds.get("email") or "")
+    host = correct_netease_imap_host(user, creds.get("imap_host"))
+    port = int(creds.get("imap_port") or 993)
     password = str(creds.get("password") or "")
-    imap: imaplib.IMAP4_SSL = imaplib.IMAP4_SSL(host, port)
+    imap: imaplib.IMAP4_SSL = imaplib.IMAP4_SSL(host, port, timeout=IMAP_CONNECT_TIMEOUT)
+    if _should_send_imap_id(imap, host):
+        _imap_send_id(imap)
     imap.login(user, password)
     return imap
 
 
 def probe_credentials(creds: dict[str, Any]) -> None:
-    """Validate mailbox credentials via IMAP login."""
+    """Validate mailbox credentials via IMAP login + INBOX select."""
     imap = _imap_login(creds)
-    with contextlib.suppress(Exception):
-        imap.logout()
+    try:
+        typ, _data = imap.select("INBOX")
+        if typ != "OK":
+            raise imaplib.IMAP4.error(f"SELECT INBOX failed: {_data}")
+    finally:
+        with contextlib.suppress(Exception):
+            imap.logout()
 
 
 def _extract_body(msg: email.message.Message) -> str:

--- a/src/octop/infra/connectors/mail_servers.py
+++ b/src/octop/infra/connectors/mail_servers.py
@@ -1,0 +1,90 @@
+"""Shared IMAP/SMTP host presets for mailbox connectors."""
+
+from __future__ import annotations
+
+from typing import Any
+
+MailServers = tuple[str, int, str, int]  # imap_host, imap_port, smtp_host, smtp_port
+
+_MAIL_PROVIDER_PRESETS: dict[str, MailServers] = {
+    "qq": ("imap.qq.com", 993, "smtp.qq.com", 587),
+    "gmail": ("imap.gmail.com", 993, "smtp.gmail.com", 587),
+}
+
+# 163 / 126 / yeah 各用独立主机；混用会报 LOGIN 失败。
+_NETEASE_DOMAIN_SERVERS: dict[str, MailServers] = {
+    "163.com": ("imap.163.com", 993, "smtp.163.com", 587),
+    "126.com": ("imap.126.com", 993, "smtp.126.com", 587),
+    "yeah.net": ("imap.yeah.net", 993, "smtp.yeah.net", 587),
+}
+_NETEASE_DEFAULT_SERVERS = _NETEASE_DOMAIN_SERVERS["163.com"]
+
+NETEASE_IMAP_HOSTS = frozenset(servers[0] for servers in _NETEASE_DOMAIN_SERVERS.values())
+NETEASE_SMTP_HOSTS = frozenset(servers[2] for servers in _NETEASE_DOMAIN_SERVERS.values())
+
+DEFAULT_IMAP_HOST = "imap.qq.com"
+DEFAULT_SMTP_HOST = "smtp.qq.com"
+IMAP_CONNECT_TIMEOUT = 30
+
+
+def _email_domain(email: str) -> str:
+    text = email.strip().lower()
+    return text.rsplit("@", 1)[-1] if "@" in text else ""
+
+
+def netease_servers_for_email(email: str) -> MailServers:
+    domain = _email_domain(email)
+    return _NETEASE_DOMAIN_SERVERS.get(domain, _NETEASE_DEFAULT_SERVERS)
+
+
+def preferred_netease_imap_host(email: str) -> str | None:
+    domain = _email_domain(email)
+    servers = _NETEASE_DOMAIN_SERVERS.get(domain)
+    return servers[0] if servers else None
+
+
+def preferred_netease_smtp_host(email: str) -> str | None:
+    domain = _email_domain(email)
+    servers = _NETEASE_DOMAIN_SERVERS.get(domain)
+    return servers[2] if servers else None
+
+
+def resolve_mail_servers(credentials: dict[str, Any]) -> MailServers:
+    """Resolve IMAP/SMTP hosts from mail_provider and/or email domain."""
+    provider = str(credentials.get("mail_provider") or "").strip().lower()
+    email = str(credentials.get("email") or "").strip().lower()
+    domain = _email_domain(email)
+
+    if provider == "netease" or domain in _NETEASE_DOMAIN_SERVERS:
+        return netease_servers_for_email(email)
+    if provider in _MAIL_PROVIDER_PRESETS:
+        return _MAIL_PROVIDER_PRESETS[provider]
+    if domain in ("qq.com", "foxmail.com"):
+        return _MAIL_PROVIDER_PRESETS["qq"]
+    if domain == "gmail.com":
+        return _MAIL_PROVIDER_PRESETS["gmail"]
+
+    return (
+        str(credentials.get("imap_host") or DEFAULT_IMAP_HOST),
+        int(credentials.get("imap_port") or 993),
+        str(credentials.get("smtp_host") or DEFAULT_SMTP_HOST),
+        int(credentials.get("smtp_port") or 587),
+    )
+
+
+def correct_netease_imap_host(email: str, stored_host: str | None) -> str:
+    """Fix legacy NetEase hosts (e.g. 126 stored as imap.163.com)."""
+    host = str(stored_host or "").strip()
+    preferred = preferred_netease_imap_host(email)
+    if preferred and (not host or host in NETEASE_IMAP_HOSTS):
+        return preferred
+    return host or DEFAULT_IMAP_HOST
+
+
+def correct_netease_smtp_host(email: str, stored_host: str | None) -> str:
+    """Fix legacy NetEase SMTP hosts the same way as IMAP."""
+    host = str(stored_host or "").strip()
+    preferred = preferred_netease_smtp_host(email)
+    if preferred and (not host or host in NETEASE_SMTP_HOSTS):
+        return preferred
+    return host or DEFAULT_SMTP_HOST

--- a/tests/unit/connectors/test_mail_servers.py
+++ b/tests/unit/connectors/test_mail_servers.py
@@ -1,0 +1,119 @@
+"""Unit tests for shared mailbox host resolution and qq-mail IMAP login."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from octop.infra.connectors import mail_servers
+from octop.infra.connectors.gateway.adapters import qq_mail
+from octop.infra.connectors.mail_servers import (
+    correct_netease_imap_host,
+    correct_netease_smtp_host,
+    resolve_mail_servers,
+)
+
+
+@pytest.mark.parametrize(
+    ("email", "provider", "imap_host", "smtp_host"),
+    [
+        ("a@163.com", "netease", "imap.163.com", "smtp.163.com"),
+        ("a@126.com", "netease", "imap.126.com", "smtp.126.com"),
+        ("a@yeah.net", "netease", "imap.yeah.net", "smtp.yeah.net"),
+        ("a@qq.com", "qq", "imap.qq.com", "smtp.qq.com"),
+        ("a@gmail.com", "gmail", "imap.gmail.com", "smtp.gmail.com"),
+        # Domain alone is enough when provider is omitted.
+        ("a@126.com", "", "imap.126.com", "smtp.126.com"),
+    ],
+)
+def test_resolve_mail_servers(email: str, provider: str, imap_host: str, smtp_host: str) -> None:
+    creds: dict[str, Any] = {"email": email, "password": "x"}
+    if provider:
+        creds["mail_provider"] = provider
+    resolved = resolve_mail_servers(creds)
+    assert resolved[0] == imap_host
+    assert resolved[2] == smtp_host
+
+
+def test_correct_netease_imap_host_fixes_legacy_163_for_126() -> None:
+    assert correct_netease_imap_host("user@126.com", "imap.163.com") == "imap.126.com"
+    assert correct_netease_imap_host("user@126.com", None) == "imap.126.com"
+    assert correct_netease_imap_host("user@126.com", "") == "imap.126.com"
+
+
+def test_correct_netease_imap_host_keeps_custom_non_netease() -> None:
+    assert correct_netease_imap_host("user@126.com", "imap.example.com") == "imap.example.com"
+
+
+def test_correct_netease_smtp_host_fixes_legacy() -> None:
+    assert correct_netease_smtp_host("user@yeah.net", "smtp.163.com") == "smtp.yeah.net"
+
+
+def test_should_send_imap_id_for_netease_host() -> None:
+    imap = MagicMock()
+    imap.capabilities = ()
+    assert qq_mail._should_send_imap_id(imap, "imap.126.com") is True
+
+
+def test_should_send_imap_id_when_capability_advertised() -> None:
+    imap = MagicMock()
+    imap.capabilities = ("IMAP4rev1", "ID")
+    assert qq_mail._should_send_imap_id(imap, "imap.custom.example") is True
+
+
+def test_should_not_send_imap_id_without_netease_or_capability() -> None:
+    imap = MagicMock()
+    imap.capabilities = ("IMAP4rev1",)
+    assert qq_mail._should_send_imap_id(imap, "imap.qq.com") is False
+
+
+def test_imap_login_sends_id_and_uses_corrected_host() -> None:
+    fake_imap = MagicMock()
+    fake_imap.capabilities = ("IMAP4rev1", "ID")
+    fake_imap._simple_command.return_value = ("OK", [b"ID completed"])
+    fake_imap.login.return_value = ("OK", [b"LOGIN completed"])
+
+    with patch(
+        "octop.infra.connectors.gateway.adapters.qq_mail.imaplib.IMAP4_SSL",
+        return_value=fake_imap,
+    ) as ssl_ctor:
+        imap = qq_mail._imap_login(
+            {
+                "email": "user@126.com",
+                "password": "auth-code",
+                "imap_host": "imap.163.com",  # legacy wrong host
+            }
+        )
+
+    assert imap is fake_imap
+    ssl_ctor.assert_called_once_with(
+        "imap.126.com",
+        993,
+        timeout=mail_servers.IMAP_CONNECT_TIMEOUT,
+    )
+    fake_imap._simple_command.assert_called_once()
+    assert fake_imap._simple_command.call_args[0][0] == "ID"
+    fake_imap.login.assert_called_once_with("user@126.com", "auth-code")
+
+
+def test_imap_login_skips_id_for_qq() -> None:
+    fake_imap = MagicMock()
+    fake_imap.capabilities = ("IMAP4rev1",)
+    fake_imap.login.return_value = ("OK", [b"LOGIN completed"])
+
+    with patch(
+        "octop.infra.connectors.gateway.adapters.qq_mail.imaplib.IMAP4_SSL",
+        return_value=fake_imap,
+    ):
+        qq_mail._imap_login(
+            {
+                "email": "user@qq.com",
+                "password": "auth-code",
+                "imap_host": "imap.qq.com",
+            }
+        )
+
+    fake_imap._simple_command.assert_not_called()
+    fake_imap.login.assert_called_once_with("user@qq.com", "auth-code")

--- a/tests/unit/test_connectors.py
+++ b/tests/unit/test_connectors.py
@@ -495,6 +495,32 @@ def test_mail_provider_netease():
     assert payload["smtp_host"] == "smtp.163.com"
 
 
+def test_mail_provider_netease_126_uses_126_hosts():
+    payload = validate_create_credentials(
+        "qq-mail",
+        {
+            "email": "a@126.com",
+            "password": "code",
+            "mail_provider": "netease",
+        },
+    )
+    assert payload["imap_host"] == "imap.126.com"
+    assert payload["smtp_host"] == "smtp.126.com"
+
+
+def test_mail_provider_netease_yeah_uses_yeah_hosts():
+    payload = validate_create_credentials(
+        "qq-mail",
+        {
+            "email": "a@yeah.net",
+            "password": "code",
+            "mail_provider": "netease",
+        },
+    )
+    assert payload["imap_host"] == "imap.yeah.net"
+    assert payload["smtp_host"] == "smtp.yeah.net"
+
+
 def test_catalog_entry_dict_has_no_tools():
     from octop.infra.connectors.catalog import catalog_entry_to_dict, get_catalog_entry
 


### PR DESCRIPTION
## Summary
- Resolve 163/126/yeah IMAP/SMTP hosts by email domain instead of always using `imap.163.com` (fixes 126 `LOGIN Login error or password error`)
- Send IMAP `ID` for NetEase hosts or when the server advertises `ID` capability; probe now also `SELECT INBOX`
- Centralize mail host presets in `mail_servers.py`, add IMAP connect timeout, and cover host correction / ID login with unit tests

## Test plan
- [x] `make format` / `make lint` / `make typecheck`
- [x] `uv run pytest tests/unit/connectors/test_mail_servers.py tests/unit/test_connectors.py -k mail -q`
- [x] Live probe: 126 / 163 / QQ / Gmail app password login + search


Made with [Cursor](https://cursor.com)