### PR TITLE
feat: allow specifying custom agent_id when creating experts

### DIFF
--- a/dashboard/src/api/modules/expertMarket.ts
+++ b/dashboard/src/api/modules/expertMarket.ts
@@ -57,6 +57,7 @@ export interface CreateMarketExpertResponse {
 
 export interface CreateMarketExpertBody {
   name?: string;
+  agent_id?: string;
   description?: string;
   providers?: string[];
   default_model?: string;

--- a/dashboard/src/locales/en.json
+++ b/dashboard/src/locales/en.json
@@ -419,6 +419,8 @@
     "marketLoadFailed": "Failed to load the expert market",
     "marketBackendMissing": "The backend has not loaded the Expert Market API yet. Restart Octop or confirm it is running this updated code.",
     "marketSearchPlaceholder": "Search expert market",
+    "marketCreateModalTitle": "Create Expert from Market",
+    "marketCreateModalHint": "Specify an optional Expert ID for the new agent. If left empty, a random ID will be generated automatically.",
     "sceneAll": "All",
     "scenes": {
       "academic": "Academic",

--- a/dashboard/src/locales/en.json
+++ b/dashboard/src/locales/en.json
@@ -397,6 +397,8 @@
     "agentId": "Expert ID",
     "agentIdHelp": "Optional. If left empty, a random ID will be auto-generated.",
     "agentIdPlaceholder": "e.g. my-expert-id",
+    "agentIdInvalid": "Only letters, numbers, hyphens, and underscores allowed. Must start with a letter or number.",
+    "agentIdTooLong": "Agent ID must be 1-64 characters.",
     "copyAgentId": "Click to copy expert ID",
     "table": {
       "name": "Name",

--- a/dashboard/src/locales/en.json
+++ b/dashboard/src/locales/en.json
@@ -395,6 +395,8 @@
     "mbtiDefault": "Default",
     "mbtiViewDetail": "Click to view personality details",
     "agentId": "Expert ID",
+    "agentIdHelp": "Optional. If left empty, a random ID will be auto-generated.",
+    "agentIdPlaceholder": "e.g. my-expert-id",
     "copyAgentId": "Click to copy expert ID",
     "table": {
       "name": "Name",

--- a/dashboard/src/locales/zh.json
+++ b/dashboard/src/locales/zh.json
@@ -419,6 +419,8 @@
     "marketLoadFailed": "加载专家市场失败",
     "marketBackendMissing": "后端还没有加载专家市场接口，请重启 Octop 后端或确认当前运行的是这份新代码。",
     "marketSearchPlaceholder": "搜索专家市场",
+    "marketCreateModalTitle": "从市场创建专家",
+    "marketCreateModalHint": "可选指定新专家的 ID。留空将自动生成随机 ID。",
     "sceneAll": "全部",
     "scenes": {
       "academic": "学术",

--- a/dashboard/src/locales/zh.json
+++ b/dashboard/src/locales/zh.json
@@ -397,6 +397,8 @@
     "agentId": "专家 ID",
     "agentIdHelp": "可选。留空将自动生成随机 ID。",
     "agentIdPlaceholder": "例如 my-expert-id",
+    "agentIdInvalid": "仅允许字母、数字、连字符和下划线，且必须以字母或数字开头。",
+    "agentIdTooLong": "专家 ID 长度为 1-64 个字符。",
     "copyAgentId": "点击复制专家 ID",
     "table": {
       "name": "名称",

--- a/dashboard/src/locales/zh.json
+++ b/dashboard/src/locales/zh.json
@@ -395,6 +395,8 @@
     "mbtiDefault": "默认",
     "mbtiViewDetail": "点击查看人格说明",
     "agentId": "专家 ID",
+    "agentIdHelp": "可选。留空将自动生成随机 ID。",
+    "agentIdPlaceholder": "例如 my-expert-id",
     "copyAgentId": "点击复制专家 ID",
     "table": {
       "name": "名称",

--- a/dashboard/src/pages/Experts/components/CreateFromExpertDrawer.tsx
+++ b/dashboard/src/pages/Experts/components/CreateFromExpertDrawer.tsx
@@ -272,6 +272,22 @@ export default function CreateFromExpertDrawer({
           name="agent_id"
           label={t("experts.agentId")}
           help={t("experts.agentIdHelp")}
+          rules={[
+            {
+              validator: (_, value: string | undefined) => {
+                if (!value || !value.trim()) return Promise.resolve();
+                const trimmed = value.trim();
+                if (trimmed.length > 64) {
+                  return Promise.reject(new Error(t("experts.agentIdTooLong")));
+                }
+                if (!/^[a-zA-Z0-9][a-zA-Z0-9_-]*$/.test(trimmed)) {
+                  return Promise.reject(new Error(t("experts.agentIdInvalid")));
+                }
+                return Promise.resolve();
+              },
+            },
+          ]}
+          getValueFromEvent={(e) => e.target.value?.trimStart() ?? ""}
         >
           <Input placeholder={t("experts.agentIdPlaceholder")} />
         </Form.Item>

--- a/dashboard/src/pages/Experts/components/CreateFromExpertDrawer.tsx
+++ b/dashboard/src/pages/Experts/components/CreateFromExpertDrawer.tsx
@@ -64,6 +64,7 @@ export default function CreateFromExpertDrawer({
   const skillSlugDisplayName = useSkillSlugDisplayName();
   const [form] = Form.useForm<{
     name: string;
+    agent_id?: string;
     description: string;
     default_model: string;
     backend_choice: string;
@@ -93,6 +94,7 @@ export default function CreateFromExpertDrawer({
     setPathMappings([]);
     form.setFieldsValue({
       name: pickLocale(expert.label, lang) || expert.id,
+      agent_id: undefined,
       description: pickLocale(expert.description, lang),
       default_model: MODEL_AUTO_VALUE,
       backend_choice: DEFAULT_BACKEND,
@@ -173,6 +175,7 @@ export default function CreateFromExpertDrawer({
           method: "POST",
           body: JSON.stringify({
             name: values.name,
+            agent_id: values.agent_id || undefined,
             description: values.description || undefined,
             default_model:
               defaultModelFromForm(values.default_model) ?? undefined,
@@ -263,6 +266,14 @@ export default function CreateFromExpertDrawer({
           rules={[{ required: true, message: t("experts.pleaseEnterName") }]}
         >
           <Input />
+        </Form.Item>
+
+        <Form.Item
+          name="agent_id"
+          label={t("experts.agentId")}
+          help={t("experts.agentIdHelp")}
+        >
+          <Input placeholder={t("experts.agentIdPlaceholder")} />
         </Form.Item>
 
         <Form.Item name="description" label={t("experts.agentDescription")}>

--- a/dashboard/src/pages/Experts/components/ExpertMarketTab.tsx
+++ b/dashboard/src/pages/Experts/components/ExpertMarketTab.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { CSSProperties } from "react";
-import { Button, Drawer, Input, Segmented, Spin, Tag } from "antd";
+import { Button, Drawer, Form, Input, Modal, Segmented, Spin, Tag } from "antd";
 import { message } from "@/utils/antdMessage";
 
 import {
@@ -15,6 +15,7 @@ import type { TFunction } from "i18next";
 import { useTranslation } from "react-i18next";
 import {
   expertMarketApi,
+  type CreateMarketExpertBody,
   type ExpertMarketQuickPrompt,
   type MarketExpert,
 } from "../../../api/modules/expertMarket";
@@ -82,6 +83,9 @@ export default function ExpertMarketTab({
   const [selected, setSelected] = useState<MarketExpert | null>(null);
   const [detailLoading, setDetailLoading] = useState(false);
   const [creatingSlug, setCreatingSlug] = useState<string | null>(null);
+  const [createModalOpen, setCreateModalOpen] = useState(false);
+  const [pendingExpert, setPendingExpert] = useState<MarketExpert | null>(null);
+  const [configForm] = Form.useForm<{ agent_id?: string }>();
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const fetchMarket = useCallback(
@@ -137,11 +141,11 @@ export default function ExpertMarketTab({
   );
 
   const createMarketExpert = useCallback(
-    async (expert: MarketExpert) => {
+    async (expert: MarketExpert, body: CreateMarketExpertBody = {}) => {
       if (creatingSlug) return;
       setCreatingSlug(expert.slug);
       try {
-        const result = await expertMarketApi.install(expert.slug);
+        const result = await expertMarketApi.install(expert.slug, body);
         const enrichment = result.market?.welcome_enrichment;
         if (enrichment === "pending") {
           message.success(
@@ -162,6 +166,27 @@ export default function ExpertMarketTab({
     },
     [creatingSlug, onCreated, t],
   );
+
+  const handleOpenCreateModal = useCallback((expert: MarketExpert) => {
+    setPendingExpert(expert);
+    setCreateModalOpen(true);
+    configForm.resetFields();
+  }, [configForm]);
+
+  const handleConfirmCreate = useCallback(async () => {
+    if (!pendingExpert) return;
+    const values = await configForm.validateFields();
+    setCreateModalOpen(false);
+    const body: CreateMarketExpertBody = {};
+    if (values.agent_id) body.agent_id = values.agent_id;
+    await createMarketExpert(pendingExpert, body);
+  }, [pendingExpert, configForm, createMarketExpert]);
+
+  const handleCreateModalClose = useCallback(() => {
+    if (creatingSlug) return;
+    setCreateModalOpen(false);
+    setPendingExpert(null);
+  }, [creatingSlug]);
 
   const totalText = useMemo(
     () => t("experts.totalMarket", { count: items.length }),
@@ -340,7 +365,7 @@ export default function ExpertMarketTab({
                     disabled={Boolean(creatingSlug)}
                     onClick={(e) => {
                       e.stopPropagation();
-                      void createMarketExpert(expert);
+                      handleOpenCreateModal(expert);
                     }}
                   >
                     {installed
@@ -369,7 +394,7 @@ export default function ExpertMarketTab({
               icon={<Download size={14} />}
               loading={creatingSlug === selected.slug}
               disabled={Boolean(creatingSlug)}
-              onClick={() => void createMarketExpert(selected)}
+              onClick={() => handleOpenCreateModal(selected)}
             >
               {installedExpertIds.has(selected.id)
                 ? t("experts.createAgainFromMarket")
@@ -501,6 +526,37 @@ export default function ExpertMarketTab({
           </div>
         )}
       </Drawer>
+
+      <Modal
+        title={t("experts.marketCreateModalTitle")}
+        open={createModalOpen}
+        onCancel={handleCreateModalClose}
+        destroyOnClose
+        confirmLoading={Boolean(creatingSlug)}
+        onOk={() => void handleConfirmCreate()}
+        okText={t("common.create")}
+        cancelText={t("common.cancel")}
+      >
+        {pendingExpert && (
+          <div style={{ marginBottom: 16 }}>
+            <div style={{ fontSize: 13, color: "var(--fn-text-secondary)", marginBottom: 4 }}>
+              {t("experts.marketCreateModalHint")}
+            </div>
+            <Tag style={{ marginTop: 4 }}>
+              {labelOf(pendingExpert, lang)}
+            </Tag>
+          </div>
+        )}
+        <Form form={configForm} layout="vertical" size="middle">
+          <Form.Item
+            name="agent_id"
+            label={t("experts.agentId")}
+            help={t("experts.agentIdHelp")}
+          >
+            <Input placeholder={t("experts.agentIdPlaceholder")} />
+          </Form.Item>
+        </Form>
+      </Modal>
     </div>
   );
 }

--- a/dashboard/src/pages/Experts/components/ExpertMarketTab.tsx
+++ b/dashboard/src/pages/Experts/components/ExpertMarketTab.tsx
@@ -176,10 +176,11 @@ export default function ExpertMarketTab({
   const handleConfirmCreate = useCallback(async () => {
     if (!pendingExpert) return;
     const values = await configForm.validateFields();
-    setCreateModalOpen(false);
     const body: CreateMarketExpertBody = {};
     if (values.agent_id) body.agent_id = values.agent_id;
     await createMarketExpert(pendingExpert, body);
+    setCreateModalOpen(false);
+    setPendingExpert(null);
   }, [pendingExpert, configForm, createMarketExpert]);
 
   const handleCreateModalClose = useCallback(() => {

--- a/src/octop/api/routers/agents.py
+++ b/src/octop/api/routers/agents.py
@@ -20,6 +20,7 @@ router = APIRouter()
 
 class AgentCreateBody(BaseModel):
     name: str
+    agent_id: str | None = None
     description: str | None = None
     persona_mbti: str | None = None
     default_model: str | None = None
@@ -148,6 +149,7 @@ async def create_agent(
     assert server.app_runtime is not None
     spec = AgentCreateSpec(
         name=body.name,
+        agent_id=body.agent_id,
         user_id=user.id,
         description=body.description,
         persona_mbti=body.persona_mbti,

--- a/src/octop/api/routers/agents.py
+++ b/src/octop/api/routers/agents.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 from typing import Any, Literal
 
 from fastapi import APIRouter, Depends, Query
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 
 from octop.api.common.agent import assert_agent_owner
 from octop.api.deps import current_user, get_server
@@ -16,6 +17,9 @@ from octop.infra.errors import ErrorCode, OctopError
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+# Agent ID validation pattern: starts with letter/number, then letters/numbers/hyphens/underscores
+_AGENT_ID_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$")
 
 
 class AgentCreateBody(BaseModel):
@@ -28,6 +32,23 @@ class AgentCreateBody(BaseModel):
     config: dict[str, Any] = {}
     icon: str | None = None
     template_name: str | None = None
+
+    @field_validator("agent_id")
+    @classmethod
+    def _validate_agent_id(cls, v: str | None) -> str | None:
+        if v is None:
+            return v
+        stripped = v.strip()
+        if not stripped:
+            raise ValueError("Agent ID cannot be empty or whitespace only")
+        if len(stripped) > 64:
+            raise ValueError("Agent ID must be 1-64 characters")
+        if not _AGENT_ID_RE.match(stripped):
+            raise ValueError(
+                "Agent ID can only contain letters, numbers, hyphens, and underscores, "
+                "and must start with a letter or number"
+            )
+        return stripped
 
 
 class AgentPatchBody(BaseModel):

--- a/src/octop/api/routers/experts.py
+++ b/src/octop/api/routers/experts.py
@@ -53,6 +53,7 @@ _SAFE_MARKET_REASONS: dict[SkillHubMarketErrorKind, str] = {
 
 class FromExpertBody(BaseModel):
     name: str | None = None
+    agent_id: str | None = None
     description: str | None = None
     providers: list[str] | None = None
     default_model: str | None = None
@@ -262,6 +263,7 @@ async def install_expert_hub_item(
             slug=slug,
             options=SkillHubMarketAgentCreateOptions(
                 name=body.name,
+                agent_id=body.agent_id,
                 description=body.description,
                 providers=body.providers,
                 default_model=body.default_model,
@@ -344,6 +346,7 @@ async def create_agent_from_expert(
         expert=expert,
         user_id=user.id,
         name=body.name,
+        agent_id=body.agent_id,
         description=body.description,
         locale=locale,
         default_model=body.default_model,

--- a/src/octop/api/routers/experts.py
+++ b/src/octop/api/routers/experts.py
@@ -12,10 +12,11 @@ POST /api/experts/hub/{slug}/install → create agent from market expert
 from __future__ import annotations
 
 import asyncio
+import re
 from typing import Any
 
 from fastapi import APIRouter, Depends
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from octop.api.deps import current_user, get_server
 from octop.infra.agents.experts.catalog import (
@@ -59,6 +60,23 @@ class FromExpertBody(BaseModel):
     default_model: str | None = None
     backend: dict[str, Any] | None = None
     skill_package_ids: list[str] | None = None
+
+    @field_validator("agent_id")
+    @classmethod
+    def _validate_agent_id(cls, v: str | None) -> str | None:
+        if v is None:
+            return v
+        stripped = v.strip()
+        if not stripped:
+            raise ValueError("Agent ID cannot be empty or whitespace only")
+        if len(stripped) > 64:
+            raise ValueError("Agent ID must be 1-64 characters")
+        if not re.match(r"^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$", stripped):
+            raise ValueError(
+                "Agent ID can only contain letters, numbers, hyphens, and underscores, "
+                "and must start with a letter or number"
+            )
+        return stripped
 
 
 class LocalizedTextResponse(BaseModel):

--- a/src/octop/cli/commands/agent.py
+++ b/src/octop/cli/commands/agent.py
@@ -19,12 +19,14 @@ def agent() -> None:
 
 @agent.command("create")
 @click.argument("name")
+@click.option("--agent-id", "agent_id", default=None, help="Custom agent ID (short string, optional).")
 @click.option("--persona-mbti", "persona_mbti", default=None)
 @click.option("--default-model", "default_model", default=None)
 @click.option("--template", "template_name", default=None, help="Agent template name.")
 @click.option("--user", "as_user", default=None, help="Create for another user (admin)")
 def create(
     name: str,
+    agent_id: str | None,
     persona_mbti: str | None,
     default_model: str | None,
     template_name: str | None,
@@ -47,6 +49,7 @@ def create(
             assert server.app_runtime is not None
             spec = AgentCreateSpec(
                 name=name,
+                agent_id=agent_id,
                 user_id=uid,
                 persona_mbti=persona_mbti,
                 default_model=default_model,
@@ -64,8 +67,9 @@ def create(
 @agent.command("from-expert")
 @click.argument("expert_id")
 @click.option("--name", default=None)
+@click.option("--agent-id", "agent_id", default=None, help="Custom agent ID (short string, optional).")
 @click.option("--user", "as_user", default=None)
-def from_expert(expert_id: str, name: str | None, as_user: str | None) -> None:
+def from_expert(expert_id: str, name: str | None, agent_id: str | None, as_user: str | None) -> None:
     """Create an agent from a bundled expert template (embedded server)."""
     import asyncio
 
@@ -93,6 +97,7 @@ def from_expert(expert_id: str, name: str | None, as_user: str | None) -> None:
                 expert=expert,
                 user_id=uid,
                 name=name,
+                agent_id=agent_id,
                 locale=locale,
             )
             return await server.app_runtime.agent_registry.create(spec, defer_bootstrap=True)

--- a/src/octop/cli/commands/agent.py
+++ b/src/octop/cli/commands/agent.py
@@ -19,7 +19,9 @@ def agent() -> None:
 
 @agent.command("create")
 @click.argument("name")
-@click.option("--agent-id", "agent_id", default=None, help="Custom agent ID (short string, optional).")
+@click.option(
+    "--agent-id", "agent_id", default=None, help="Custom agent ID (short string, optional)."
+)
 @click.option("--persona-mbti", "persona_mbti", default=None)
 @click.option("--default-model", "default_model", default=None)
 @click.option("--template", "template_name", default=None, help="Agent template name.")
@@ -67,9 +69,13 @@ def create(
 @agent.command("from-expert")
 @click.argument("expert_id")
 @click.option("--name", default=None)
-@click.option("--agent-id", "agent_id", default=None, help="Custom agent ID (short string, optional).")
+@click.option(
+    "--agent-id", "agent_id", default=None, help="Custom agent ID (short string, optional)."
+)
 @click.option("--user", "as_user", default=None)
-def from_expert(expert_id: str, name: str | None, agent_id: str | None, as_user: str | None) -> None:
+def from_expert(
+    expert_id: str, name: str | None, agent_id: str | None, as_user: str | None
+) -> None:
     """Create an agent from a bundled expert template (embedded server)."""
     import asyncio
 

--- a/src/octop/infra/agents/experts/market_creation.py
+++ b/src/octop/infra/agents/experts/market_creation.py
@@ -39,6 +39,7 @@ WelcomeEnrichment = Literal["pending", "skipped", "succeeded", "failed"]
 @dataclass(frozen=True)
 class SkillHubMarketAgentCreateOptions:
     name: str | None = None
+    agent_id: str | None = None
     description: str | None = None
     providers: list[str] | None = None
     default_model: str | None = None
@@ -284,6 +285,7 @@ async def create_agent_from_skillhub_skillset(
         expert=expert,
         user_id=user.id,
         name=options.name,
+        agent_id=options.agent_id,
         description=options.description,
         locale=locale,
         default_model=options.default_model,


### PR DESCRIPTION
## 概述

允许用户在通过 API、CLI 和 Dashboard 创建 Expert（专家）/ Agent（智能体）时，自定义指定 Agent ID。

`AgentCreateSpec` 和 `AgentManager.create()` 本身已经支持传入 `agent_id` 参数，但此前该能力并未对 API、CLI 用户以及 Dashboard 前端开放。本次修改将这一能力贯穿至所有入口，并增加了统一的输入校验。

## 变更内容

### 后端（Python）

| 文件 | 修改内容 |
|------|----------|
| `src/octop/api/routers/agents.py` | 为 `AgentCreateBody` 添加 `agent_id` 字段，并使用 Pydantic 进行校验（正则、长度、去除首尾空格） |
| `src/octop/api/routers/experts.py` | 为 `FromExpertBody` 添加 `agent_id` 字段，使用相同校验规则，并在创建流程中透传 |
| `src/octop/cli/commands/agent.py` | 为 `create` 和 `from-expert` 命令新增 `--agent-id` 参数 |
| `src/octop/infra/agents/experts/market_creation.py` | 为 `SkillHubMarketAgentCreateOptions` 添加 `agent_id` 字段，并传递至创建配置 |

### 前端（TypeScript）

| 文件 | 修改内容 |
|------|----------|
| `dashboard/src/.../CreateFromExpertDrawer.tsx` | 新增 Agent ID 输入框及表单校验 |
| `dashboard/src/.../ExpertMarketTab.tsx` | 在安装 Market Expert 前新增配置弹窗 |
| `dashboard/src/api/modules/expertMarket.ts` | 为 `CreateMarketExpertBody` 添加 `agent_id` 字段 |
| `dashboard/src/locales/en.json` | 新增英文文案 |
| `dashboard/src/locales/zh.json` | 新增中文文案 |

## 校验规则

| 规则 | 行为 |
|------|------|
| 未填写 / 空值 | 自动生成随机 6 位 Crockford Base32 ID |
| 仅包含空白字符 | 自动去除首尾空格，若为空则视为未填写 |
| 长度 | 1～64 个字符 |
| 格式 | `^[a-zA-Z0-9][a-zA-Z0-9_-]*$` |
| 重复 ID | 由 `AgentManager.create()` 返回 `AGENT_BUSY` 错误 |

## 使用入口

| 路径 | 用法 |
|------|------|
| `POST /api/agents` | 请求体中传入 `{"agent_id": "my-id"}` |
| `POST /api/agents/from-expert/{id}` | 请求体中传入 `{"agent_id": "my-id"}` |
| `POST /api/experts/hub/{slug}/install` | 请求体中传入 `{"agent_id": "my-id"}` |
| `octop agent create` | 使用 `--agent-id my-id` |
| `octop agent from-expert` | 使用 `--agent-id my-id` |
| Dashboard：Built-in Experts | 创建表单新增 Agent ID 输入框 |
| Dashboard：Expert Market | 安装前配置弹窗新增 Agent ID 输入框 |

---

## Summary

Allow users to specify a custom ID when creating experts/agents via API, CLI, and dashboard UI.

The `AgentCreateSpec` and `AgentManager.create()` already support a user-provided `agent_id` parameter. However, this parameter was not exposed to API consumers, CLI users, or the dashboard frontend. This PR wires it through all layers and adds input validation.

## Changes

### Backend (Python)

| File | Change |
|------|--------|
| `src/octop/api/routers/agents.py` | Add `agent_id` field to `AgentCreateBody` with Pydantic validator (regex, length, trim) |
| `src/octop/api/routers/experts.py` | Add `agent_id` field to `FromExpertBody` with same validator; pass through in create flows |
| `src/octop/cli/commands/agent.py` | Add `--agent-id` option to `create` and `from-expert` commands |
| `src/octop/infra/agents/experts/market_creation.py` | Add `agent_id` to `SkillHubMarketAgentCreateOptions` and pass to create spec |

### Frontend (TypeScript)

| File | Change |
|------|--------|
| `dashboard/src/.../CreateFromExpertDrawer.tsx` | Agent ID input field with form validation |
| `dashboard/src/.../ExpertMarketTab.tsx` | Config modal before market install |
| `dashboard/src/api/modules/expertMarket.ts` | Add `agent_id` to `CreateMarketExpertBody` type |
| `dashboard/src/locales/en.json` | English translations |
| `dashboard/src/locales/zh.json` | Chinese translations |

## Validation Rules

| Rule | Behavior |
|------|----------|
| Omitted / empty | Auto-generates random 6-char Crockford base32 ID |
| Whitespace-only | Rejected (auto-trimmed on frontend) |
| Length | 1-64 characters |
| Format | `^[a-zA-Z0-9][a-zA-Z0-9_-]*$` |
| Duplicate | `AGENT_BUSY` error from `AgentManager.create()` |

## Entry Points

| Path | Usage |
|------|-------|
| `POST /api/agents` | `{"agent_id": "my-id"}` in body |
| `POST /api/agents/from-expert/{id}` | `{"agent_id": "my-id"}` in body |
| `POST /api/experts/hub/{slug}/install` | `{"agent_id": "my-id"}` in body |
| `octop agent create` | `--agent-id my-id` |
| `octop agent from-expert` | `--agent-id my-id` |
| Dashboard: Built-in Experts | Input field in create form |
| Dashboard: Expert Market | Config modal before install |