### PR TITLE
docs(mirrors): optimize default China mirror examples to Tencent Cloud

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,19 +10,19 @@
 #   docker run -d -p 8088:8088 -v octop-data:/data/.octop -e HOME=/data octop:latest
 #
 # 国内加速（可选，需 BuildKit，docker/docker_build.sh 默认已开启）:
-#   PIP_INDEX_URL=https://mirrors.aliyun.com/pypi/simple \
-#   PIP_TRUSTED_HOST=mirrors.aliyun.com \
-#   NPM_REGISTRY=https://registry.npmmirror.com \
-#   APT_MIRROR=mirrors.aliyun.com \
+#   PIP_INDEX_URL=https://mirrors.cloud.tencent.com/pypi/simple \
+#   PIP_TRUSTED_HOST=mirrors.cloud.tencent.com \
+#   NPM_REGISTRY=https://mirrors.cloud.tencent.com/npm/ \
+#   APT_MIRROR=mirrors.cloud.tencent.com \
 #   bash docker/docker_build.sh
 #
 # 或直接传 build-arg:
 #   docker build \
 #     -f docker/Dockerfile \
-#     --build-arg PIP_INDEX_URL=https://mirrors.aliyun.com/pypi/simple \
-#     --build-arg PIP_TRUSTED_HOST=mirrors.aliyun.com \
-#     --build-arg NPM_REGISTRY=https://registry.npmmirror.com \
-#     --build-arg APT_MIRROR=mirrors.aliyun.com \
+#     --build-arg PIP_INDEX_URL=https://mirrors.cloud.tencent.com/pypi/simple \
+#     --build-arg PIP_TRUSTED_HOST=mirrors.cloud.tencent.com \
+#     --build-arg NPM_REGISTRY=https://mirrors.cloud.tencent.com/npm/ \
+#     --build-arg APT_MIRROR=mirrors.cloud.tencent.com \
 #     --build-arg NODE_MAX_OLD_SPACE_SIZE=1024 \
 #     -t octop:latest .
 #

--- a/docker/README.md
+++ b/docker/README.md
@@ -45,10 +45,10 @@ docker run -d \
 Pass mirror env vars when building:
 
 ```bash
-PIP_INDEX_URL=https://mirrors.aliyun.com/pypi/simple \
-PIP_TRUSTED_HOST=mirrors.aliyun.com \
-NPM_REGISTRY=https://registry.npmmirror.com \
-APT_MIRROR=mirrors.aliyun.com \
+PIP_INDEX_URL=https://mirrors.cloud.tencent.com/pypi/simple \
+PIP_TRUSTED_HOST=mirrors.cloud.tencent.com \
+NPM_REGISTRY=https://mirrors.cloud.tencent.com/npm/ \
+APT_MIRROR=mirrors.cloud.tencent.com \
 bash docker/docker_build.sh
 ```
 

--- a/docker/README_CN.md
+++ b/docker/README_CN.md
@@ -45,10 +45,10 @@ docker run -d \
 构建时可通过环境变量加速依赖下载：
 
 ```bash
-PIP_INDEX_URL=https://mirrors.aliyun.com/pypi/simple \
-PIP_TRUSTED_HOST=mirrors.aliyun.com \
-NPM_REGISTRY=https://registry.npmmirror.com \
-APT_MIRROR=mirrors.aliyun.com \
+PIP_INDEX_URL=https://mirrors.cloud.tencent.com/pypi/simple \
+PIP_TRUSTED_HOST=mirrors.cloud.tencent.com \
+NPM_REGISTRY=https://mirrors.cloud.tencent.com/npm/ \
+APT_MIRROR=mirrors.cloud.tencent.com \
 bash docker/docker_build.sh
 ```
 

--- a/docker/docker_build.sh
+++ b/docker/docker_build.sh
@@ -11,10 +11,10 @@
 #   bash docker/docker_build.sh octop:dev --no-cache
 #
 # 国内加速（可选，需 BuildKit，本脚本默认已开启）:
-#   PIP_INDEX_URL=https://mirrors.aliyun.com/pypi/simple \
-#   PIP_TRUSTED_HOST=mirrors.aliyun.com \
-#   NPM_REGISTRY=https://registry.npmmirror.com \
-#   APT_MIRROR=mirrors.aliyun.com \
+#   PIP_INDEX_URL=https://mirrors.cloud.tencent.com/pypi/simple \
+#   PIP_TRUSTED_HOST=mirrors.cloud.tencent.com \
+#   NPM_REGISTRY=https://mirrors.cloud.tencent.com/npm/ \
+#   APT_MIRROR=mirrors.cloud.tencent.com \
 #   bash docker/docker_build.sh
 # =============================================================================
 set -euo pipefail

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -40,7 +40,7 @@ bash scripts/install.sh --from-source
 bash scripts/install.sh --from-source /path/to/orca
 
 # 使用国内 PyPI 镜像加速依赖
-bash scripts/install.sh --mirror https://mirrors.aliyun.com/pypi/simple
+bash scripts/install.sh --mirror https://mirrors.cloud.tencent.com/pypi/simple
 ```
 
 Windows PowerShell 等价参数：`-Version`、`-FromSource`、`-SourceDir`、`-Extras`。

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -85,7 +85,7 @@ Octop 安装脚本 (macOS / Linux)
   --from-source [目录]  从源码安装；未指定目录时从 git 仓库克隆
   --from-pypi           从 PyPI 安装（默认）
   --extras <附加组件>   额外可选组件（例如 desktop）；browser/playwright 默认安装
-  --mirror <镜像URL>    指定 PyPI 镜像（例如 https://mirrors.aliyun.com/pypi/simple）
+  --mirror <镜像URL>    指定 PyPI 镜像（例如 https://mirrors.cloud.tencent.com/pypi/simple）
   -h, --help            显示此帮助
 
 说明: 若系统已安装 Chrome/Chromium（常见于 macOS/Windows 或 Linux 桌面），


### PR DESCRIPTION
## Summary
- Update the "faster downloads" mirror examples in docker docs and
  install scripts to use Tencent Cloud's PyPI/APT/NPM mirrors
  (mirrors.cloud.tencent.com), so the documented defaults match what
  scripts/install.sh and self_update.py already try first at runtime.
- Files: docker/Dockerfile, docker/docker_build.sh, docker/README.md,
  docker/README_CN.md, scripts/README.md, scripts/install.sh
  (--help text)

## Test plan
- Docs/comment-only change, no code paths affected.
- Verified the referenced Tencent Cloud mirror endpoints
  (pypi/simple, npm/, debian apt source) are live and match the
  URI format already used by the existing APT_MIRROR build-arg
  logic in docker/Dockerfile.