### PR TITLE
fix: import complete GitHub skill bundles

### DIFF
--- a/src/octop/infra/agents/skills_hub.py
+++ b/src/octop/infra/agents/skills_hub.py
@@ -3,17 +3,20 @@
 from __future__ import annotations
 
 import base64
+import io
 import json
 import logging
 import os
 import re
 import time
+import zipfile
 from dataclasses import dataclass
 from typing import Any
 from urllib.error import HTTPError, URLError
-from urllib.parse import unquote, urlencode, urlparse
+from urllib.parse import quote, unquote, urlencode, urlparse
 from urllib.request import Request, urlopen
 
+from octop.infra.agents.skill_packages import MAX_SKILL_BYTES, MAX_SKILL_FILES
 from octop.infra.utils.frontmatter import parse_frontmatter
 
 logger = logging.getLogger(__name__)
@@ -275,6 +278,92 @@ def _http_text_get(url: str, params: dict[str, Any] | None = None) -> str:
         params=params,
         accept="text/plain, text/markdown, */*",
     )
+
+
+def _http_bytes_get(
+    url: str,
+    params: dict[str, Any] | None = None,
+    accept: str = "application/octet-stream, application/zip, */*",
+    max_bytes: int = MAX_SKILL_BYTES * 4,
+) -> bytes:
+    full_url = url
+    if params:
+        full_url = f"{url}?{urlencode(params)}"
+    req = Request(
+        full_url,
+        headers={
+            "Accept": accept,
+            "User-Agent": "octop-skills-hub/1.0",
+        },
+    )
+    retries = _hub_http_retries()
+    timeout = _hub_http_timeout()
+    attempts = retries + 1
+    last_error: Exception | None = None
+    for attempt in range(1, attempts + 1):
+        try:
+            with urlopen(req, timeout=timeout) as resp:
+                chunks: list[bytes] = []
+                total = 0
+                while True:
+                    chunk = resp.read(64 * 1024)
+                    if not chunk:
+                        break
+                    total += len(chunk)
+                    if total > max_bytes:
+                        raise ValueError(
+                            f"Remote archive exceeds size limit ({max_bytes} bytes)"
+                        )
+                    chunks.append(chunk)
+                return b"".join(chunks)
+        except HTTPError as e:
+            last_error = e
+            status = getattr(e, "code", 0) or 0
+            if attempt < attempts and status in RETRYABLE_HTTP_STATUS:
+                delay = _compute_backoff_seconds(attempt)
+                logger.warning(
+                    "Hub HTTP %s on %s (attempt %d/%d), retrying in %.2fs",
+                    status,
+                    full_url,
+                    attempt,
+                    attempts,
+                    delay,
+                )
+                time.sleep(delay)
+                continue
+            raise
+        except URLError as e:
+            last_error = e
+            if attempt < attempts:
+                delay = _compute_backoff_seconds(attempt)
+                logger.warning(
+                    "Hub URL error on %s (attempt %d/%d), retrying in %.2fs: %s",
+                    full_url,
+                    attempt,
+                    attempts,
+                    delay,
+                    e,
+                )
+                time.sleep(delay)
+                continue
+            raise
+        except TimeoutError as e:
+            last_error = e
+            if attempt < attempts:
+                delay = _compute_backoff_seconds(attempt)
+                logger.warning(
+                    "Hub timeout on %s (attempt %d/%d), retrying in %.2fs",
+                    full_url,
+                    attempt,
+                    attempts,
+                    delay,
+                )
+                time.sleep(delay)
+                continue
+            raise
+    if last_error is not None:
+        raise last_error
+    raise RuntimeError(f"Failed to request hub URL: {full_url}")
 
 
 def _norm_search_items(data: Any) -> list[dict[str, Any]]:
@@ -668,6 +757,10 @@ def _github_raw_url(owner: str, repo: str, ref: str, path: str) -> str:
     return f"https://raw.githubusercontent.com/{owner}/{repo}/{ref}/{cleaned}"
 
 
+def _github_archive_url(owner: str, repo: str, ref: str) -> str:
+    return f"https://github.com/{owner}/{repo}/archive/{quote(ref, safe='')}.zip"
+
+
 def _github_has_token() -> bool:
     return bool(os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN"))
 
@@ -707,6 +800,13 @@ def _branch_candidates(owner: str, repo: str, requested_version: str) -> list[st
 def _skill_md_root_candidates(skill_hint: str) -> list[str]:
     skill = skill_hint.strip()
     if skill:
+        if skill.startswith("skills/"):
+            trimmed = skill[len("skills/") :].strip("/")
+            candidates = [skill]
+            if trimmed:
+                candidates.append(trimmed)
+            candidates.append("")
+            return candidates
         return [
             _join_repo_path("skills", skill),
             skill,
@@ -747,6 +847,51 @@ def _find_skill_bundle_via_raw(
                             raise
             return branch, root, files
     return None
+
+
+def _github_collect_archive_files(
+    owner: str,
+    repo: str,
+    ref: str,
+    root: str,
+    *,
+    max_files: int = MAX_SKILL_FILES,
+) -> dict[str, str]:
+    root_prefix = root.strip("/")
+    payload = _http_bytes_get(_github_archive_url(owner, repo, ref))
+    files: dict[str, str] = {}
+    with zipfile.ZipFile(io.BytesIO(payload)) as archive:
+        for member in archive.infolist():
+            if member.is_dir():
+                continue
+            path = member.filename.replace("\\", "/")
+            if "/" not in path:
+                continue
+            rel_repo_path = path.split("/", 1)[1]
+            if root_prefix:
+                prefix = f"{root_prefix}/"
+                if rel_repo_path == root_prefix:
+                    continue
+                if not rel_repo_path.startswith(prefix):
+                    continue
+                rel = rel_repo_path[len(prefix) :]
+            else:
+                rel = rel_repo_path
+            if not rel:
+                continue
+            try:
+                content = archive.read(member).decode("utf-8")
+            except UnicodeDecodeError:
+                logger.warning("Skip non-UTF8 file in GitHub archive: %s", rel_repo_path)
+                continue
+            files[rel] = content
+            if len(files) > max_files:
+                raise ValueError(
+                    f"GitHub archive has too many files under selected path ({max_files} max)"
+                )
+    if "SKILL.md" not in files:
+        raise ValueError("GitHub archive does not contain SKILL.md under selected path")
+    return files
 
 
 def _github_get_default_branch(owner: str, repo: str) -> str:
@@ -1004,7 +1149,18 @@ def _fetch_bundle_from_github_repo(
         requested_version,
     )
     if raw_bundle is not None:
-        _branch, _root, raw_files = raw_bundle
+        branch, root, raw_files = raw_bundle
+        try:
+            archive_files = _github_collect_archive_files(owner, repo, branch, root)
+            return {"name": display_name, "files": archive_files}, source_url
+        except Exception as exc:
+            logger.warning(
+                "GitHub archive fetch failed for %s/%s@%s (%s), falling back to raw/API",
+                owner,
+                repo,
+                branch,
+                exc,
+            )
         return {"name": display_name, "files": raw_files}, source_url
 
     if not _github_has_token():
@@ -1098,6 +1254,40 @@ def _fetch_bundle_from_github_url(
     elif path_hint == "SKILL.md":
         path_hint = ""
     branch = requested_version.strip() or branch_in_url.strip()
+    if (
+        requested_version.strip() == ""
+        and branch_in_url.strip()
+        and "/skills/" in path_hint
+        and not path_hint.startswith("skills/")
+    ):
+        extra_branch, skill_path = path_hint.split("/skills/", 1)
+        if extra_branch.strip():
+            branch = f"{branch_in_url.strip()}/{extra_branch.strip('/')}"
+            path_hint = f"skills/{skill_path}"
+    if (
+        requested_version.strip() == ""
+        and branch_in_url.strip()
+        and path_hint
+        and "/" in path_hint
+        and _find_skill_bundle_via_raw(owner, repo, path_hint, branch) is None
+    ):
+        # GitHub tree URLs encode branch and path in one slash-delimited tail.
+        # Try all split points to recover branch names like "feature/x".
+        tail = [branch_in_url.strip(), *[p for p in path_hint.split("/") if p]]
+        for split in range(len(tail), 0, -1):
+            candidate_branch = "/".join(tail[:split]).strip("/")
+            candidate_path = "/".join(tail[split:]).strip("/")
+            if not candidate_branch:
+                continue
+            if _find_skill_bundle_via_raw(
+                owner,
+                repo,
+                candidate_path,
+                candidate_branch,
+            ) is not None:
+                branch = candidate_branch
+                path_hint = candidate_path
+                break
     return _fetch_bundle_from_repo_and_skill_hint(
         owner=owner,
         repo=repo,

--- a/src/octop/infra/agents/skills_hub.py
+++ b/src/octop/infra/agents/skills_hub.py
@@ -311,9 +311,7 @@ def _http_bytes_get(
                         break
                     total += len(chunk)
                     if total > max_bytes:
-                        raise ValueError(
-                            f"Remote archive exceeds size limit ({max_bytes} bytes)"
-                        )
+                        raise ValueError(f"Remote archive exceeds size limit ({max_bytes} bytes)")
                     chunks.append(chunk)
                 return b"".join(chunks)
         except HTTPError as e:
@@ -1279,12 +1277,15 @@ def _fetch_bundle_from_github_url(
             candidate_path = "/".join(tail[split:]).strip("/")
             if not candidate_branch:
                 continue
-            if _find_skill_bundle_via_raw(
-                owner,
-                repo,
-                candidate_path,
-                candidate_branch,
-            ) is not None:
+            if (
+                _find_skill_bundle_via_raw(
+                    owner,
+                    repo,
+                    candidate_path,
+                    candidate_branch,
+                )
+                is not None
+            ):
                 branch = candidate_branch
                 path_hint = candidate_path
                 break

--- a/tests/unit/agents/test_skills_hub_raw.py
+++ b/tests/unit/agents/test_skills_hub_raw.py
@@ -3,17 +3,17 @@
 from __future__ import annotations
 
 import io
+import zipfile
 from unittest.mock import patch
 from urllib.error import HTTPError
-import zipfile
 
 import pytest
 
+from octop.infra.agents import skills_hub
 from octop.infra.agents.skills_hub import (
     is_supported_skill_url,
     resolve_bundle_from_url,
 )
-from octop.infra.agents import skills_hub
 
 FIND_SKILLS_MD = """---
 name: find-skills

--- a/tests/unit/agents/test_skills_hub_raw.py
+++ b/tests/unit/agents/test_skills_hub_raw.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import io
 from unittest.mock import patch
 from urllib.error import HTTPError
+import zipfile
 
 import pytest
 
@@ -11,6 +13,7 @@ from octop.infra.agents.skills_hub import (
     is_supported_skill_url,
     resolve_bundle_from_url,
 )
+from octop.infra.agents import skills_hub
 
 FIND_SKILLS_MD = """---
 name: find-skills
@@ -75,6 +78,93 @@ def test_resolve_skills_sh_url_falls_back_to_second_branch(
         )
 
     assert resolved.name == "find-skills"
+
+
+def test_resolve_github_url_imports_all_files_from_skill_directory_without_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+
+    def _fake_http_text_get(url: str, params: dict | None = None) -> str:
+        del params
+        if url.endswith("/skills/find-skills/SKILL.md"):
+            return FIND_SKILLS_MD
+        raise HTTPError(url, 404, "Not Found", None, None)
+
+    archive = io.BytesIO()
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr("skills-repo-main/README.md", "repo root")
+        zf.writestr("skills-repo-main/skills/find-skills/SKILL.md", FIND_SKILLS_MD)
+        zf.writestr("skills-repo-main/skills/find-skills/references/doc.md", "# ref")
+        zf.writestr("skills-repo-main/skills/find-skills/scripts/run.sh", "echo ok")
+        zf.writestr("skills-repo-main/skills/find-skills/meta/config.json", "{}")
+
+    with (
+        patch("octop.infra.agents.skills_hub._http_text_get", side_effect=_fake_http_text_get),
+        patch("octop.infra.agents.skills_hub._http_bytes_get", return_value=archive.getvalue()),
+    ):
+        resolved = resolve_bundle_from_url(
+            bundle_url="https://github.com/example/skills-repo/tree/main/skills/find-skills",
+        )
+
+    uploads = dict(resolved.uploads)
+    assert resolved.name == "find-skills"
+    assert "skills/find-skills/SKILL.md" in uploads
+    assert uploads["skills/find-skills/references/doc.md"] == b"# ref"
+    assert uploads["skills/find-skills/scripts/run.sh"] == b"echo ok"
+    assert uploads["skills/find-skills/meta/config.json"] == b"{}"
+
+
+def test_resolve_github_url_with_slash_branch_uses_encoded_archive_ref(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    seen_archive_url: list[str] = []
+
+    def _fake_http_text_get(url: str, params: dict | None = None) -> str:
+        del params
+        if "/feature/x/" in url and url.endswith("/skills/find-skills/SKILL.md"):
+            return FIND_SKILLS_MD
+        raise HTTPError(url, 404, "Not Found", None, None)
+
+    def _fake_http_bytes_get(url: str, *args: object, **kwargs: object) -> bytes:
+        del args, kwargs
+        seen_archive_url.append(url)
+        archive = io.BytesIO()
+        with zipfile.ZipFile(archive, "w") as zf:
+            zf.writestr("skills-repo-feature-x/skills/find-skills/SKILL.md", FIND_SKILLS_MD)
+        return archive.getvalue()
+
+    with (
+        patch("octop.infra.agents.skills_hub._http_text_get", side_effect=_fake_http_text_get),
+        patch("octop.infra.agents.skills_hub._http_bytes_get", side_effect=_fake_http_bytes_get),
+    ):
+        resolved = resolve_bundle_from_url(
+            bundle_url="https://github.com/example/skills-repo/tree/feature/x/skills/find-skills",
+        )
+
+    assert resolved.name == "find-skills"
+    assert seen_archive_url == ["https://github.com/example/skills-repo/archive/feature%2Fx.zip"]
+
+
+def test_github_archive_rejects_too_many_files(monkeypatch: pytest.MonkeyPatch) -> None:
+    archive = io.BytesIO()
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr("skills-repo-main/skills/find-skills/SKILL.md", FIND_SKILLS_MD)
+        zf.writestr("skills-repo-main/skills/find-skills/a.txt", "a")
+
+    monkeypatch.setattr(skills_hub, "_http_bytes_get", lambda *_a, **_k: archive.getvalue())
+
+    with pytest.raises(ValueError, match="too many files"):
+        skills_hub._github_collect_archive_files(
+            "example",
+            "skills-repo",
+            "main",
+            "skills/find-skills",
+            max_files=1,
+        )
 
 
 def test_custom_import_source_can_be_enabled_without_frontend_changes(


### PR DESCRIPTION
## Summary
- import the full skill directory from GitHub archive downloads instead of only preserving `SKILL.md`
- harden GitHub archive fetching for encoded branch refs, file-count limits, and streamed size guards
- add unit coverage for multi-file imports, slash-containing branch names, and archive overflow rejection

## Test plan
- [x] `uv run pytest tests/unit/agents/test_skills_hub_raw.py -q`
- [x] `uv run pytest tests/integration/test_skills_api.py -k import_skill_from_url -q`

Made with [Cursor](https://cursor.com)