### PR TITLE
feat: unify provider model modal workflows

### DIFF
--- a/dashboard/src/locales/en.json
+++ b/dashboard/src/locales/en.json
@@ -1770,7 +1770,16 @@
     "configured": "Configured",
     "presetNameExists": "A provider with this name already exists, please edit it directly",
     "sharedProviders": "Shared Providers (Admin)",
-    "pleaseEnterApiKey": "Please enter API Key"
+    "pleaseEnterApiKey": "Please enter API Key",
+    "fetchModels": "Fetch models",
+    "fetchingModels": "Fetching…",
+    "fetchModelsSuccess": "Fetched {{count}} models (disabled by default)",
+    "fetchModelsMerged": "Added {{count}} new models to list (existing ones unchanged)",
+    "fetchModelsNoNew": "No new models to add",
+    "fetchModelsFailed": "Failed to fetch models: {{error}}",
+    "fetchModelsUnsupportedKind": "Auto-fetch is only supported for OpenAI-compatible providers",
+    "customModelsLabel": "Models",
+    "customModelsHint": "Fetched models are off by default — enable, test, edit, or remove; or add manually"
   },
   "advancedSettings": {
     "description": "Manage runtime configuration and environment variables.",

--- a/dashboard/src/locales/zh.json
+++ b/dashboard/src/locales/zh.json
@@ -1763,7 +1763,16 @@
     "configured": "已配置",
     "presetNameExists": "已有同名 provider，请直接编辑",
     "sharedProviders": "共享提供商（管理员）",
-    "pleaseEnterApiKey": "请输入 API Key"
+    "pleaseEnterApiKey": "请输入 API Key",
+    "fetchModels": "获取模型列表",
+    "fetchingModels": "正在获取…",
+    "fetchModelsSuccess": "已获取 {{count}} 个模型（默认未启用）",
+    "fetchModelsMerged": "已新增 {{count}} 个模型到列表（已有模型保持不变）",
+    "fetchModelsNoNew": "没有可新增的模型",
+    "fetchModelsFailed": "获取模型失败：{{error}}",
+    "fetchModelsUnsupportedKind": "仅 OpenAI 兼容供应商支持自动获取模型列表",
+    "customModelsLabel": "模型",
+    "customModelsHint": "获取后默认未启用，可开启开关、测试、编辑或删除；也可手动添加"
   },
   "advancedSettings": {
     "description": "管理运行配置和环境变量等高级选项。",

--- a/dashboard/src/pages/Settings/Models/components/modals/CustomProviderModal.tsx
+++ b/dashboard/src/pages/Settings/Models/components/modals/CustomProviderModal.tsx
@@ -1,30 +1,14 @@
 /**
- * CustomProviderModal — create a new provider with a multi-model list.
- *
- * Mirrors finnie's CustomProviderModal shape:
- *   - Provider metadata form (name, kind, base_url, api_key)
- *   - Inline model list editor (add / remove models with input types)
+ * CustomProviderModal — create a new custom provider.
  */
-import { useEffect, useState } from "react";
-import {
-  Button,
-  Divider,
-  Form,
-  Input,
-  InputNumber,
-  Modal,
-  Select,
-  Space,
-  Switch,
-  message,
-} from "antd";
-import { ChevronDown, ChevronUp, Plus, Trash2, Zap } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { Button, Divider, Form, Input, Modal, Select, Space, message } from "antd";
+import { Download, Zap } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { request } from "../../../../../api/request";
-import type { ProviderRow } from "../../useProviders";
-import { ModelMetaTags } from "../../modelMeta";
-import { enrichWizardModel } from "../../wizardModelMeta";
-import { testProviderDraft } from "../../providerApi";
+import type { ProviderModel, ProviderRow } from "../../useProviders";
+import { fetchProviderModels, testProviderDraft } from "../../providerApi";
+import { ModelListEditor } from "./ModelListEditor";
 import styles from "../../index.module.less";
 
 interface CustomProviderModalProps {
@@ -35,25 +19,10 @@ interface CustomProviderModalProps {
   apiPrefix?: string;
 }
 
-interface InitialModel {
-  id: string;
-  name: string;
-  input: string[];
-  max_tokens?: number;
-  context_window?: number;
-  reasoning?: boolean;
-}
-
 const KINDS = [
   { value: "openai", labelKey: "kindOpenaiCompat" as const },
   { value: "anthropic", labelKey: "anthropic" as const },
   { value: "bedrock", labelKey: "bedrock" as const },
-];
-
-const INPUT_TYPE_OPTIONS = [
-  { value: "text", label: "inputTypeText" as const },
-  { value: "image", label: "inputTypeImage" as const },
-  { value: "audio", label: "inputTypeAudio" as const },
 ];
 
 export function CustomProviderModal({
@@ -65,80 +34,61 @@ export function CustomProviderModal({
   const { t } = useTranslation();
   const [saving, setSaving] = useState(false);
   const [testing, setTesting] = useState(false);
-  const [form] = Form.useForm();
-  const [models, setModels] = useState<InitialModel[]>([]);
-  const [adding, setAdding] = useState(false);
-  const [showAdvanced, setShowAdvanced] = useState(false);
-  const [modelForm] = Form.useForm();
+  const [fetchingModels, setFetchingModels] = useState(false);
+  const [form] = Form.useForm<{
+    name: string;
+    kind: string;
+    base_url?: string;
+    api_key?: string;
+    note?: string;
+  }>();
+  const kind = Form.useWatch("kind", form) as string | undefined;
+  const apiKey = Form.useWatch("api_key", form) as string | undefined;
+  const [models, setModels] = useState<ProviderModel[]>([]);
+  const canTest = !!apiKey?.trim();
+
+  const draftProvider = useMemo<ProviderRow>(
+    () => ({
+      id: 0,
+      name: (form.getFieldValue("name") as string | undefined) || "draft",
+      kind: (form.getFieldValue("kind") as string | undefined) || "openai",
+      base_url: (form.getFieldValue("base_url") as string | undefined) || null,
+      api_key: (form.getFieldValue("api_key") as string | undefined) || null,
+      models,
+      note: null,
+      enabled: true,
+    }),
+    [form, models],
+  );
 
   useEffect(() => {
     if (open) {
       form.resetFields();
       form.setFieldsValue({ kind: "openai" });
-      modelForm.resetFields();
       setModels([]);
-      setAdding(false);
-      setShowAdvanced(false);
     }
-  }, [open, form, modelForm]);
+  }, [open, form]);
 
-  const handleAddModel = async () => {
-    try {
-      const values = await modelForm.validateFields();
-      const id = (values.id as string).trim();
-      if (models.some((m) => m.id === id)) {
-        message.warning(t("models.initialModelDuplicate", { name: id }));
-        return;
-      }
-      const name = (values.name as string | undefined)?.trim() || id;
-      const input: string[] = (values.input as string[] | undefined) || [
-        "text",
-      ];
-      const contextWindow =
-        values.context_window != null
-          ? (values.context_window as number)
-          : undefined;
-      const maxTokens =
-        values.max_tokens != null ? (values.max_tokens as number) : undefined;
-      const reasoning =
-        values.reasoning != null ? (values.reasoning as boolean) : undefined;
-      const meta = enrichWizardModel(
-        {
-          id,
-          name,
-          input,
-          context_window: contextWindow,
-          max_tokens: maxTokens,
-          reasoning,
-        },
-        t,
-      );
-      const entry: InitialModel = {
-        id,
-        name,
-        input: meta.input,
-      };
-      if (maxTokens != null) entry.max_tokens = maxTokens;
-      if (contextWindow != null) entry.context_window = contextWindow;
-      if (meta.reasoning) entry.reasoning = true;
-      setModels((prev) => [...prev, entry]);
-      modelForm.resetFields();
-      setAdding(false);
-      setShowAdvanced(false);
-    } catch {
-      // validation error — ignore
+  const testDraftModel = async (modelId: string) => {
+    const values = await form.validateFields(["name", "kind", "api_key", "base_url"]);
+    const key = (values.api_key as string | undefined)?.trim();
+    if (!key) {
+      return { ok: false, error: t("models.pleaseEnterApiKey") };
     }
+    return testProviderDraft({
+      name: (values.name || "draft").trim(),
+      kind: values.kind,
+      api_key: key,
+      base_url: values.base_url?.trim() || null,
+      model_id: modelId,
+    });
   };
 
-  const handleRemoveModel = (modelId: string) => {
-    setModels((prev) => prev.filter((m) => m.id !== modelId));
-  };
-
-  const handleTest = async () => {
+  const handleFetchModels = async () => {
     try {
-      const values = await form.validateFields();
-      if (models.length === 0) {
-        message.warning(t("models.testDraftNeedModel"));
+      const values = await form.validateFields(["kind", "api_key", "base_url"]);
+      if ((values.kind as string) !== "openai") {
+        message.warning(t("models.fetchModelsUnsupportedKind"));
         return;
       }
       const apiKey = (values.api_key as string | undefined)?.trim();
@@ -146,35 +96,48 @@ export function CustomProviderModal({
         message.warning(t("models.pleaseEnterApiKey"));
         return;
       }
-      setTesting(true);
-      const result = await testProviderDraft({
-        name: (values.name as string).trim(),
-        kind: values.kind as string,
+      setFetchingModels(true);
+      const result = await fetchProviderModels({
+        kind: "openai",
         api_key: apiKey,
         base_url: (values.base_url as string | undefined)?.trim() || null,
-        model_id: models[0].id,
       });
-      if (result.ok) {
-        message.success(
-          t("models.testSuccess", {
-            name: models[0].name,
-            time: result.latency_ms ?? 0,
-          }),
-        );
-      } else {
+      if (!result.ok) {
         message.error(
-          t("models.testConnectionFailed", {
+          t("models.fetchModelsFailed", {
             error: result.error ?? "unknown",
           }),
         );
+        return;
+      }
+      const remote: ProviderModel[] = (result.models ?? []).map((m) => ({
+        id: m.id,
+        name: m.name || m.id,
+        enabled: false,
+        input: ["text"],
+        thinking: null,
+      }));
+      let addedCount = 0;
+      setModels((prev) => {
+        const existing = new Set(prev.map((m) => m.id));
+        const added = remote.filter((m) => !existing.has(m.id));
+        addedCount = added.length;
+        return [...prev, ...added];
+      });
+      if (addedCount === 0) {
+        message.info(t("models.fetchModelsNoNew"));
+      } else {
+        message.success(t("models.fetchModelsMerged", { count: addedCount }));
       }
     } catch (err) {
       if (err && typeof err === "object" && "errorFields" in err) return;
       message.error(
-        err instanceof Error ? err.message : t("models.testFailedSimple"),
+        err instanceof Error
+          ? err.message
+          : t("models.fetchModelsFailed", { error: "unknown" }),
       );
     } finally {
-      setTesting(false);
+      setFetchingModels(false);
     }
   };
 
@@ -187,7 +150,7 @@ export function CustomProviderModal({
         const entry: Record<string, unknown> = {
           id: m.id,
           name: m.name,
-          enabled: true,
+          enabled: m.enabled,
           input: m.input.length > 0 ? m.input : ["text"],
           thinking: null,
         };
@@ -237,23 +200,15 @@ export function CustomProviderModal({
       destroyOnHidden
       width={560}
       footer={
-        <Space>
-          <Button onClick={onClose}>{t("common.cancel")}</Button>
-          <Button
-            icon={<Zap size={14} />}
-            loading={testing}
-            onClick={() => void handleTest()}
-          >
-            {t("models.testConnection")}
-          </Button>
-          <Button
-            type="primary"
-            loading={saving}
-            onClick={() => void handleSubmit()}
-          >
-            {t("common.create")}
-          </Button>
-        </Space>
+        <div className={styles.modalFooter}>
+          <div className={styles.modalFooterLeft} />
+          <div className={styles.modalFooterRight}>
+            <Button onClick={onClose}>{t("common.cancel")}</Button>
+            <Button type="primary" loading={saving} onClick={() => void handleSubmit()}>
+              {t("common.create")}
+            </Button>
+          </div>
+        </div>
       }
     >
       <Form form={form} layout="vertical" style={{ marginTop: 16 }}>
@@ -277,8 +232,8 @@ export function CustomProviderModal({
                 k.value === "openai"
                   ? t("models.kindOpenaiCompat")
                   : k.value === "anthropic"
-                  ? "Anthropic"
-                  : "AWS Bedrock",
+                    ? "Anthropic"
+                    : "AWS Bedrock",
             }))}
           />
         </Form.Item>
@@ -295,188 +250,65 @@ export function CustomProviderModal({
           <Input.Password placeholder="sk-..." visibilityToggle />
         </Form.Item>
 
+        {kind === "openai" && (
+          <Form.Item style={{ marginBottom: 12 }}>
+            <Button
+              icon={<Download size={14} />}
+              loading={fetchingModels}
+              onClick={() => void handleFetchModels()}
+            >
+              {fetchingModels
+                ? t("models.fetchingModels")
+                : t("models.fetchModels")}
+            </Button>
+          </Form.Item>
+        )}
+
         <Form.Item name="note" label={t("models.noteLabel")}>
           <Input.TextArea rows={2} placeholder={t("models.notePlaceholder")} />
         </Form.Item>
       </Form>
 
-      {/* ── Model list ── */}
-      <Divider style={{ margin: "8px 0 12px" }}>
-        {t("models.initialModelsLabel")}
-      </Divider>
-
-      <div className={styles.initialModelsHintText} style={{ marginBottom: 8 }}>
-        {t("models.initialModelsHint")}
-      </div>
-
-      <div className={styles.modelList}>
-        {models.length === 0 ? (
-          <div className={styles.modelListEmpty}>{t("models.noModels")}</div>
-        ) : (
-          models.map((m) => (
-            <div key={m.id} className={styles.modelListItem}>
-              <div className={styles.modelListItemInfo}>
-                <span className={styles.modelListItemName}>{m.name}</span>
-                {m.name !== m.id && (
-                  <span className={styles.modelListItemId}>{m.id}</span>
-                )}
-                <ModelMetaTags
-                  includeText
-                  input={m.input}
-                  context_window={m.context_window}
-                  max_tokens={m.max_tokens}
-                  reasoning={m.reasoning}
-                />
-              </div>
-              <div className={styles.modelListItemActions}>
-                <Button
-                  type="text"
-                  size="small"
-                  danger
-                  icon={<Trash2 size={14} />}
-                  onClick={() => handleRemoveModel(m.id)}
-                />
-              </div>
-            </div>
-          ))
+      <div style={{ marginBottom: 16 }}>
+        <Button size="small" icon={<Zap size={12} />} loading={testing} onClick={async () => {
+          try {
+            setTesting(true);
+            const modelId = models.find((m) => m.enabled !== false)?.id || models[0]?.id;
+            if (!modelId) {
+              message.warning(t("models.testDraftNeedModel"));
+              return;
+            }
+            const result = await testDraftModel(modelId);
+            if (result.ok) {
+              const latency = result.latency_ms != null ? t("models.testConnectionLatency", { time: result.latency_ms }) : "";
+              message.success(t("models.testConnectionSuccess", { name: (form.getFieldValue("name") as string) || "draft", latency }));
+            } else {
+              message.error(t("models.testConnectionFailed", { error: result.error ?? "unknown" }));
+            }
+          } finally {
+            setTesting(false);
+          }
+        }}>
+          {t("models.testConnection")}
+        </Button>
+        {kind === "openai" && (
+          <Button size="small" icon={<Download size={12} />} loading={fetchingModels} onClick={() => void handleFetchModels()} style={{ marginLeft: 8 }}>
+            {t("models.fetchModels")}
+          </Button>
         )}
       </div>
 
-      {/* ── Add model form ── */}
-      {adding ? (
-        <div className={styles.modelAddForm}>
-          <Form form={modelForm} layout="vertical" style={{ marginBottom: 0 }}>
-            <Form.Item
-              name="id"
-              label={t("models.modelIdLabel")}
-              rules={[{ required: true, message: t("models.modelIdLabel") }]}
-              style={{ marginBottom: 12 }}
-            >
-              <Input placeholder={t("models.modelIdPlaceholder")} />
-            </Form.Item>
-            <Form.Item
-              name="name"
-              label={t("models.modelNameLabel")}
-              style={{ marginBottom: 12 }}
-            >
-              <Input placeholder={t("models.modelNamePlaceholder")} />
-            </Form.Item>
-            <Form.Item
-              name="input"
-              label={t("models.inputTypes")}
-              initialValue={["text"]}
-              style={{ marginBottom: 12 }}
-            >
-              <Select
-                mode="multiple"
-                allowClear
-                placeholder={t("models.inputTypes")}
-                options={INPUT_TYPE_OPTIONS.map((opt) => ({
-                  value: opt.value,
-                  label: t(`models.${opt.label}`),
-                }))}
-              />
-            </Form.Item>
-            <div
-              style={{
-                display: "flex",
-                alignItems: "center",
-                gap: 6,
-                marginBottom: showAdvanced ? 8 : 12,
-              }}
-            >
-              <Button
-                type="link"
-                size="small"
-                style={{ padding: 0 }}
-                icon={
-                  showAdvanced ? (
-                    <ChevronUp size={14} />
-                  ) : (
-                    <ChevronDown size={14} />
-                  )
-                }
-                onClick={() => setShowAdvanced(!showAdvanced)}
-              >
-                {showAdvanced
-                  ? t("models.hideAdvanced")
-                  : t("models.showAdvanced")}
-              </Button>
-            </div>
-            {showAdvanced && (
-              <div
-                style={{
-                  background:
-                    "var(--ant-color-fill-quaternary, rgba(0,0,0,0.02))",
-                  borderRadius: 6,
-                  padding: "12px 12px 4px",
-                  marginBottom: 12,
-                }}
-              >
-                <div style={{ display: "flex", gap: 12 }}>
-                  <Form.Item
-                    name="context_window"
-                    label={t("models.contextWindow")}
-                    style={{ flex: 1, marginBottom: 10 }}
-                  >
-                    <InputNumber
-                      min={0}
-                      style={{ width: "100%" }}
-                      placeholder={t("models.contextWindowPlaceholder")}
-                    />
-                  </Form.Item>
-                  <Form.Item
-                    name="max_tokens"
-                    label={t("models.maxTokens")}
-                    style={{ flex: 1, marginBottom: 10 }}
-                  >
-                    <InputNumber
-                      min={0}
-                      style={{ width: "100%" }}
-                      placeholder={t("models.maxTokensPlaceholder")}
-                    />
-                  </Form.Item>
-                </div>
-                <Form.Item
-                  name="reasoning"
-                  label={t("models.reasoning")}
-                  valuePropName="checked"
-                  style={{ marginBottom: 10 }}
-                >
-                  <Switch size="small" />
-                </Form.Item>
-              </div>
-            )}
-            <div
-              style={{ display: "flex", gap: 8, justifyContent: "flex-end" }}
-            >
-              <Button
-                size="small"
-                onClick={() => {
-                  setAdding(false);
-                  setShowAdvanced(false);
-                  modelForm.resetFields();
-                }}
-              >
-                {t("common.cancel")}
-              </Button>
-              <Button type="primary" size="small" onClick={handleAddModel}>
-                {t("models.addModel")}
-              </Button>
-            </div>
-          </Form>
-        </div>
-      ) : (
-        <Button
-          type="dashed"
-          block
-          icon={<Plus size={14} />}
-          onClick={() => setAdding(true)}
-          style={{ marginTop: 12 }}
-        >
-          {t("models.addModel")}
-        </Button>
-      )}
+      <Divider orientation="left" style={{ fontSize: 13 }}>
+        {t("models.manageModels")}
+      </Divider>
+      <ModelListEditor
+        provider={draftProvider}
+        models={models}
+        onModelsChange={setModels}
+        apiPrefix={apiPrefix}
+        canTest={canTest}
+        onTestModel={(modelId) => testDraftModel(modelId)}
+      />
     </Modal>
   );
 }

--- a/dashboard/src/pages/Settings/Models/components/modals/ModelListEditor.tsx
+++ b/dashboard/src/pages/Settings/Models/components/modals/ModelListEditor.tsx
@@ -1,10 +1,8 @@
 /**
- * ModelListEditor — manage models within a single octop provider.
+ * ModelListEditor — edit the draft models list for a provider.
  *
- * Adapts finnie's ModelListEditor to octop's data model:
- *   - octop has no per-model add/remove/toggle API endpoints
- *   - instead, we PATCH the full `models` array via PATCH /providers/{id}
- *   - models are stored as ProviderModel[] on the ProviderRow
+ * Mutations stay local until the parent modal saves (PATCH full models array).
+ * Connectivity tests still hit the live provider endpoint.
  */
 import { useState } from "react";
 import {
@@ -35,9 +33,15 @@ import styles from "../../index.module.less";
 
 interface ModelListEditorProps {
   provider: ProviderRow;
-  onSaved: () => void | Promise<void>;
-  /** API path prefix for PATCH. Defaults to "/providers". */
+  models: ProviderModel[];
+  onModelsChange: (models: ProviderModel[]) => void;
+  /** API path prefix for test. Defaults to "/providers". */
   apiPrefix?: string;
+  canTest?: boolean;
+  onTestModel?: (
+    modelId: string,
+    modelName: string,
+  ) => Promise<{ ok: boolean; latency_ms?: number; error?: string }>;
 }
 
 const INPUT_TYPE_OPTIONS = [
@@ -48,14 +52,16 @@ const INPUT_TYPE_OPTIONS = [
 
 export function ModelListEditor({
   provider,
-  onSaved,
+  models,
+  onModelsChange,
   apiPrefix = "/providers",
+  canTest,
+  onTestModel,
 }: ModelListEditorProps) {
   const { t } = useTranslation();
   const [adding, setAdding] = useState(false);
   const [editingModelId, setEditingModelId] = useState<string | null>(null);
   const [showAdvanced, setShowAdvanced] = useState(false);
-  const [saving, setSaving] = useState(false);
   const [testingIds, setTestingIds] = useState<Set<string>>(new Set());
   const [testResults, setTestResults] = useState<
     Map<string, "success" | "failure">
@@ -63,37 +69,14 @@ export function ModelListEditor({
   const [testingForm, setTestingForm] = useState(false);
   const [form] = Form.useForm();
 
-  const models = provider.models ?? [];
-
-  /** Save the updated models list to the backend. */
-  const saveModels = async (updated: ProviderModel[]) => {
-    await request(`${apiPrefix}/${provider.id}`, {
-      method: "PATCH",
-      body: JSON.stringify({ models: updated }),
-    });
-    await onSaved();
-  };
-
-  const handleToggleEnabled = async (
+  const handleToggleEnabled = (
     modelId: string,
-    modelName: string,
+    _modelName: string,
     enabled: boolean,
   ) => {
-    try {
-      const updated = models.map((m) =>
-        m.id === modelId ? { ...m, enabled } : m,
-      );
-      await saveModels(updated);
-      message.success(
-        enabled
-          ? t("models.modelEnabled", { name: modelName })
-          : t("models.modelDisabled", { name: modelName }),
-      );
-    } catch (err) {
-      message.error(
-        err instanceof Error ? err.message : t("models.toggleFailed"),
-      );
-    }
+    onModelsChange(
+      models.map((m) => (m.id === modelId ? { ...m, enabled } : m)),
+    );
   };
 
   const handleRemoveModel = (modelId: string, modelName: string) => {
@@ -106,31 +89,35 @@ export function ModelListEditor({
       okText: t("common.delete"),
       okButtonProps: { danger: true },
       cancelText: t("common.cancel"),
-      onOk: async () => {
-        try {
-          const updated = models.filter((m) => m.id !== modelId);
-          await saveModels(updated);
-          message.success(t("models.modelRemoved", { name: modelName }));
-        } catch (err) {
-          message.error(
-            err instanceof Error ? err.message : t("models.modelRemoveFailed"),
-          );
-        }
+      onOk: () => {
+        onModelsChange(models.filter((m) => m.id !== modelId));
+        if (editingModelId === modelId) resetForm();
+        message.success(t("models.modelRemoved", { name: modelName }));
       },
+    });
+  };
+
+  const runTest = async (
+    modelId: string,
+    modelName: string,
+  ): Promise<{ ok: boolean; latency_ms?: number; error?: string }> => {
+    if (onTestModel) {
+      return onTestModel(modelId, modelName);
+    }
+    return request<{
+      ok: boolean;
+      latency_ms?: number;
+      error?: string;
+    }>(`${apiPrefix}/${provider.id}/test`, {
+      method: "POST",
+      body: JSON.stringify({ model_id: modelId }),
     });
   };
 
   const handleTestModel = async (modelId: string, modelName: string) => {
     setTestingIds((prev) => new Set(prev).add(modelId));
     try {
-      const result = await request<{
-        ok: boolean;
-        latency_ms?: number;
-        error?: string;
-      }>(`${apiPrefix}/${provider.id}/test`, {
-        method: "POST",
-        body: JSON.stringify({ model_id: modelId }),
-      });
+      const result = await runTest(modelId, modelName);
       if (result.ok) {
         message.success(
           t("models.testSuccess", {
@@ -171,20 +158,13 @@ export function ModelListEditor({
       message.warning(t("models.modelIdLabel"));
       return;
     }
-    if (!provider.api_key) {
+    if (!(canTest ?? !!provider.api_key)) {
       message.warning(t("models.testRequiresAuth"));
       return;
     }
     setTestingForm(true);
     try {
-      const result = await request<{
-        ok: boolean;
-        latency_ms?: number;
-        error?: string;
-      }>(`${apiPrefix}/${provider.id}/test`, {
-        method: "POST",
-        body: JSON.stringify({ model_id: modelId }),
-      });
+      const result = await runTest(modelId, modelId);
       const modelName =
         (form.getFieldValue("name") as string | undefined)?.trim() || modelId;
       if (result.ok) {
@@ -227,22 +207,16 @@ export function ModelListEditor({
   const handleAddModel = async () => {
     try {
       const values = await form.validateFields();
-      setSaving(true);
       const entry = buildModelEntry(values as Record<string, unknown>);
       if (models.some((m) => m.id === entry.id)) {
         message.error(t("models.initialModelDuplicate", { name: entry.id }));
         return;
       }
-      await saveModels([...models, entry]);
+      onModelsChange([...models, entry]);
       message.success(t("models.modelAdded", { name: entry.name }));
       resetForm();
     } catch (err) {
       if (err && typeof err === "object" && "errorFields" in err) return;
-      message.error(
-        err instanceof Error ? err.message : t("models.modelAddFailed"),
-      );
-    } finally {
-      setSaving(false);
     }
   };
 
@@ -250,24 +224,18 @@ export function ModelListEditor({
     if (!editingModelId) return;
     try {
       const values = await form.validateFields();
-      setSaving(true);
       const entry = buildModelEntry(values as Record<string, unknown>);
-      // Preserve enabled state from existing model
       const existing = models.find((m) => m.id === editingModelId);
       if (existing) {
         entry.enabled = existing.enabled;
       }
-      const updated = models.map((m) => (m.id === editingModelId ? entry : m));
-      await saveModels(updated);
+      onModelsChange(
+        models.map((m) => (m.id === editingModelId ? entry : m)),
+      );
       message.success(t("models.modelUpdated", { name: entry.name }));
       resetForm();
     } catch (err) {
       if (err && typeof err === "object" && "errorFields" in err) return;
-      message.error(
-        err instanceof Error ? err.message : t("models.modelUpdateFailed"),
-      );
-    } finally {
-      setSaving(false);
     }
   };
 
@@ -306,11 +274,10 @@ export function ModelListEditor({
 
   const isEditing = editingModelId !== null;
   const isFormVisible = adding || isEditing;
-  const hasApiKey = !!provider.api_key;
+  const hasApiKey = canTest ?? !!provider.api_key;
 
   return (
     <div>
-      {/* Model list */}
       <div className={styles.modelList}>
         {models.length === 0 ? (
           <div className={styles.modelListEmpty}>{t("models.noModels")}</div>
@@ -349,7 +316,6 @@ export function ModelListEditor({
                 </div>
                 <div className={styles.modelListItemActions}>
                   {hasApiKey &&
-                    isEnabled &&
                     (isTesting ? (
                       <Button
                         type="text"
@@ -406,7 +372,6 @@ export function ModelListEditor({
         )}
       </div>
 
-      {/* Add / Edit model form */}
       {isFormVisible ? (
         <div className={styles.modelAddForm}>
           <Form form={form} layout="vertical" style={{ marginBottom: 0 }}>
@@ -521,24 +486,25 @@ export function ModelListEditor({
             <div
               style={{ display: "flex", gap: 8, justifyContent: "flex-end" }}
             >
-              <Button size="small" onClick={resetForm}>
-                {t("common.cancel")}
-              </Button>
               {hasApiKey && (
                 <Button
                   size="small"
                   icon={<Zap size={14} />}
                   loading={testingForm}
-                  onClick={handleTestFormModel}
+                  onClick={() => void handleTestFormModel()}
                 >
                   {t("models.testConnection")}
                 </Button>
               )}
+              <Button size="small" onClick={resetForm}>
+                {t("common.cancel")}
+              </Button>
               <Button
                 type="primary"
                 size="small"
-                loading={saving}
-                onClick={isEditing ? handleEditModel : handleAddModel}
+                onClick={() =>
+                  void (isEditing ? handleEditModel() : handleAddModel())
+                }
               >
                 {isEditing ? t("models.saveEdit") : t("models.addModel")}
               </Button>

--- a/dashboard/src/pages/Settings/Models/components/modals/PresetProviderModal.tsx
+++ b/dashboard/src/pages/Settings/Models/components/modals/PresetProviderModal.tsx
@@ -1,16 +1,17 @@
 /**
- * PresetProviderModal — quick setup dialog for a built-in preset provider.
+ * PresetProviderModal — create a provider from preset using unified layout.
  */
-import { useEffect, useState } from "react";
-import { Form, Input, Modal, Tag, message, Button, Space } from "antd";
-import { Zap } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { Button, Divider, Form, Input, Modal, message } from "antd";
+import { Download, Zap } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { request } from "../../../../../api/request";
 import { enrichWizardModel } from "../../wizardModelMeta";
-import type { ProviderPreset, ProviderRow } from "../../useProviders";
-import { PresetModelPicker } from "../PresetModelPicker";
+import type { ProviderModel, ProviderPreset, ProviderRow } from "../../useProviders";
 import { CodexOAuthConnect } from "../CodexOAuthConnect";
-import { testProviderDraft } from "../../providerApi";
+import { fetchProviderModels, testProviderDraft } from "../../providerApi";
+import { ModelListEditor } from "./ModelListEditor";
+import styles from "../../index.module.less";
 
 interface PresetProviderModalProps {
   preset: ProviderPreset;
@@ -23,8 +24,7 @@ interface PresetForm {
   name: string;
   base_url: string;
   api_key?: string;
-  selectedModels: string[];
-  customModel?: string;
+  kind: string;
 }
 
 export function PresetProviderModal({
@@ -36,34 +36,132 @@ export function PresetProviderModal({
   const { t } = useTranslation();
   const [saving, setSaving] = useState(false);
   const [testing, setTesting] = useState(false);
+  const [fetchingModels, setFetchingModels] = useState(false);
+  const [draftModels, setDraftModels] = useState<ProviderModel[]>([]);
   const [form] = Form.useForm<PresetForm>();
   const isOllama = preset.id === "ollama";
   const isCodexOAuth = preset.auth_method === "codex_oauth";
+  const apiKey = Form.useWatch("api_key", form) as string | undefined;
+  const canTest = !!(apiKey?.trim() || isOllama);
+
+  const draftProvider = useMemo<ProviderRow>(
+    () => ({
+      id: 0,
+      name: (form.getFieldValue("name") as string | undefined) || preset.name,
+      kind: preset.protocol,
+      base_url: (form.getFieldValue("base_url") as string | undefined) || preset.base_url,
+      api_key: (form.getFieldValue("api_key") as string | undefined) || (isOllama ? "ollama" : null),
+      models: draftModels,
+      note: null,
+      enabled: true,
+    }),
+    [draftModels, form, isOllama, preset.base_url, preset.name, preset.protocol],
+  );
 
   useEffect(() => {
     if (open) {
+      const baseModels: ProviderModel[] = preset.models.map((m) => {
+        const meta = enrichWizardModel(m, t);
+        const ctx = m.context_window ?? m.max_input_tokens ?? meta.context_window;
+        const entry: ProviderModel = {
+          id: m.id,
+          name: m.name,
+          enabled: true,
+          input: meta.input,
+          thinking: null,
+        };
+        if (meta.reasoning) entry.reasoning = true;
+        if (ctx) entry.context_window = ctx;
+        if (meta.max_tokens) entry.max_tokens = meta.max_tokens;
+        return entry;
+      });
+      setDraftModels(baseModels);
       form.resetFields();
       form.setFieldsValue({
         name: preset.name,
         base_url: preset.base_url,
-        selectedModels: preset.models.map((m) => m.id),
+        kind: preset.protocol,
       });
     }
-  }, [open, preset, form]);
+  }, [open, preset, form, t]);
 
-  const resolveModelId = (values: PresetForm): string | null => {
-    const selectedIds = new Set(values.selectedModels ?? []);
-    const first = preset.models.find((m) => selectedIds.has(m.id));
-    if (first) return first.id;
-    const custom = values.customModel?.trim();
-    return custom || null;
+  const handleFetchModels = async () => {
+    if (isCodexOAuth) return;
+    try {
+      const values = await form.validateFields(["base_url", "api_key"]);
+      const apiKey = values.api_key?.trim() || (isOllama ? "ollama" : "");
+      if (!apiKey) {
+        message.warning(t("models.pleaseEnterApiKey"));
+        return;
+      }
+      setFetchingModels(true);
+      const result = await fetchProviderModels({
+        kind: "openai",
+        api_key: apiKey,
+        base_url: values.base_url?.trim() || preset.base_url,
+      });
+      if (!result.ok) {
+        message.error(
+          t("models.fetchModelsFailed", {
+            error: result.error ?? "unknown",
+          }),
+        );
+        return;
+      }
+      const fetched = result.models ?? [];
+      if (fetched.length === 0) {
+        message.info(t("models.fetchModelsNoNew"));
+        return;
+      }
+      const existingIds = new Set(draftModels.map((m) => m.id));
+      const missing: ProviderModel[] = fetched
+        .filter((m) => !existingIds.has(m.id))
+        .map((m) => ({
+          id: m.id,
+          name: m.name || m.id,
+          enabled: false,
+          input: ["text"],
+          thinking: null,
+        }));
+      if (missing.length === 0) {
+        message.info(t("models.fetchModelsNoNew"));
+        return;
+      }
+      setDraftModels((prev) => [...prev, ...missing]);
+      message.success(t("models.fetchModelsMerged", { count: missing.length }));
+    } catch (err) {
+      if (err && typeof err === "object" && "errorFields" in err) return;
+      message.error(
+        err instanceof Error
+          ? err.message
+          : t("models.fetchModelsFailed", { error: "unknown" }),
+      );
+    } finally {
+      setFetchingModels(false);
+    }
+  };
+
+  const testDraftModel = async (modelId: string) => {
+    const values = await form.validateFields(["name", "base_url", "api_key"]);
+    const key = values.api_key?.trim() || (isOllama ? "ollama" : "");
+    if (!key) {
+      return { ok: false, error: t("models.pleaseEnterApiKey") };
+    }
+    return testProviderDraft({
+      name: values.name.trim(),
+      kind: preset.protocol,
+      api_key: key,
+      base_url: values.base_url?.trim() || preset.base_url,
+      model_id: modelId,
+    });
   };
 
   const handleTest = async () => {
     if (isCodexOAuth) return;
     try {
       const values = await form.validateFields();
-      const modelId = resolveModelId(values);
+      const modelId =
+        draftModels.find((m) => m.enabled !== false)?.id || draftModels[0]?.id;
       if (!modelId) {
         message.warning(t("models.testDraftNeedModel"));
         return;
@@ -74,17 +172,11 @@ export function PresetProviderModal({
         return;
       }
       setTesting(true);
-      const result = await testProviderDraft({
-        name: values.name.trim(),
-        kind: preset.protocol,
-        api_key: apiKey,
-        base_url: values.base_url?.trim() || preset.base_url,
-        model_id: modelId,
-      });
+      const result = await testDraftModel(modelId);
       if (result.ok) {
         message.success(
           t("models.testSuccess", {
-            name: modelId,
+            name: values.name,
             time: result.latency_ms ?? 0,
           }),
         );
@@ -111,39 +203,6 @@ export function PresetProviderModal({
       const values = await form.validateFields();
       setSaving(true);
 
-      const selectedIds = new Set(values.selectedModels ?? []);
-      const modelEntries = preset.models
-        .filter((m) => selectedIds.has(m.id))
-        .map((m) => {
-          const meta = enrichWizardModel(m, t);
-          const entry: Record<string, unknown> = {
-            id: m.id,
-            name: m.name,
-            enabled: true,
-            input: meta.input,
-            thinking: null,
-          };
-          if (meta.reasoning) entry.reasoning = true;
-          const ctx =
-            m.context_window ?? m.max_input_tokens ?? meta.context_window;
-          if (ctx) entry.context_window = ctx;
-          if (meta.max_tokens) entry.max_tokens = meta.max_tokens;
-          return entry;
-        });
-
-      if (values.customModel?.trim()) {
-        const cid = values.customModel.trim();
-        if (!modelEntries.some((m) => m.id === cid)) {
-          modelEntries.push({
-            id: cid,
-            name: cid,
-            enabled: true,
-            input: ["text"],
-            thinking: null,
-          });
-        }
-      }
-
       await request<ProviderRow>("/admin/providers", {
         method: "POST",
         body: JSON.stringify({
@@ -151,7 +210,7 @@ export function PresetProviderModal({
           kind: preset.protocol,
           base_url: values.base_url?.trim() || null,
           api_key: values.api_key?.trim() || (isOllama ? "ollama" : null),
-          models: modelEntries,
+          models: draftModels,
         }),
       });
       message.success(
@@ -188,29 +247,17 @@ export function PresetProviderModal({
       cancelText={t("common.cancel")}
       destroyOnHidden
       width={640}
-      footer={
-        isCodexOAuth ? (
-          <Button onClick={onClose}>{t("common.cancel")}</Button>
-        ) : (
-          <Space>
+      footer={isCodexOAuth ? <Button onClick={onClose}>{t("common.cancel")}</Button> : (
+        <div className={styles.modalFooter}>
+          <div className={styles.modalFooterLeft} />
+          <div className={styles.modalFooterRight}>
             <Button onClick={onClose}>{t("common.cancel")}</Button>
-            <Button
-              icon={<Zap size={14} />}
-              loading={testing}
-              onClick={() => void handleTest()}
-            >
-              {t("models.testConnection")}
-            </Button>
-            <Button
-              type="primary"
-              loading={saving}
-              onClick={() => void handleSubmit()}
-            >
+            <Button type="primary" loading={saving} onClick={() => void handleSubmit()}>
               {t("common.create")}
             </Button>
-          </Space>
-        )
-      }
+          </div>
+        </div>
+      )}
     >
       {isCodexOAuth ? (
         <CodexOAuthConnect
@@ -220,6 +267,7 @@ export function PresetProviderModal({
           }}
         />
       ) : (
+        <>
         <Form form={form} layout="vertical" style={{ marginTop: 16 }}>
           <Form.Item
             name="name"
@@ -229,11 +277,11 @@ export function PresetProviderModal({
             <Input placeholder={preset.name} />
           </Form.Item>
 
-          <Form.Item label={t("models.kindLabel")}>
-            <Tag color="blue">{preset.protocol}</Tag>
+          <Form.Item name="kind" label={t("models.kindLabel")}>
+            <Input disabled style={{ color: "var(--fn-text-secondary)" }} />
           </Form.Item>
 
-          <Form.Item name="base_url" label="Base URL">
+          <Form.Item name="base_url" label="Base URL" extra={t("models.baseUrlExtra")}>
             <Input placeholder={preset.base_url || "https://..."} />
           </Form.Item>
 
@@ -254,34 +302,29 @@ export function PresetProviderModal({
               visibilityToggle
             />
           </Form.Item>
-
-          {preset.models.length > 0 && (
-            <Form.Item
-              name="selectedModels"
-              label={t("models.initialModelsLabel")}
-              rules={[
-                {
-                  validator: (_, ids: string[] | undefined) =>
-                    (ids?.length ?? 0) > 0
-                      ? Promise.resolve()
-                      : Promise.reject(
-                          new Error(t("models.selectAtLeastOneModel")),
-                        ),
-                },
-              ]}
-            >
-              <PresetModelPicker models={preset.models} />
-            </Form.Item>
-          )}
-
-          <Form.Item
-            name="customModel"
-            label={t("models.addModel")}
-            extra={t("models.modelIdPlaceholder")}
-          >
-            <Input placeholder={t("models.modelIdPlaceholder")} />
-          </Form.Item>
         </Form>
+
+        <div style={{ marginBottom: 16 }}>
+          <Button icon={<Zap size={14} />} loading={testing} onClick={() => void handleTest()}>
+            {t("models.testConnection")}
+          </Button>
+          <Button icon={<Download size={14} />} loading={fetchingModels} onClick={() => void handleFetchModels()} style={{ marginLeft: 8 }}>
+            {t("models.fetchModels")}
+          </Button>
+        </div>
+
+        <Divider orientation="left" style={{ fontSize: 13 }}>
+          {t("models.manageModels")}
+        </Divider>
+        <ModelListEditor
+          provider={draftProvider}
+          models={draftModels}
+          onModelsChange={setDraftModels}
+          apiPrefix="/admin/providers"
+          canTest={canTest}
+          onTestModel={(modelId) => testDraftModel(modelId)}
+        />
+        </>
       )}
     </Modal>
   );

--- a/dashboard/src/pages/Settings/Models/components/modals/ProviderConfigModal.tsx
+++ b/dashboard/src/pages/Settings/Models/components/modals/ProviderConfigModal.tsx
@@ -11,8 +11,8 @@ import { Button, Divider, Form, Input, Modal, Select, message } from "antd";
 import { Download, Key, Loader2, Trash2, X, Zap } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { request } from "../../../../../api/request";
-import type { ProviderRow } from "../../useProviders";
-import { testProviderDraft } from "../../providerApi";
+import type { ProviderRow, ProviderModel } from "../../useProviders";
+import { fetchProviderModels, testProviderDraft } from "../../providerApi";
 import { getProviderDocs } from "../../../../../assets/providers";
 import { ModelListEditor } from "./ModelListEditor";
 import styles from "../../index.module.less";
@@ -78,7 +78,9 @@ export function ProviderConfigModal({
   const [saving, setSaving] = useState(false);
   const [formDirty, setFormDirty] = useState(false);
   const [testing, setTesting] = useState(false);
+  const [fetchingModels, setFetchingModels] = useState(false);
   const [form] = Form.useForm<ProviderConfigForm>();
+  const [draftModels, setDraftModels] = useState<ProviderModel[]>([]);
 
   const hasApiKey = !!provider.api_key && provider.api_key.length > 0;
   const isOllama = isOllamaProvider(provider);
@@ -304,21 +306,32 @@ export function ProviderConfigModal({
   }, [hasApiKey, t]);
 
   useEffect(() => {
-    if (open) {
-      // Derive current default model: first from models list
-      const currentDefaultModel = provider.models?.length
-        ? provider.models[0].id
-        : "";
-      form.setFieldsValue({
-        kind: provider.kind,
-        base_url: provider.base_url ?? "",
-        api_key: undefined,
-        model: currentDefaultModel,
-        note: provider.note ?? "",
-      });
-      setFormDirty(false);
-    }
-  }, [provider, form, open]);
+    if (!open) return;
+    // Only hydrate when the modal opens (or provider id changes), so
+    // background refreshes / local model toggles do not reset the form.
+    const currentDefaultModel = provider.models?.length
+      ? provider.models[0].id
+      : "";
+    form.setFieldsValue({
+      kind: provider.kind,
+      base_url: provider.base_url ?? "",
+      api_key: undefined,
+      model: currentDefaultModel,
+      note: provider.note ?? "",
+    });
+    setDraftModels(
+      (provider.models ?? []).map((m) => ({
+        ...m,
+        enabled: m.enabled !== false,
+      })),
+    );
+    setFormDirty(false);
+  }, [open, provider.id, form]);
+
+  const handleModelsChange = (models: ProviderModel[]) => {
+    setDraftModels(models);
+    setFormDirty(true);
+  };
 
   const handleSubmit = async () => {
     try {
@@ -339,6 +352,17 @@ export function ProviderConfigModal({
         : "";
       if ((values.model ?? "") !== existingDefault)
         payload.model = values.model?.trim() || null;
+
+      const modelsChanged =
+        JSON.stringify(
+          (provider.models ?? []).map((m) => ({
+            ...m,
+            enabled: m.enabled !== false,
+          })),
+        ) !== JSON.stringify(draftModels);
+      if (modelsChanged) {
+        payload.models = draftModels;
+      }
 
       if (Object.keys(payload).length === 0) {
         message.info(t("models.noChanges"));
@@ -397,8 +421,8 @@ export function ProviderConfigModal({
       const values = form.getFieldsValue();
       const modelId =
         (values.model as string | undefined)?.trim() ||
-        provider.models?.find((m) => m.enabled)?.id ||
-        provider.models?.[0]?.id;
+        draftModels.find((m) => m.enabled !== false)?.id ||
+        draftModels[0]?.id;
       if (!modelId) {
         message.warning(t("models.testDraftNeedModel"));
         return;
@@ -456,6 +480,70 @@ export function ProviderConfigModal({
       );
     } finally {
       setTesting(false);
+    }
+  };
+
+  const handleFetchModels = async () => {
+    try {
+      const values = form.getFieldsValue();
+      const kind = (values.kind as string | undefined) ?? provider.kind;
+      if (kind !== "openai") {
+        message.warning(t("models.fetchModelsUnsupportedKind"));
+        return;
+      }
+      const draftApiKey = (values.api_key as string | undefined)?.trim();
+      const draftBaseUrl = (values.base_url as string | undefined)?.trim();
+      const apiKey = draftApiKey || provider.api_key || "";
+      if (!apiKey) {
+        message.warning(t("models.pleaseEnterApiKey"));
+        return;
+      }
+
+      setFetchingModels(true);
+      const result = await fetchProviderModels({
+        kind: "openai",
+        api_key: apiKey,
+        base_url: draftBaseUrl || provider.base_url,
+      });
+      if (!result.ok) {
+        message.error(
+          t("models.fetchModelsFailed", {
+            error: result.error ?? "unknown",
+          }),
+        );
+        return;
+      }
+      const fetched = result.models ?? [];
+      if (fetched.length === 0) {
+        message.info(t("models.fetchModelsNoNew"));
+        return;
+      }
+
+      const existingIds = new Set(draftModels.map((m) => m.id));
+      const missing = fetched.filter((m) => !existingIds.has(m.id));
+      if (missing.length === 0) {
+        message.info(t("models.fetchModelsNoNew"));
+        return;
+      }
+
+      const added: ProviderModel[] = missing.map((m) => ({
+        id: m.id,
+        name: m.name || m.id,
+        enabled: false,
+        input: ["text"],
+        thinking: null,
+      }));
+      setDraftModels((prev) => [...prev, ...added]);
+      setFormDirty(true);
+      message.success(t("models.fetchModelsMerged", { count: missing.length }));
+    } catch (err) {
+      message.error(
+        err instanceof Error
+          ? err.message
+          : t("models.fetchModelsFailed", { error: "unknown" }),
+      );
+    } finally {
+      setFetchingModels(false);
     }
   };
 
@@ -524,12 +612,12 @@ export function ProviderConfigModal({
             "测试连接时使用此模型；留空则使用第一个已启用的模型",
           )}
         >
-          {provider.models?.length ? (
+          {draftModels.length ? (
             <Select
               showSearch
               allowClear
               placeholder={t("models.defaultModelPlaceholder")}
-              options={provider.models.map((m) => ({
+              options={draftModels.map((m) => ({
                 value: m.id,
                 label: m.name !== m.id ? `${m.name} (${m.id})` : m.id,
               }))}
@@ -553,15 +641,15 @@ export function ProviderConfigModal({
         >
           {t("models.testConnection")}
         </Button>
-        <span
-          style={{
-            fontSize: 11,
-            color: "var(--fn-text-quaternary)",
-            marginLeft: 8,
-          }}
+        <Button
+          size="small"
+          icon={<Download size={12} />}
+          loading={fetchingModels}
+          onClick={handleFetchModels}
+          style={{ marginLeft: 8 }}
         >
-          {t("models.testPingHint")}
-        </span>
+          {t("models.fetchModels")}
+        </Button>
       </div>
 
       {/* ===== Models section ===== */}
@@ -571,7 +659,8 @@ export function ProviderConfigModal({
 
       <ModelListEditor
         provider={provider}
-        onSaved={onSaved}
+        models={draftModels}
+        onModelsChange={handleModelsChange}
         apiPrefix={apiPrefix}
       />
 

--- a/dashboard/src/pages/Settings/Models/index.module.less
+++ b/dashboard/src/pages/Settings/Models/index.module.less
@@ -705,10 +705,9 @@
 }
 
 .modelListItemDisabled {
-  opacity: 0.5;
+  opacity: 0.55;
 
   .modelListItemName {
-    text-decoration: line-through;
     color: var(--fn-text-tertiary);
   }
 }

--- a/dashboard/src/pages/Settings/Models/providerApi.ts
+++ b/dashboard/src/pages/Settings/Models/providerApi.ts
@@ -31,6 +31,38 @@ export async function testProviderDraft(
   });
 }
 
+export interface FetchProviderModelsParams {
+  kind: string;
+  api_key?: string;
+  base_url?: string | null;
+  extra_json?: string | null;
+}
+
+export interface FetchedProviderModel {
+  id: string;
+  name: string;
+}
+
+export interface FetchProviderModelsResult {
+  ok: boolean;
+  models?: FetchedProviderModel[];
+  error?: string;
+}
+
+export async function fetchProviderModels(
+  params: FetchProviderModelsParams,
+): Promise<FetchProviderModelsResult> {
+  return request<FetchProviderModelsResult>("/admin/providers/fetch-models", {
+    method: "POST",
+    body: JSON.stringify({
+      kind: params.kind,
+      api_key: params.api_key?.trim() || null,
+      base_url: params.base_url?.trim() || null,
+      extra_json: params.extra_json ?? null,
+    }),
+  });
+}
+
 export async function startCodexOAuth() {
   return request<{
     state_id: string;

--- a/dashboard/src/pages/Settings/Models/useProviders.ts
+++ b/dashboard/src/pages/Settings/Models/useProviders.ts
@@ -3,7 +3,7 @@
  *
  * Fetches all providers and presets via the admin endpoints.
  */
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { request } from "../../../api/request";
 import { providerApi } from "../../../api/modules/provider";
@@ -82,9 +82,12 @@ export function useProviders(): UseProvidersResult {
   });
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const hasLoadedRef = useRef(false);
 
   const fetchAll = useCallback(async () => {
-    setLoading(true);
+    // Only show full-page loading on first load so open config modals
+    // are not unmounted by subsequent refreshes.
+    if (!hasLoadedRef.current) setLoading(true);
     setError(null);
     try {
       const [rows, presetList, resolved, active] = await Promise.all([
@@ -121,6 +124,7 @@ export function useProviders(): UseProvidersResult {
       console.error("Failed to load providers:", err);
       setError(msg);
     } finally {
+      hasLoadedRef.current = true;
       setLoading(false);
     }
   }, [t]);

--- a/src/octop/api/routers/providers.py
+++ b/src/octop/api/routers/providers.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+from types import SimpleNamespace
 from typing import Any, cast
 
 from fastapi import APIRouter, Depends
@@ -13,8 +14,10 @@ from pydantic import BaseModel
 from octop.api.deps import current_admin, current_user, get_server
 from octop.infra.agents.providers.presets import load_provider_presets
 from octop.infra.agents.providers.probe import (
+    fetch_openai_compatible_models,
     make_probe_provider_row,
     probe_provider_row,
+    provider_headers,
 )
 from octop.infra.agents.providers.resolved import list_resolved_models as _list_resolved_models
 from octop.infra.errors import ErrorCode, OctopError
@@ -81,18 +84,11 @@ class ProviderTestDraftBody(BaseModel):
     extra_json: str | None = None
 
 
-def _provider_headers(row: Any) -> dict[str, str]:
-    raw = getattr(row, "extra_json", None)
-    if not raw:
-        return {}
-    try:
-        extra = json.loads(raw)
-    except Exception:
-        return {}
-    if not isinstance(extra, dict):
-        return {}
-    headers = extra.get("headers")
-    return dict(headers) if isinstance(headers, dict) else {}
+class ProviderFetchModelsBody(BaseModel):
+    kind: str
+    api_key: str | None = None
+    base_url: str | None = None
+    extra_json: str | None = None
 
 
 def _is_codex_base_url(base_url: str | None) -> bool:
@@ -290,6 +286,28 @@ async def admin_test_provider_draft(
         extra_json=body.extra_json,
     )
     return await probe_provider_row(row, model_id=model_id)
+
+
+@admin_router.post("/fetch-models", summary="List models from an OpenAI-compatible draft")
+async def admin_fetch_provider_models(
+    body: ProviderFetchModelsBody,
+    _: Any = Depends(current_admin),
+) -> dict[str, Any]:
+    """Fetch remote model ids via OpenAI-compatible ``GET /models`` (openai kind only)."""
+    if body.kind != "openai":
+        return {
+            "ok": False,
+            "error": "fetch models is only supported for openai-compatible providers",
+        }
+    api_key = (body.api_key or "").strip()
+    if not api_key:
+        return {"ok": False, "error": "api_key is required"}
+    draft = SimpleNamespace(extra_json=body.extra_json)
+    return await fetch_openai_compatible_models(
+        base_url=(body.base_url or "").strip() or None,
+        api_key=api_key,
+        extra_headers=provider_headers(draft) or None,
+    )
 
 
 async def _run_codex_device_poll(

--- a/src/octop/infra/agents/providers/probe.py
+++ b/src/octop/infra/agents/providers/probe.py
@@ -9,9 +9,14 @@ import time
 from types import SimpleNamespace
 from typing import Any
 
+import httpx
+
 from octop.infra.agents.providers import KIND_TO_PROTOCOL
 
 logger = logging.getLogger(__name__)
+
+_DEFAULT_OPENAI_BASE_URL = "https://api.openai.com/v1"
+_FETCH_MODELS_TIMEOUT_S = 30.0
 
 
 def provider_headers(row: Any) -> dict[str, str]:
@@ -102,3 +107,67 @@ async def probe_provider_row(row: Any, *, model_id: str | None = None) -> dict[s
     latency_ms = int((time.perf_counter() - started) * 1000)
     _ = getattr(result, "content", None)
     return {"ok": True, "latency_ms": latency_ms}
+
+
+def _models_list_url(base_url: str | None) -> str:
+    root = (base_url or "").strip().rstrip("/") or _DEFAULT_OPENAI_BASE_URL
+    return f"{root}/models"
+
+
+async def fetch_openai_compatible_models(
+    *,
+    base_url: str | None,
+    api_key: str,
+    extra_headers: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    """List models via OpenAI-compatible ``GET {base}/models``."""
+    url = _models_list_url(base_url)
+    headers: dict[str, str] = {"Authorization": f"Bearer {api_key}"}
+    if extra_headers:
+        headers.update(extra_headers)
+    try:
+        async with httpx.AsyncClient(timeout=_FETCH_MODELS_TIMEOUT_S) as client:
+            response = await client.get(url, headers=headers)
+    except Exception as exc:
+        logger.info("provider fetch-models failed for %s: %s", url, exc)
+        return {"ok": False, "error": str(exc)}
+
+    if response.status_code >= 400:
+        detail = response.text.strip()
+        if len(detail) > 300:
+            detail = detail[:300] + "…"
+        error = f"HTTP {response.status_code}"
+        if detail:
+            error = f"{error}: {detail}"
+        return {"ok": False, "error": error}
+
+    try:
+        payload = response.json()
+    except Exception:
+        return {
+            "ok": False,
+            "error": "response is not valid JSON (expected OpenAI-compatible /models)",
+        }
+
+    data = payload.get("data") if isinstance(payload, dict) else None
+    if not isinstance(data, list):
+        return {
+            "ok": False,
+            "error": "response is not OpenAI-compatible (expected {data: [{id, …}]})",
+        }
+
+    models: list[dict[str, str]] = []
+    seen: set[str] = set()
+    for item in data:
+        if not isinstance(item, dict):
+            continue
+        mid = item.get("id")
+        if not isinstance(mid, str) or not mid.strip():
+            continue
+        mid = mid.strip()
+        if mid in seen:
+            continue
+        seen.add(mid)
+        models.append({"id": mid, "name": mid})
+    models.sort(key=lambda m: m["id"])
+    return {"ok": True, "models": models}

--- a/tests/integration/test_provider_fetch_models.py
+++ b/tests/integration/test_provider_fetch_models.py
@@ -1,0 +1,67 @@
+"""Integration tests for admin provider fetch-models endpoint."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+
+async def test_admin_fetch_models_requires_api_key(env: Any) -> None:
+    client, _srv, auth = env
+    r = await client.post(
+        "/api/admin/providers/fetch-models",
+        headers=auth,
+        json={
+            "kind": "openai",
+            "api_key": "",
+            "base_url": "https://api.example.com/v1",
+        },
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["ok"] is False
+    assert "api_key" in body["error"]
+
+
+async def test_admin_fetch_models_rejects_non_openai_kind(env: Any) -> None:
+    client, _srv, auth = env
+    r = await client.post(
+        "/api/admin/providers/fetch-models",
+        headers=auth,
+        json={
+            "kind": "anthropic",
+            "api_key": "sk-test",
+            "base_url": "https://api.anthropic.com",
+        },
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["ok"] is False
+    assert "openai" in body["error"].lower()
+
+
+async def test_admin_fetch_models_success(env: Any) -> None:
+    client, _srv, auth = env
+    fake = {
+        "ok": True,
+        "models": [{"id": "gpt-4o", "name": "gpt-4o"}],
+    }
+    with patch(
+        "octop.api.routers.providers.fetch_openai_compatible_models",
+        new=AsyncMock(return_value=fake),
+    ) as mocked:
+        r = await client.post(
+            "/api/admin/providers/fetch-models",
+            headers=auth,
+            json={
+                "kind": "openai",
+                "api_key": "sk-test",
+                "base_url": "https://api.example.com/v1",
+            },
+        )
+    assert r.status_code == 200, r.text
+    assert r.json() == fake
+    mocked.assert_awaited_once()
+    kwargs = mocked.await_args.kwargs
+    assert kwargs["api_key"] == "sk-test"
+    assert kwargs["base_url"] == "https://api.example.com/v1"

--- a/tests/unit/test_provider_fetch_models.py
+++ b/tests/unit/test_provider_fetch_models.py
@@ -1,0 +1,133 @@
+"""Unit tests for OpenAI-compatible remote model listing."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from octop.infra.agents.providers.probe import fetch_openai_compatible_models
+
+
+def _mock_response(status: int, payload: Any) -> httpx.Response:
+    request = httpx.Request("GET", "https://api.example.com/v1/models")
+    return httpx.Response(status, json=payload, request=request)
+
+
+@pytest.mark.asyncio
+async def test_fetch_models_parses_openai_list() -> None:
+    response = _mock_response(
+        200,
+        {"data": [{"id": "gpt-4o"}, {"id": "gpt-4o-mini", "owned_by": "system"}]},
+    )
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("octop.infra.agents.providers.probe.httpx.AsyncClient", return_value=mock_client):
+        result = await fetch_openai_compatible_models(
+            base_url="https://api.example.com/v1",
+            api_key="sk-test",
+        )
+
+    assert result["ok"] is True
+    assert result["models"] == [
+        {"id": "gpt-4o", "name": "gpt-4o"},
+        {"id": "gpt-4o-mini", "name": "gpt-4o-mini"},
+    ]
+    mock_client.get.assert_awaited_once()
+    args, kwargs = mock_client.get.await_args
+    assert args[0] == "https://api.example.com/v1/models"
+    assert kwargs["headers"]["Authorization"] == "Bearer sk-test"
+
+
+@pytest.mark.asyncio
+async def test_fetch_models_defaults_openai_base_url() -> None:
+    response = _mock_response(200, {"data": []})
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("octop.infra.agents.providers.probe.httpx.AsyncClient", return_value=mock_client):
+        result = await fetch_openai_compatible_models(base_url=None, api_key="sk-test")
+
+    assert result["ok"] is True
+    assert result["models"] == []
+    assert mock_client.get.await_args.args[0] == "https://api.openai.com/v1/models"
+
+
+@pytest.mark.asyncio
+async def test_fetch_models_rejects_non_openai_payload() -> None:
+    response = _mock_response(200, {"models": ["gpt-4o"]})
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("octop.infra.agents.providers.probe.httpx.AsyncClient", return_value=mock_client):
+        result = await fetch_openai_compatible_models(
+            base_url="https://api.example.com/v1",
+            api_key="sk-test",
+        )
+
+    assert result["ok"] is False
+    assert "OpenAI" in result["error"] or "compatible" in result["error"].lower()
+
+
+@pytest.mark.asyncio
+async def test_fetch_models_auth_error() -> None:
+    response = _mock_response(401, {"error": {"message": "invalid key"}})
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("octop.infra.agents.providers.probe.httpx.AsyncClient", return_value=mock_client):
+        result = await fetch_openai_compatible_models(
+            base_url="https://api.example.com/v1",
+            api_key="bad",
+        )
+
+    assert result["ok"] is False
+    assert "401" in result["error"] or "invalid" in result["error"].lower()
+
+
+@pytest.mark.asyncio
+async def test_fetch_models_merges_extra_headers() -> None:
+    response = _mock_response(200, {"data": [{"id": "m1"}]})
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("octop.infra.agents.providers.probe.httpx.AsyncClient", return_value=mock_client):
+        await fetch_openai_compatible_models(
+            base_url="https://api.example.com/v1/",
+            api_key="sk-test",
+            extra_headers={"X-Custom": "1"},
+        )
+
+    headers = mock_client.get.await_args.kwargs["headers"]
+    assert headers["Authorization"] == "Bearer sk-test"
+    assert headers["X-Custom"] == "1"
+
+
+@pytest.mark.asyncio
+async def test_fetch_models_connection_error() -> None:
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(side_effect=httpx.ConnectError("boom"))
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("octop.infra.agents.providers.probe.httpx.AsyncClient", return_value=mock_client):
+        result = await fetch_openai_compatible_models(
+            base_url="https://api.example.com/v1",
+            api_key="sk-test",
+        )
+
+    assert result["ok"] is False
+    assert result["error"]


### PR DESCRIPTION
## Summary
- unify custom/preset/config provider dialogs into a shared layout: connection form, action bar, and model management section
- add OpenAI-compatible model fetching in config and preset dialogs with merge behavior (only append missing models, keep existing entries unchanged)
- move model editing to a shared draft-based `ModelListEditor` flow so toggles/edits/deletes are persisted only after explicit save
- add backend fetch-model endpoint coverage and probe helper unit tests for model-list retrieval behavior

## Test plan
- [x] `uv run pytest tests/unit/test_provider_fetch_models.py tests/integration/test_provider_fetch_models.py tests/unit/test_provider_probe.py tests/integration/test_provider_test_draft.py -q`
- [x] `cd dashboard && npx tsc --noEmit`

Made with [Cursor](https://cursor.com)