### PR TITLE
fix: render raw-event timestamps in the server timezone (#110)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
 - 技能相关域逻辑迁至 `infra/skills/`；数据库迁移合并为 schema v2（cron MCP + skill_packages 含图标）
 - 备份/恢复纳入 `skill-packages/` 目录，恢复前清空避免残留
 
+### 修复
+- Memory 原始事件列表的时间戳按服务器时区展示，与其余 Memory 页保持一致 (#110)
+
 ## [0.9.16] - 2026-07-29
 
 ### 新增

--- a/dashboard/src/pages/Agent/Memory/RawEventsList.test.tsx
+++ b/dashboard/src/pages/Agent/Memory/RawEventsList.test.tsx
@@ -19,6 +19,12 @@ vi.mock("../../../api/modules/memoryDashboard", () => ({
   },
 }));
 
+vi.mock("../../../api/modules/settings", () => ({
+  octopSettingsApi: {
+    timezone: vi.fn().mockResolvedValue({ timezone: "Asia/Shanghai" }),
+  },
+}));
+
 import { memoryDashboardApi } from "../../../api/modules/memoryDashboard";
 import RawEventsList from "./RawEventsList";
 
@@ -112,5 +118,33 @@ describe("<RawEventsList />", () => {
     await waitFor(() => expect(api.listRawEvents).toHaveBeenCalled());
     // MemoryPipelineEmpty consults statsCounts to decide its copy.
     await waitFor(() => expect(api.statsCounts).toHaveBeenCalledWith("ZYWZTD"));
+  });
+
+  it("renders timestamps in the server timezone (Asia/Shanghai)", async () => {
+    api.listRawEvents.mockResolvedValue(
+      rawResp([makeRaw({ timestamp: "2026-07-15T02:00:00Z" })]),
+    );
+
+    render(<RawEventsList agentId="ZYWZTD" />);
+    await waitFor(() => {
+      expect(screen.getByText("项目截止日期是周五")).toBeInTheDocument();
+    });
+    // 2026-07-15T02:00:00Z == 10:00 in Asia/Shanghai (UTC+8).
+    await waitFor(() => {
+      expect(screen.getByText(/2026/)).toBeInTheDocument();
+    });
+    const timeText = screen.getByText(/2026/).textContent ?? "";
+    expect(timeText).toContain("10:");
+  });
+
+  it("falls back to the raw ISO string for an invalid timestamp", async () => {
+    api.listRawEvents.mockResolvedValue(
+      rawResp([makeRaw({ timestamp: "not-a-date" })]),
+    );
+
+    render(<RawEventsList agentId="ZYWZTD" />);
+    await waitFor(() => {
+      expect(screen.getByText("not-a-date")).toBeInTheDocument();
+    });
   });
 });

--- a/dashboard/src/pages/Agent/Memory/RawEventsList.tsx
+++ b/dashboard/src/pages/Agent/Memory/RawEventsList.tsx
@@ -20,6 +20,8 @@ import {
 } from "../../../api/modules/memoryDashboard";
 import MemoryLayerView from "./shared/MemoryLayerView";
 import MemoryPipelineEmpty from "./shared/MemoryPipelineEmpty";
+import { useServerTimezone } from "../../../hooks/useServerTimezone";
+import { formatServerIsoDateTime } from "../../../utils/formatMessageTime";
 
 const PAGE_SIZE = 20;
 
@@ -66,14 +68,9 @@ function eventTypeColor(type: string): string | undefined {
   return undefined;
 }
 
-function formatTime(iso: string): string {
-  const d = new Date(iso);
-  if (Number.isNaN(d.getTime())) return iso;
-  return d.toLocaleString();
-}
-
 export default function RawEventsList({ agentId }: Props) {
   const { t } = useTranslation();
+  const timeZone = useServerTimezone();
   const [items, setItems] = useState<RawEventItem[]>([]);
   const [total, setTotal] = useState(0);
   const [page, setPage] = useState(1);
@@ -174,7 +171,7 @@ export default function RawEventsList({ agentId }: Props) {
             {e.content}
           </div>
           <div style={{ marginTop: 2, fontSize: 12, color: "#8c8c8c" }}>
-            {formatTime(e.timestamp)}
+            {formatServerIsoDateTime(e.timestamp, timeZone)}
           </div>
         </div>
       )}
@@ -197,7 +194,8 @@ export default function RawEventsList({ agentId }: Props) {
             type="secondary"
             style={{ fontSize: 12, marginTop: 16 }}
           >
-            {t("memory.raw.capturedAt", "捕获于")} {formatTime(e.timestamp)}
+            {t("memory.raw.capturedAt", "捕获于")}{" "}
+            {formatServerIsoDateTime(e.timestamp, timeZone)}
           </Typography.Paragraph>
         </div>
       )}


### PR DESCRIPTION
## Summary

Fixes the remaining timestamp inconsistency in the Memory dashboard: \`RawEventsList\` rendered timestamps with a bare \`d.toLocaleString()\` (browser-local timezone), while every other Memory view (\`EpisodesList\`, \`JournalList\`, \`ConversationRecords\`, \`ProfileOverview\`) uses \`useServerTimezone()\` + \`formatServerIsoDateTime\`. Per AGENTS.md §7, user-visible timestamps must use the server timezone.

## Changes

- \`RawEventsList.tsx\`: drop the local \`formatTime\` helper; use \`useServerTimezone()\` + \`formatServerIsoDateTime(iso, timeZone)\` (invalid ISO still falls back to the raw string).
- \`RawEventsList.test.tsx\`: mock the settings timezone API and add cases for server-timezone rendering (Asia/Shanghai) and invalid-timestamp fallback.

## Test plan

- \`vitest run\` — 177 passed (38 files)
- \`tsc --noEmit\` — clean
- Backend \`make test\` unaffected (frontend-only change)

CHANGELOG.md updated.