### PR TITLE
fix(ci): trigger Sync Main Into Develop via workflow_run

### DIFF
--- a/.github/workflows/sync-main-to-develop.yml
+++ b/.github/workflows/sync-main-to-develop.yml
@@ -1,8 +1,18 @@
 name: Sync Main Into Develop
 
-# After a GitHub Release is published (Release workflow: PyPI → github-release),
-# open a main → develop sync PR and merge it when possible.
+# After Release succeeds, sync main → develop.
+#
+# Do NOT rely only on `release: published`: when the Release workflow creates a
+# GitHub Release with GITHUB_TOKEN, GitHub does not start other `release`
+# workflows. `workflow_run` does fire for GITHUB_TOKEN-triggered workflows.
+# `workflow_dispatch` allows a manual catch-up from the Actions tab.
 on:
+  workflow_run:
+    workflows:
+      - Release
+    types:
+      - completed
+  workflow_dispatch:
   release:
     types:
       - published
@@ -14,7 +24,12 @@ permissions:
 jobs:
   sync:
     name: Sync main into develop
-    if: startsWith(github.event.release.tag_name, 'v')
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'release' && startsWith(github.event.release.tag_name, 'v')) ||
+      (github.event_name == 'workflow_run' &&
+       github.event.workflow_run.conclusion == 'success' &&
+       startsWith(github.event.workflow_run.head_branch, 'v'))
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -25,7 +40,7 @@ jobs:
       - name: Open or merge sync PR
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ github.event.release.tag_name }}
+          TAG: ${{ github.event.release.tag_name || github.event.workflow_run.head_branch || 'manual' }}
         run: |
           set -euo pipefail
           version="${TAG#v}"


### PR DESCRIPTION
## Summary
- Release 用 `GITHUB_TOKEN` 创建 GitHub Release 时，不会触发其它 `release` 工作流，导致 0.9.16 发版后 Sync 从未跑过（Total runs: 0）
- 改为监听 `workflow_run`（Release 成功后），并支持 Actions 手动 `workflow_dispatch`

## Test plan
- [ ] 合入 main 后，Actions 中 Sync 工作流出现 Manual run 入口
- [ ] 下次 `v*` Release 成功后应自动开/合 main→develop sync PR

Made with [Cursor](https://cursor.com)