### PR TITLE
fix(ci): dispatch Sync Main Into Develop from Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 concurrency:
   group: release-${{ github.ref }}
@@ -120,3 +121,15 @@ jobs:
           body_path: .release-notes.md
           files: dist/*
           generate_release_notes: true
+
+  # workflow_run / release:published are unreliable when Release itself was
+  # started via GITHUB_TOKEN workflow_dispatch (Auto Tag). Explicitly cascade.
+  sync-develop:
+    name: Trigger sync main into develop
+    needs: github-release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch Sync Main Into Develop
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh workflow run sync-main-to-develop.yml --ref main

--- a/.github/workflows/sync-main-to-develop.yml
+++ b/.github/workflows/sync-main-to-develop.yml
@@ -2,10 +2,11 @@ name: Sync Main Into Develop
 
 # After Release succeeds, sync main → develop.
 #
-# Do NOT rely only on `release: published`: when the Release workflow creates a
-# GitHub Release with GITHUB_TOKEN, GitHub does not start other `release`
-# workflows. `workflow_run` does fire for GITHUB_TOKEN-triggered workflows.
-# `workflow_dispatch` allows a manual catch-up from the Actions tab.
+# Primary trigger: Release.yml explicitly dispatches this workflow (see
+# sync-develop job). Do not rely only on `release: published` or
+# `workflow_run` — when Auto Tag starts Release with GITHUB_TOKEN, those
+# events often never create a Sync run. workflow_dispatch remains for
+# manual catch-up; workflow_run / release are kept as best-effort backups.
 on:
   workflow_run:
     workflows:


### PR DESCRIPTION
## Summary
- After GitHub Release is created, explicitly `gh workflow run sync-main-to-develop.yml`
- Documents that `workflow_run` / `release: published` did not fire when Release was started by Auto Tag via GITHUB_TOKEN

## Context
v0.9.17 shipped but Sync never ran (zero Actions history). Manual catch-up is in #124.

## Test plan
- [ ] Merge to main
- [ ] Next release should open/merge a sync PR automatically after Release completes

Made with [Cursor](https://cursor.com)