### PR TITLE
fix(ci): dispatch Release/Docker after auto-tag

### DIFF
--- a/.github/workflows/auto-tag-on-release.yml
+++ b/.github/workflows/auto-tag-on-release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 jobs:
   tag:
@@ -61,3 +62,14 @@ jobs:
           tag="${{ steps.version.outputs.tag }}"
           git tag "$tag"
           git push origin "$tag"
+
+      # GITHUB_TOKEN tag pushes do not cascade to other workflows. Explicitly
+      # dispatch Release / Docker Publish (workflow_dispatch is exempt).
+      - name: Trigger Release and Docker Publish
+        if: steps.check_tag.outputs.should_publish == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tag="${{ steps.version.outputs.tag }}"
+          gh workflow run release.yml --ref "$tag"
+          gh workflow run docker-publish.yml --ref "$tag"

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,6 +7,9 @@ on:
   push:
     tags:
       - "v*"
+  # Allow Auto Tag On Release Merge to cascade after a GITHUB_TOKEN tag push
+  # (token-authored pushes do not retrigger push workflows).
+  workflow_dispatch:
 
 jobs:
   docker:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
   push:
     tags:
       - "v*"
+  # Allow Auto Tag On Release Merge to cascade after a GITHUB_TOKEN tag push
+  # (token-authored pushes do not retrigger push workflows).
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
- `GITHUB_TOKEN` 推送的 `v*` tag 不会连锁触发其他 workflow，导致合入 release PR 后只打了 tag、Release/Docker 不跑（0.9.16 已复现）。
- 为 `release.yml` / `docker-publish.yml` 增加 `workflow_dispatch`；auto-tag 在推 tag 后显式 `gh workflow run` 触发二者。

## Test plan
- [ ] CI green
- [ ] 合入 main 后，下次 `release/*` 合入应自动：打 tag → 触发 Release + Docker Publish（无需手动删/重推 tag）
- [ ] 0.9.16 已通过人工重推 tag 补发，本 PR 不改版本号


Made with [Cursor](https://cursor.com)