### PR TITLE
feat(dashboard): polish updates/HTTPS settings and format in make all

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Pre-commit gate: backend ship bar + dashboard production build.
+# Pre-commit gate: make all (format BE+FE + lint + typecheck + test) + dashboard build.
 # Enable once per clone:  make install-hooks
 # Bypass (emergency only): SKIP_PRECOMMIT=1 git commit ...
 # Or: git commit --no-verify
@@ -13,8 +13,29 @@ fi
 ROOT="$(git rev-parse --show-toplevel)"
 cd "$ROOT"
 
-echo "[pre-commit] make all  (lint + typecheck + test)"
+# Remember staged paths so we can re-add them after auto-format rewrites the worktree.
+# Portable (bash 3.2+): avoid `mapfile` (bash 4+ only).
+STAGED_FILES=()
+while IFS= read -r line; do
+  [[ -n "$line" ]] && STAGED_FILES+=("$line")
+done < <(git diff --cached --name-only --diff-filter=ACMR || true)
+
+echo "[pre-commit] make all  (format-all + lint + typecheck + test)"
 make all
+
+# If format rewrote files that were already staged, refresh the index so the
+# commit includes the formatted content (worktree vs index drift).
+if ((${#STAGED_FILES[@]} > 0)); then
+  existing=()
+  for f in "${STAGED_FILES[@]}"; do
+    if [[ -e "$f" || -L "$f" ]]; then
+      existing+=("$f")
+    fi
+  done
+  if ((${#existing[@]} > 0)); then
+    git add -- "${existing[@]}"
+  fi
+fi
 
 echo "[pre-commit] dashboard npm run build"
 (

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -183,18 +183,20 @@ Frontend talks to Octop **only** via `/api` HTTP — never import or assume Pyth
 
 ```bash
 make install-hooks                      # once per clone: enable .githooks pre-commit
+make all                                # format-all + lint + typecheck + test (ship bar)
+make format-all                         # backend Ruff + dashboard Prettier write
+make lint                               # ruff check + format check
+make typecheck                          # mypy --strict src/octop
+make format                             # ruff auto-fix + format (backend only)
+make format-frontend                    # prettier write (dashboard only)
 uv run pytest -m "not live"            # full test suite (no LLM calls)
 uv run pytest tests/unit -x -q        # unit tests only, stop on first fail
 uv run pytest tests/integration -x -q # integration tests only
-make lint                               # ruff check + format check
-make typecheck                          # mypy --strict src/octop
-make format                             # auto-fix lint issues
-make all                                # lint + typecheck + test (ship bar)
 cd dashboard && npx tsc --noEmit       # frontend typecheck (after UI changes)
 make build-frontend                     # dashboard/ → src/octop/dashboard/
 ```
 
-**Git hooks (required for local commits):** after cloning, run **`make install-hooks`** once. That sets `core.hooksPath=.githooks` so every `git commit` runs `make all` plus `dashboard` `npm run build` before the commit is created. Bypass only in emergencies: `SKIP_PRECOMMIT=1 git commit …` or `git commit --no-verify`. Do **not** skip hooks to land red tests — fix the suite first (CI runs on Linux **and** Windows).
+**Git hooks (required for local commits):** after cloning, run **`make install-hooks`** once. That sets `core.hooksPath=.githooks` so every `git commit` runs **`make all`** (which first runs **`format-all`**: backend Ruff + dashboard Prettier write, then lint / typecheck / test) and dashboard **`npm run build`**. Formatted files that were already staged are re-added so the commit includes the formatted content. Bypass only in emergencies: `SKIP_PRECOMMIT=1 git commit …` or `git commit --no-verify`. Do **not** skip hooks to land red tests — fix the suite first (CI runs on Linux **and** Windows).
 
 ## 7. Key patterns
 
@@ -336,7 +338,7 @@ Boundary rules are in [§5](#5-module-boundaries). Additionally:
 | Internationalization (dashboard) | `dashboard/src/locales/`, `dashboard/src/i18n.ts`, `dashboard/src/utils/apiError.ts` |
 | Server timezone (config.json) | `default_timezone` in `config.py`; `GET /api/settings/timezone`; `dashboard/src/hooks/useServerTimezone.ts`; `dashboard/src/utils/formatMessageTime.ts` |
 | Test layout & shared helpers | `tests/support/` (`fakes`, `auth`, `http`, `scenarios`, `app`), `tests/integration/conftest.py`, `tests/unit/{db,cron,gateway,agents,api,cli}/` |
-| Pre-commit hooks | `make install-hooks` → `.githooks/pre-commit` (`make all` + dashboard build) |
+| Pre-commit hooks | `make install-hooks` → `.githooks/pre-commit` (`make all` incl. `format-all` + dashboard build) |
 | What is a Thread? | `infra/gateway/threads.py`, `infra/db/repos/threads.py` |
 | Workspace backend resolution | `infra/backend/resolver.py`, `infra/backend/adapter.py` |
 | Connectors & OAuth | `infra/connectors/`, `api/routers/connectors.py` |
@@ -350,7 +352,7 @@ Boundary rules are in [§5](#5-module-boundaries). Additionally:
 1. **Clarify scope** — read relevant code/docs; confirm assumptions and ambiguities with the user (see [§1](#1-collaboration-principles)).
 2. **Hooks** — if this clone has not run `make install-hooks` yet, do it before committing (see [§6](#6-run-commands)). Pre-commit must stay green (`make all` + dashboard build).
 3. **Minimal implementation** — change only task-related files; dashboard source is in `dashboard/`, build output in `src/octop/dashboard/` (run `make build-frontend` after UI changes).
-4. **Verify** — backend: `make all` (`lint` + `typecheck` + `test`). After `dashboard/` changes, also run `cd dashboard && npx tsc --noEmit` (and `npm run lint` when appropriate). After API route changes, glance at `/api/docs` for readable summaries and schemas. After i18n JSON changes, run `uv run pytest tests/unit/i18n -q`. Treat Windows CI as part of the bar: follow [§7 Cross-platform tests](#7-key-patterns).
+4. **Verify** — backend/ship bar: `make all` (`format-all` + `lint` + `typecheck` + `test`). After `dashboard/` changes, also run `cd dashboard && npx tsc --noEmit` (and `npm run lint` when appropriate). After API route changes, glance at `/api/docs` for readable summaries and schemas. After i18n JSON changes, run `uv run pytest tests/unit/i18n -q`. Treat Windows CI as part of the bar: follow [§7 Cross-platform tests](#7-key-patterns).
 5. **Wrap up** — remove orphan symbols introduced in this change; do not commit or push unless asked.
 
 ### Branching & release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@
 
 ## [Unreleased]
 
+### 新增
+- 高级设置「更新」页提供按安装方式升级说明与一键检查升级双栏布局
+- 高级设置 HTTPS 页优化签发状态与预检结果展示
+
+### 变更
+- `make all` 先执行前后端 `format-all`（Ruff + Prettier）；pre-commit 在 format 后回写已暂存文件并构建 dashboard
+
 ## [0.9.18] - 2026-08-02
 
 ### 新增

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ git clone https://github.com/TencentCloud/Octop.git octop
 cd octop
 make install          # backend dev dependencies
 make install-hooks    # once per clone: pre-commit runs make all + dashboard build
-make all              # backend lint + typecheck + test (CI ship bar)
+make all              # format-all + backend lint + typecheck + test (ship bar)
 ```
 
 For frontend work (separate terminal):
@@ -29,7 +29,7 @@ make check-all        # full stack quality gate
 |---------|-------------|
 | `make install` | Install Python dev dependencies |
 | `make install-hooks` | Point git at `.githooks` (pre-commit: `make all` + dashboard build) |
-| `make all` | Backend lint + typecheck + test |
+| `make all` | `format-all` + backend lint + typecheck + test |
 | `make check-all` | Full stack quality gate |
 | `make dev` | Start frontend + backend dev servers |
 | `make build` | Build dashboard + Python wheel |
@@ -90,7 +90,7 @@ git clone https://github.com/TencentCloud/Octop.git octop
 cd octop
 make install
 make install-hooks    # 每个 clone 执行一次：提交前跑 make all + 前端 build
-make all              # 后端质量门禁
+make all              # format-all + 后端 lint / typecheck / test
 ```
 
 前端开发（另开终端）：

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Makefile for Octop
 # Usage:
 #   make              - Show this help
-#   make all          - Backend lint + typecheck + test (CI ship bar)
+#   make all          - format (BE+FE) + backend lint + typecheck + test (ship bar)
 #   make build        - Build frontend + Python wheel
 #   make publish      - Build + upload to PyPI
 #
@@ -56,8 +56,8 @@ help:
 	@echo "  test-online      pytest against .venv-online (not live)"
 	@echo "  run-online       Start octop run from .venv-online"
 	@echo ""
-	@echo "Quality targets (backend — CI ship bar):"
-	@echo "  all              lint + typecheck + test (backend)"
+	@echo "Quality targets (ship bar):"
+	@echo "  all              format-all + lint + typecheck + test (backend lint/typecheck/test)"
 	@echo "  lint             Ruff check + format check (src, tests)"
 	@echo "  format           Ruff auto-fix + format (src, tests)"
 	@echo "  typecheck        mypy --strict src/octop"
@@ -71,12 +71,12 @@ help:
 	@echo ""
 	@echo "Quality targets (full stack):"
 	@echo "  lint-all         lint + lint-frontend"
-	@echo "  format-all       format + format-frontend"
+	@echo "  format-all       format + format-frontend (also first step of make all)"
 	@echo "  typecheck-all    typecheck + typecheck-frontend"
 	@echo "  check-all        lint-all + typecheck-all + test"
 	@echo ""
 	@echo "Utility targets:"
-	@echo "  install-hooks    Point git to .githooks (pre-commit runs make all + npm run build)"
+	@echo "  install-hooks    Point git to .githooks (pre-commit: make all + dashboard build)"
 	@echo "  install          Install Python dev dependencies (alias: install-dev)"
 	@echo "  install-dev      uv sync / pip install -e \".[dev]\""
 	@echo "  install-tools    Install build + twine for publishing"
@@ -196,7 +196,7 @@ run-online:
 # ─── Quality (backend) ───────────────────────────────────────────────────────
 
 .PHONY: all
-all: lint typecheck test
+all: format-all lint typecheck test
 
 .PHONY: lint
 lint:
@@ -266,7 +266,7 @@ install-hooks:
 	@echo "[install-hooks] Setting core.hooksPath=.githooks"
 	git config core.hooksPath .githooks
 	@chmod +x "$(REPO_ROOT)/.githooks/"* 2>/dev/null || true
-	@echo "[install-hooks] Done. Pre-commit will run: make all && (cd dashboard && npm run build)"
+	@echo "[install-hooks] Done. Pre-commit will run: make all (incl. format-all), dashboard build"
 	@echo "[install-hooks] Bypass: SKIP_PRECOMMIT=1 git commit …   or   git commit --no-verify"
 
 .PHONY: install install-dev

--- a/README.md
+++ b/README.md
@@ -415,7 +415,7 @@ tests/         unit/ + integration/
 ```bash
 # Backend
 make install          # pip install -e ".[dev]"
-make all              # lint + typecheck + test (ship bar)
+make all              # format-all + lint + typecheck + test (ship bar)
 
 # Frontend (separate terminal)
 make dev-frontend     # Vite dev server on :5173 (override with VITE_DEV_PORT)

--- a/README_CN.md
+++ b/README_CN.md
@@ -424,7 +424,7 @@ tests/         unit/ + integration/
 ```bash
 # 后端
 make install          # pip install -e ".[dev]"
-make all              # lint + typecheck + test（发布门槛）
+make all              # format-all + lint + typecheck + test（发布门槛）
 
 # 前端（另开终端）
 make dev-frontend     # Vite 开发服务器 :5173

--- a/dashboard/src/api/modules/connectors.ts
+++ b/dashboard/src/api/modules/connectors.ts
@@ -226,10 +226,13 @@ export const connectorsApi = {
     cli_config_key?: string;
     domains?: string[];
   }) =>
-    request<FeishuUserAuthStartResult>("/connectors/feishu-cli/user-auth/start", {
-      method: "POST",
-      body: JSON.stringify(body),
-    }),
+    request<FeishuUserAuthStartResult>(
+      "/connectors/feishu-cli/user-auth/start",
+      {
+        method: "POST",
+        body: JSON.stringify(body),
+      },
+    ),
 
   feishuUserAuthComplete: (body: {
     app_id: string;
@@ -247,7 +250,9 @@ export const connectorsApi = {
 
   feishuUserAuthStartInstance: (instanceId: string) =>
     request<FeishuUserAuthStartResult>(
-      `/connector-instances/${encodeURIComponent(instanceId)}/feishu-user-auth/start`,
+      `/connector-instances/${encodeURIComponent(
+        instanceId,
+      )}/feishu-user-auth/start`,
       { method: "POST" },
     ),
 
@@ -256,7 +261,9 @@ export const connectorsApi = {
     body: { device_code: string; cli_config_key?: string },
   ) =>
     request<FeishuUserAuthCompleteResult>(
-      `/connector-instances/${encodeURIComponent(instanceId)}/feishu-user-auth/complete`,
+      `/connector-instances/${encodeURIComponent(
+        instanceId,
+      )}/feishu-user-auth/complete`,
       {
         method: "POST",
         body: JSON.stringify(body),

--- a/dashboard/src/api/modules/skillPackages.test.ts
+++ b/dashboard/src/api/modules/skillPackages.test.ts
@@ -54,13 +54,17 @@ describe("skillPackagesApi", () => {
       method: "PATCH",
       body: JSON.stringify({ name: "renamed" }),
     });
-    expect(request).toHaveBeenNthCalledWith(3, "/skill-packages/from-skillhub", {
-      method: "POST",
-      body: JSON.stringify({
-        slug: "starter",
-        icon_name: "sparkles",
-      }),
-    });
+    expect(request).toHaveBeenNthCalledWith(
+      3,
+      "/skill-packages/from-skillhub",
+      {
+        method: "POST",
+        body: JSON.stringify({
+          slug: "starter",
+          icon_name: "sparkles",
+        }),
+      },
+    );
     expect(request).toHaveBeenNthCalledWith(4, "/skill-packages/pkg-1/skills", {
       method: "POST",
       body: JSON.stringify({

--- a/dashboard/src/api/modules/skillPackages.ts
+++ b/dashboard/src/api/modules/skillPackages.ts
@@ -86,13 +86,10 @@ export const skillPackagesApi = {
     packageId: string,
     body: { bundle_url: string; version?: string; overwrite?: boolean },
   ) =>
-    request<SkillPackageSkill>(
-      `/skill-packages/${packageId}/skills/import`,
-      {
-        method: "POST",
-        body: JSON.stringify(body),
-      },
-    ),
+    request<SkillPackageSkill>(`/skill-packages/${packageId}/skills/import`, {
+      method: "POST",
+      body: JSON.stringify(body),
+    }),
 
   hubSearch: (q: string, limit = 50) =>
     request<Record<string, unknown>[]>(

--- a/dashboard/src/components/BrowserWorkspace/ChatDockPanelShell.tsx
+++ b/dashboard/src/components/BrowserWorkspace/ChatDockPanelShell.tsx
@@ -1,4 +1,10 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { Dropdown, Tooltip } from "antd";
 import type { MenuProps } from "antd";
 import { useTranslation } from "react-i18next";
@@ -48,13 +54,7 @@ const POPUP_Z = {
  */
 function clearPopupPlacementStyles(panel: HTMLElement | null) {
   if (!panel) return;
-  for (const prop of [
-    "left",
-    "top",
-    "right",
-    "bottom",
-    "transform",
-  ] as const) {
+  for (const prop of ["left", "top", "right", "bottom", "transform"] as const) {
     panel.style.removeProperty(prop);
   }
 }
@@ -378,15 +378,15 @@ const ChatDockPanelShell: React.FC<ChatDockPanelShellProps> = ({
     mode === "popup" && popupFullscreen
       ? { ...style }
       : mode === "popup" && popupPos
-        ? {
-            ...style,
-            left: popupPos.x,
-            top: popupPos.y,
-            right: "auto",
-            bottom: "auto",
-            transform: "none",
-          }
-        : style;
+      ? {
+          ...style,
+          left: popupPos.x,
+          top: popupPos.y,
+          right: "auto",
+          bottom: "auto",
+          transform: "none",
+        }
+      : style;
 
   const layoutMenuItems: MenuProps["items"] = useMemo(
     () => [

--- a/dashboard/src/components/RailEdgeControl.tsx
+++ b/dashboard/src/components/RailEdgeControl.tsx
@@ -31,7 +31,11 @@ function WideChevron({ dir }: { dir: "left" | "right" }) {
       aria-hidden
     >
       <path
-        d={dir === "left" ? "M7.5 2.5 L2.5 11 L7.5 19.5" : "M2.5 2.5 L7.5 11 L2.5 19.5"}
+        d={
+          dir === "left"
+            ? "M7.5 2.5 L2.5 11 L7.5 19.5"
+            : "M2.5 2.5 L7.5 11 L2.5 19.5"
+        }
         fill="none"
         stroke="currentColor"
         strokeWidth="1.75"

--- a/dashboard/src/hooks/usePathTabs.ts
+++ b/dashboard/src/hooks/usePathTabs.ts
@@ -66,8 +66,7 @@ export function usePathTabs<T extends string>({
     location.pathname === basePath ||
     location.pathname.startsWith(`${basePath}/`);
   const isBare = location.pathname === basePath;
-  const hasInvalidSegment =
-    underBase && !isBare && pathTab === null;
+  const hasInvalidSegment = underBase && !isBare && pathTab === null;
   const activeTab: T = pathTab ?? readSaved();
 
   const [mounted, setMounted] = useState<Partial<Record<T, boolean>>>(
@@ -118,10 +117,7 @@ export function usePathTabs<T extends string>({
     [activeTab, basePath, isTab, location.search, location.hash, navigate],
   );
 
-  const isMounted = useCallback(
-    (tab: T) => Boolean(mounted[tab]),
-    [mounted],
-  );
+  const isMounted = useCallback((tab: T) => Boolean(mounted[tab]), [mounted]);
 
   return {
     activeTab,

--- a/dashboard/src/layouts/PageShell.tsx
+++ b/dashboard/src/layouts/PageShell.tsx
@@ -207,11 +207,7 @@ type PageShellTabbedProps = TabbedShellProps & {
 };
 
 /** Custom tab bar + scrollable body (desktop pins the bar). */
-function PageShellTabbed({
-  tabBar,
-  children,
-  ...shell
-}: PageShellTabbedProps) {
+function PageShellTabbed({ tabBar, children, ...shell }: PageShellTabbedProps) {
   const isMobile = useIsMobile();
   return (
     <PageShell {...shell} fill={!isMobile}>

--- a/dashboard/src/locales/en.json
+++ b/dashboard/src/locales/en.json
@@ -1664,6 +1664,17 @@
   "tls": {
     "title": "HTTPS (Let's Encrypt)",
     "subtitle": "Issue a free TLS certificate when this server listens on 0.0.0.0:80. After issuance, Octop runs HTTPS on 443 and keeps HTTP on 80 for ACME renewals.",
+    "setupTitle": "Certificate setup",
+    "setupDesc": "Enter a domain that points to this host's public IP. Run checks first, then issue or renew the certificate.",
+    "progressTitle": "Issuance progress",
+    "progressDesc": "Tracks preflight and Let's Encrypt progress. Check results appear below when available.",
+    "checksTitle": "Preflight results",
+    "statusDomain": "Domain",
+    "statusExpires": "Expires",
+    "statusTask": "Status",
+    "statusNone": "Not configured",
+    "stateIdle": "Idle",
+    "stateFailed": "Failed",
     "loadError": "Failed to load TLS status",
     "domainRequired": "Enter a domain name",
     "domainLabel": "Domain",
@@ -1954,7 +1965,9 @@
     },
     "update": {
       "title": "Version & Updates",
-      "description": "Check for the latest release and upgrade Octop with one click.",
+      "description": "Check for the latest release and upgrade in place; use the guide on the right for other install methods.",
+      "panelTitle": "Version upgrade",
+      "panelDesc": "Check for a new release and install it when supported. Restart the service after a successful upgrade.",
       "currentVersion": "Current Version",
       "latestVersion": "Latest Version",
       "checkButton": "Check for Updates",
@@ -1985,7 +1998,40 @@
       "restartTimeout": "Restart timed out. Run manually: octop service restart",
       "restartFailed": "Restart request failed. Check the service and try again.",
       "releaseNotes": "Release Notes",
-      "updateModalTitle": "New Version Available"
+      "updateModalTitle": "New Version Available",
+      "guideTitle": "Update by install method",
+      "guideIntro": "If the one-click upgrade on the left is unavailable, pick the commands for your install method. Restart after upgrading; data stays in ~/.octop (or OCTOP_HOME).",
+      "guideDataNote": "Upgrades do not wipe local data: accounts, agents, chats and memory, skills, channels, and model settings live in the working directory. Reinstalling or updating the package keeps using that data.",
+      "guide": {
+        "ui": {
+          "title": "In-console upgrade",
+          "body": "Prefer Check for Updates and Upgrade Now on the left (package installs, not editable/source). In service mode you can Restart Service when done."
+        },
+        "installer": {
+          "title": "One-line installer",
+          "body": "If you used the official install script, re-run the same install command to upgrade in place (it reuses the environment and data under ~/.octop)."
+        },
+        "cli": {
+          "title": "CLI: octop update",
+          "body": "If the octop command is on your PATH (installer or managed venv), run:"
+        },
+        "pip": {
+          "title": "pip install",
+          "body": "If you installed into your own Python environment with pip:"
+        },
+        "source": {
+          "title": "From source",
+          "body": "For git / editable installs, in-page upgrade is disabled. Pull the latest code, build the dashboard, then reinstall:"
+        },
+        "docker": {
+          "title": "Docker",
+          "body": "Rebuild and restart the image, and keep the same data volume (~/.octop or octop-data) so nothing is lost:"
+        },
+        "restart": {
+          "title": "Restart after upgrade",
+          "body": "The new package only takes effect after the process restarts. Use the command that matches how you launched Octop:"
+        }
+      }
     }
   },
   "agentConfig": {

--- a/dashboard/src/locales/zh.json
+++ b/dashboard/src/locales/zh.json
@@ -490,7 +490,7 @@
     "defaultModelLabel": "默认模型",
     "defaultModelPlaceholder": "选择一个模型",
     "skillPackagesLabel": "技能包",
-    "skillPackagesHint": "创建专家时挂载选中的技能包。目前仅支持「本地完整环境（文件系统+指令执行）」或「本地文件系统（不能执行指令）」，且存储根目录必须为 \/。",
+    "skillPackagesHint": "创建专家时挂载选中的技能包。目前仅支持「本地完整环境（文件系统+指令执行）」或「本地文件系统（不能执行指令）」，且存储根目录必须为 /。",
     "skillPackagesPlaceholder": "选择技能包",
     "iconLabels": {
       "sparkles": "闪光",
@@ -987,7 +987,7 @@
     "packagesLoadFailed": "加载技能包失败",
     "packagesUpdateFailed": "更新已挂载技能包失败",
     "packageConflictHint": "工作区技能“{{slug}}”会覆盖此技能包中的同名技能。",
-    "mountBackendHint": "挂载目前仅支持「本地完整环境（文件系统+指令执行）」或「本地文件系统（不能执行指令）」，且存储根目录必须为 \/，其他后端暂不支持。",
+    "mountBackendHint": "挂载目前仅支持「本地完整环境（文件系统+指令执行）」或「本地文件系统（不能执行指令）」，且存储根目录必须为 /，其他后端暂不支持。",
     "installedSkillsDesc": "管理已安装的内置和自定义技能。",
     "tencentSkillHubDesc": "浏览和安装来自腾讯 SkillHub 的社区技能。",
     "install": "安装",
@@ -1660,6 +1660,17 @@
   "tls": {
     "title": "HTTPS（Let's Encrypt）",
     "subtitle": "当服务监听 0.0.0.0:80 且域名已指向公网时，可申请免费 TLS 证书。签发后 HTTPS 走 443，HTTP 80 保留用于 ACME 续期。",
+    "setupTitle": "证书配置",
+    "setupDesc": "填写已解析到本机公网 IP 的域名，先运行检查，通过后再申请或续期证书。",
+    "progressTitle": "签发进度",
+    "progressDesc": "展示预检与 Let's Encrypt 签发流程进度；检查结果会显示在下方。",
+    "checksTitle": "预检结果",
+    "statusDomain": "域名",
+    "statusExpires": "证书到期",
+    "statusTask": "当前状态",
+    "statusNone": "未配置",
+    "stateIdle": "空闲",
+    "stateFailed": "失败",
     "loadError": "加载 TLS 状态失败",
     "domainRequired": "请输入域名",
     "domainLabel": "域名",
@@ -1949,7 +1960,9 @@
     },
     "update": {
       "title": "版本与更新",
-      "description": "检查最新版本，一键升级 Octop。",
+      "description": "检查最新版本，一键升级 Octop；右侧可按安装方式查看完整升级说明。",
+      "panelTitle": "版本升级",
+      "panelDesc": "检查是否有新版本，并在支持时一键安装。更新完成后请重启服务。",
       "currentVersion": "当前版本",
       "latestVersion": "最新版本",
       "checkButton": "检查更新",
@@ -1980,7 +1993,40 @@
       "restartTimeout": "重启超时，请手动执行：octop service restart",
       "restartFailed": "重启请求失败，请检查服务状态后重试",
       "releaseNotes": "更新说明",
-      "updateModalTitle": "发现新版本"
+      "updateModalTitle": "发现新版本",
+      "guideTitle": "按安装方式更新",
+      "guideIntro": "若不能使用左侧一键升级，请按你的安装方式选择下方命令。升级后请重启服务；配置与数据默认保留在 ~/.octop（或 OCTOP_HOME）。",
+      "guideDataNote": "升级不会清空本机数据：用户账号、Agent、对话与记忆、技能、通道与模型配置等均保存在工作目录中，重新安装或更新软件本身即可继续使用。",
+      "guide": {
+        "ui": {
+          "title": "控制台一键升级",
+          "body": "优先使用左侧「检查更新」与「立即升级」（非源码/可编辑安装）。服务模式可在完成后点「重启服务」。"
+        },
+        "installer": {
+          "title": "一键安装脚本",
+          "body": "若你是用官方安装脚本装的，重新执行同一安装命令即可自动升级到最新版（会复用 ~/.octop 下的环境与数据）。"
+        },
+        "cli": {
+          "title": "CLI：octop update",
+          "body": "若命令行可直接使用 octop（安装脚本或 venv 布局），在终端执行："
+        },
+        "pip": {
+          "title": "pip 安装",
+          "body": "若你是用 pip 装到自己的 Python 环境，可升级包本身："
+        },
+        "source": {
+          "title": "源码安装",
+          "body": "从 Git 源码开发/editable 安装时，本页一键升级不可用。请拉取最新代码、构建控制台前端后重新安装到当前环境："
+        },
+        "docker": {
+          "title": "Docker",
+          "body": "Docker 部署请重新构建并启动镜像，并继续挂载原有数据卷（~/.octop 或 octop-data），避免丢数据："
+        },
+        "restart": {
+          "title": "升级后重启",
+          "body": "包更新完成后需要重启进程才生效。任选与你的启动方式匹配的命令："
+        }
+      }
     }
   },
   "agentConfig": {

--- a/dashboard/src/pages/Admin/Plugins/InstalledPluginsPanel.tsx
+++ b/dashboard/src/pages/Admin/Plugins/InstalledPluginsPanel.tsx
@@ -231,11 +231,7 @@ export function InstalledPluginsPanel() {
         okText={t("plugins.install")}
       >
         <Space direction="vertical" style={{ width: "100%" }} size="middle">
-          <Alert
-            type="info"
-            showIcon
-            message={t("plugins.installUrlHint")}
-          />
+          <Alert type="info" showIcon message={t("plugins.installUrlHint")} />
           <Input
             prefix={<Package size={16} />}
             placeholder={t("plugins.installUrlPlaceholder")}

--- a/dashboard/src/pages/Admin/Storage/StorageBackendModal.tsx
+++ b/dashboard/src/pages/Admin/Storage/StorageBackendModal.tsx
@@ -292,7 +292,10 @@ export function StorageBackendDrawer({
         layout="vertical"
         onValuesChange={(_, all) => {
           if (!restoringDraftRef.current) {
-            saveFormDraft(draftScope, all as unknown as Record<string, unknown>);
+            saveFormDraft(
+              draftScope,
+              all as unknown as Record<string, unknown>,
+            );
           }
         }}
       >

--- a/dashboard/src/pages/Admin/Users/index.module.less
+++ b/dashboard/src/pages/Admin/Users/index.module.less
@@ -89,11 +89,19 @@
 .roleOptionSelected {
   box-shadow: 0 0 0 1px var(--role-accent);
   border-color: var(--role-accent);
-  background: color-mix(in srgb, var(--role-accent) 10%, var(--fn-bg-elevated, var(--fn-bg-primary)));
+  background: color-mix(
+    in srgb,
+    var(--role-accent) 10%,
+    var(--fn-bg-elevated, var(--fn-bg-primary))
+  );
 
   &:hover {
     border-color: var(--role-accent);
-    background: color-mix(in srgb, var(--role-accent) 14%, var(--fn-bg-elevated, var(--fn-bg-primary)));
+    background: color-mix(
+      in srgb,
+      var(--role-accent) 14%,
+      var(--fn-bg-elevated, var(--fn-bg-primary))
+    );
   }
 }
 
@@ -156,7 +164,12 @@
   row-gap: 4px;
   padding: 9px 12px 9px 11px;
   border: 1px solid var(--fn-border-secondary);
-  border-left: 3px solid color-mix(in srgb, var(--fn-color-brand, #e85d75) 55%, var(--fn-border-primary));
+  border-left: 3px solid
+    color-mix(
+      in srgb,
+      var(--fn-color-brand, #e85d75) 55%,
+      var(--fn-border-primary)
+    );
   border-radius: var(--fn-radius-md, 8px);
   background: var(--fn-bg-secondary, var(--fn-bg-elevated));
   box-sizing: border-box;

--- a/dashboard/src/pages/Admin/Users/index.tsx
+++ b/dashboard/src/pages/Admin/Users/index.tsx
@@ -1054,9 +1054,7 @@ export default function AdminUsersPage() {
           <Form.Item
             label={t("adminUsers.formPassword")}
             name="password"
-            rules={[
-              { required: true, message: t("adminUsers.formPassword") },
-            ]}
+            rules={[{ required: true, message: t("adminUsers.formPassword") }]}
           >
             <Input.Password
               prefix={<Lock {...FIELD_ICON_PROPS} />}

--- a/dashboard/src/pages/Agent/Channels/components/ChannelDrawer.tsx
+++ b/dashboard/src/pages/Agent/Channels/components/ChannelDrawer.tsx
@@ -199,8 +199,8 @@ export function ChannelDrawer({
   const draftScope = editing
     ? `channel:${editing.id}`
     : selectedKind
-      ? `channel:new:${selectedKind}`
-      : "";
+    ? `channel:new:${selectedKind}`
+    : "";
   const restoringDraftRef = useRef(false);
 
   const stopPolling = useCallback(() => {
@@ -1155,7 +1155,10 @@ export function ChannelDrawer({
           onValuesChange={(changed, all) => {
             if (changed.kind) setSelectedKind(changed.kind as ChannelKey);
             if (!restoringDraftRef.current && draftScope) {
-              saveFormDraft(draftScope, all as unknown as Record<string, unknown>);
+              saveFormDraft(
+                draftScope,
+                all as unknown as Record<string, unknown>,
+              );
             }
           }}
         >

--- a/dashboard/src/pages/Agent/Connectors/index.module.less
+++ b/dashboard/src/pages/Agent/Connectors/index.module.less
@@ -514,8 +514,13 @@
 
 .cliInstallHintError {
   color: var(--fn-text-secondary);
-  background: color-mix(in srgb, var(--fn-danger, #c0392b) 8%, var(--fn-surface-sunken));
-  border: 1px solid color-mix(in srgb, var(--fn-danger, #c0392b) 25%, transparent);
+  background: color-mix(
+    in srgb,
+    var(--fn-danger, #c0392b) 8%,
+    var(--fn-surface-sunken)
+  );
+  border: 1px solid
+    color-mix(in srgb, var(--fn-danger, #c0392b) 25%, transparent);
 }
 
 .cliInstallCommand {

--- a/dashboard/src/pages/Agent/Connectors/index.tsx
+++ b/dashboard/src/pages/Agent/Connectors/index.tsx
@@ -365,7 +365,7 @@ function ConnectorConfigDrawer({
       try {
         popup.document.title = "Feishu Auth";
         popup.document.body.innerHTML =
-          "<p style=\"font:14px/1.5 system-ui;padding:24px;color:#666\">Loading…</p>";
+          '<p style="font:14px/1.5 system-ui;padding:24px;color:#666">Loading…</p>';
       } catch {
         // Cross-origin / closed — ignore.
       }
@@ -458,8 +458,7 @@ function ConnectorConfigDrawer({
         );
       } else {
         message.error(
-          result.error ??
-            t("connectors.cliInstallFailed", "主机 CLI 安装失败"),
+          result.error ?? t("connectors.cliInstallFailed", "主机 CLI 安装失败"),
         );
       }
     } catch (e) {
@@ -515,7 +514,8 @@ function ConnectorConfigDrawer({
         started = await connectorsApi.feishuUserAuthStart({
           app_id,
           app_secret,
-          cli_config_key: String(values.cli_config_key ?? "").trim() || undefined,
+          cli_config_key:
+            String(values.cli_config_key ?? "").trim() || undefined,
         });
       }
       form.setFieldsValue({ cli_config_key: started.cli_config_key });
@@ -532,11 +532,7 @@ function ConnectorConfigDrawer({
       popup?.close();
       console.error(e);
       message.error(
-        apiErrorMessage(
-          e,
-          t("connectors.feishuUserAuthFailed", "授权失败"),
-          t,
-        ),
+        apiErrorMessage(e, t("connectors.feishuUserAuthFailed", "授权失败"), t),
       );
     } finally {
       setFeishuUserAuthBusy(false);
@@ -586,12 +582,11 @@ function ConnectorConfigDrawer({
       setFeishuUserReady(true);
       setFeishuAuthNeedsReauth(false);
       setFeishuUserAuth(null);
-      const persisted =
-        Boolean(instance?.instance_id) && hasStoredCredentials;
+      const persisted = Boolean(instance?.instance_id) && hasStoredCredentials;
       if (done.warning || done.search_docs_scope === false) {
         message.warning(
-          done.warning
-            || t(
+          done.warning ||
+            t(
               "connectors.feishuUserAuthWarning",
               "已登录，但文档搜索权限可能未开通，请检查开放平台权限后重新授权",
             ),
@@ -600,20 +595,13 @@ function ConnectorConfigDrawer({
         message.success(
           persisted
             ? t("connectors.feishuUserAuthSuccessSaved", "授权完成")
-            : t(
-                "connectors.feishuUserAuthSuccess",
-                "授权完成，请保存连接器",
-              ),
+            : t("connectors.feishuUserAuthSuccess", "授权完成，请保存连接器"),
         );
       }
     } catch (e) {
       console.error(e);
       message.error(
-        apiErrorMessage(
-          e,
-          t("connectors.feishuUserAuthFailed", "授权失败"),
-          t,
-        ),
+        apiErrorMessage(e, t("connectors.feishuUserAuthFailed", "授权失败"), t),
       );
     } finally {
       setFeishuUserAuthBusy(false);
@@ -732,11 +720,13 @@ function ConnectorConfigDrawer({
     const feishuAppIdChanged =
       entry.kind === "feishu-cli" &&
       Boolean(preview.app_id) &&
-      String(values.app_id ?? "").trim() !== String(preview.app_id ?? "").trim();
+      String(values.app_id ?? "").trim() !==
+        String(preview.app_id ?? "").trim();
     const wecomBotIdChanged =
       entry.kind === "wecom-cli" &&
       Boolean(preview.bot_id) &&
-      String(values.bot_id ?? "").trim() !== String(preview.bot_id ?? "").trim();
+      String(values.bot_id ?? "").trim() !==
+        String(preview.bot_id ?? "").trim();
     const identityChanged = feishuAppIdChanged || wecomBotIdChanged;
     if (identityChanged && !freshSecret) {
       message.warning(
@@ -941,7 +931,11 @@ function ConnectorConfigDrawer({
                 </Button>
               )}
               {!isAdmin && cliInfo?.installed && (
-                <Button type="default" icon={<CheckCircle2 size={14} />} disabled>
+                <Button
+                  type="default"
+                  icon={<CheckCircle2 size={14} />}
+                  disabled
+                >
                   {t("connectors.cliReady", "CLI 已就绪")}
                 </Button>
               )}
@@ -1104,7 +1098,10 @@ function ConnectorConfigDrawer({
           layout="vertical"
           onValuesChange={(_, all) => {
             if (!restoringDraftRef.current && draftScope) {
-              saveFormDraft(draftScope, all as unknown as Record<string, unknown>);
+              saveFormDraft(
+                draftScope,
+                all as unknown as Record<string, unknown>,
+              );
             }
           }}
         >
@@ -1237,19 +1234,19 @@ function ConnectorConfigDrawer({
                         "用户授权已失效，请重新登录授权。",
                       )
                     : feishuUserReady
-                      ? t(
-                          "connectors.feishuUserAuthReady",
-                          "已授权，可搜索文档。",
-                        )
-                      : feishuUserAuth
-                        ? t(
-                            "connectors.feishuUserAuthPendingHint",
-                            "请在弹出的页面完成授权，然后点「我已授权」。",
-                          )
-                        : t(
-                            "connectors.feishuUserAuthHint",
-                            "点击登录授权，完成后点「我已授权」。",
-                          )}
+                    ? t(
+                        "connectors.feishuUserAuthReady",
+                        "已授权，可搜索文档。",
+                      )
+                    : feishuUserAuth
+                    ? t(
+                        "connectors.feishuUserAuthPendingHint",
+                        "请在弹出的页面完成授权，然后点「我已授权」。",
+                      )
+                    : t(
+                        "connectors.feishuUserAuthHint",
+                        "点击登录授权，完成后点「我已授权」。",
+                      )}
                 </div>
                 {feishuUserReady && feishuRefreshExpiresAt && (
                   <div className={styles.feishuUserAuthHint}>
@@ -1262,7 +1259,11 @@ function ConnectorConfigDrawer({
                 )}
                 <div className={styles.quickAuthBar}>
                   <Button
-                    type={feishuUserReady && !feishuAuthNeedsReauth ? "default" : "primary"}
+                    type={
+                      feishuUserReady && !feishuAuthNeedsReauth
+                        ? "default"
+                        : "primary"
+                    }
                     loading={feishuUserAuthBusy}
                     onClick={() => void handleFeishuUserAuthStart()}
                   >
@@ -1286,10 +1287,7 @@ function ConnectorConfigDrawer({
                     className={styles.feishuUserAuthReopen}
                     onClick={() => openUrl(feishuUserAuth.verification_url)}
                   >
-                    {t(
-                      "connectors.feishuUserAuthReopen",
-                      "未弹出？再打开一次",
-                    )}
+                    {t("connectors.feishuUserAuthReopen", "未弹出？再打开一次")}
                   </button>
                 )}
               </div>
@@ -1343,66 +1341,66 @@ function ConnectorConfigDrawer({
           {entry.auth_kind === "api_key" &&
             entry.kind !== "feishu-cli" &&
             entry.kind !== "wecom-cli" && (
-            <>
-              <Form.Item
-                name="api_key"
-                label={t("connectors.apiKey", "API Key")}
-                rules={secretFieldRules(secretRequired)}
-                extra={
-                  configuredExtra(preview, "api_key_configured", t) ??
-                  (!hideFieldGuide && manualUrl ? (
-                    <a href={manualUrl} target="_blank" rel="noreferrer">
-                      {t("connectors.apiKeyDoc", "查看如何获取 API Key")}
-                    </a>
-                  ) : undefined)
-                }
-              >
-                <Input.Password
-                  placeholder={
-                    hasStoredCredentials
-                      ? t("connectors.secretPlaceholder", "留空表示不修改")
-                      : entry.kind === "tencent-ima"
-                      ? t(
-                          "connectors.imaApiKeyPlaceholder",
-                          "从 IMA 配置页复制（仅展示一次）",
-                        )
-                      : t("connectors.apiKeyPlaceholder", "粘贴 API Key")
+              <>
+                <Form.Item
+                  name="api_key"
+                  label={t("connectors.apiKey", "API Key")}
+                  rules={secretFieldRules(secretRequired)}
+                  extra={
+                    configuredExtra(preview, "api_key_configured", t) ??
+                    (!hideFieldGuide && manualUrl ? (
+                      <a href={manualUrl} target="_blank" rel="noreferrer">
+                        {t("connectors.apiKeyDoc", "查看如何获取 API Key")}
+                      </a>
+                    ) : undefined)
                   }
-                />
-              </Form.Item>
-              {entry.kind === "tencent-ima" && (
-                <Form.Item
-                  name="client_id"
-                  label="Client ID"
-                  rules={[{ required: true }]}
                 >
-                  <Input
-                    placeholder={t(
-                      "connectors.imaClientIdPlaceholder",
-                      "从 IMA 配置页复制",
-                    )}
+                  <Input.Password
+                    placeholder={
+                      hasStoredCredentials
+                        ? t("connectors.secretPlaceholder", "留空表示不修改")
+                        : entry.kind === "tencent-ima"
+                        ? t(
+                            "connectors.imaApiKeyPlaceholder",
+                            "从 IMA 配置页复制（仅展示一次）",
+                          )
+                        : t("connectors.apiKeyPlaceholder", "粘贴 API Key")
+                    }
                   />
                 </Form.Item>
-              )}
-              {entry.kind === "tencent-lexiang" && (
-                <Form.Item
-                  name="client_id"
-                  label={t(
-                    "connectors.lexiangCompanyFrom",
-                    "企业标识 (company_from)",
-                  )}
-                  rules={[{ required: true }]}
-                >
-                  <Input
-                    placeholder={t(
-                      "connectors.lexiangCompanyFromPlaceholder",
-                      "从乐享凭证页复制",
+                {entry.kind === "tencent-ima" && (
+                  <Form.Item
+                    name="client_id"
+                    label="Client ID"
+                    rules={[{ required: true }]}
+                  >
+                    <Input
+                      placeholder={t(
+                        "connectors.imaClientIdPlaceholder",
+                        "从 IMA 配置页复制",
+                      )}
+                    />
+                  </Form.Item>
+                )}
+                {entry.kind === "tencent-lexiang" && (
+                  <Form.Item
+                    name="client_id"
+                    label={t(
+                      "connectors.lexiangCompanyFrom",
+                      "企业标识 (company_from)",
                     )}
-                  />
-                </Form.Item>
-              )}
-            </>
-          )}
+                    rules={[{ required: true }]}
+                  >
+                    <Input
+                      placeholder={t(
+                        "connectors.lexiangCompanyFromPlaceholder",
+                        "从乐享凭证页复制",
+                      )}
+                    />
+                  </Form.Item>
+                )}
+              </>
+            )}
 
           {entry.auth_kind === "oauth2" && (
             <>

--- a/dashboard/src/pages/Agent/Memory/MemoryPanel.tsx
+++ b/dashboard/src/pages/Agent/Memory/MemoryPanel.tsx
@@ -133,14 +133,14 @@ export default function MemoryPanel({
                   "按人、项目、工具等主题，分组浏览相关记忆",
                 )
               : libraryView === "atoms"
-                ? t(
-                    "memory.library.hintAtoms",
-                    "扁平展示全部记忆，可按重要程度筛选",
-                  )
-                : t(
-                    "memory.library.hintRaw",
-                    "提炼前捕获的原始对话记忆（条数与「对话记录」不一一对应）",
-                  )}
+              ? t(
+                  "memory.library.hintAtoms",
+                  "扁平展示全部记忆，可按重要程度筛选",
+                )
+              : t(
+                  "memory.library.hintRaw",
+                  "提炼前捕获的原始对话记忆（条数与「对话记录」不一一对应）",
+                )}
           </span>
         </div>
         {libraryView === "tree" ? (

--- a/dashboard/src/pages/Agent/Memory/Overview.tsx
+++ b/dashboard/src/pages/Agent/Memory/Overview.tsx
@@ -215,10 +215,7 @@ export default function Overview({
         ) : !state.growth || state.growth.series.length === 0 ? (
           <Empty
             image={Empty.PRESENTED_IMAGE_SIMPLE}
-            description={t(
-              "memory.overview.turnsEmpty",
-              "近 7 天暂无对话轮次",
-            )}
+            description={t("memory.overview.turnsEmpty", "近 7 天暂无对话轮次")}
           />
         ) : (
           <div className={styles.turnsChart}>

--- a/dashboard/src/pages/Agent/Memory/VectorSearchConfig.tsx
+++ b/dashboard/src/pages/Agent/Memory/VectorSearchConfig.tsx
@@ -1,14 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { useTranslation } from "react-i18next";
-import {
-  Select,
-  Input,
-  Button,
-  Spin,
-  Progress,
-  Modal,
-  Alert,
-} from "antd";
+import { Select, Input, Button, Spin, Progress, Modal, Alert } from "antd";
 import { message } from "@/utils/antdMessage";
 
 import { Download, CheckCircle, AlertCircle } from "lucide-react";

--- a/dashboard/src/pages/Agent/Personalization/components/MBTISelector.tsx
+++ b/dashboard/src/pages/Agent/Personalization/components/MBTISelector.tsx
@@ -408,8 +408,7 @@ export default function MBTISelector({
           {t("personalization.mbti.listSummary", {
             total: types.length,
             selected: currentLabel,
-            defaultValue:
-              "当前有（{{total}}）个人格，已选中「{{selected}}」",
+            defaultValue: "当前有（{{total}}）个人格，已选中「{{selected}}」",
           })}
         </span>
         {!showHeader && showTestAction && (

--- a/dashboard/src/pages/Agent/Skills/components/SkillDrawer.module.less
+++ b/dashboard/src/pages/Agent/Skills/components/SkillDrawer.module.less
@@ -30,7 +30,6 @@
   gap: 16px;
 }
 
-
 .createFields {
   min-width: 0;
   flex-shrink: 0;

--- a/dashboard/src/pages/Agent/Skills/components/SkillDrawer.tsx
+++ b/dashboard/src/pages/Agent/Skills/components/SkillDrawer.tsx
@@ -280,8 +280,8 @@ export function SkillDrawer({
   const drawerTitle = isCreate
     ? t("skills.createSkill")
     : localEditMode
-      ? t("skills.editSkill")
-      : t("skills.viewSkill");
+    ? t("skills.editSkill")
+    : t("skills.viewSkill");
 
   const nameField = (
     <Form.Item
@@ -493,9 +493,7 @@ export function SkillDrawer({
         <Form
           form={form}
           layout="vertical"
-          className={
-            isCreate || isEdit ? styles.createForm : styles.viewForm
-          }
+          className={isCreate || isEdit ? styles.createForm : styles.viewForm}
           onFinish={handleSubmit}
         >
           {isCreate || isEdit ? (

--- a/dashboard/src/pages/Agent/Skills/components/SkillHubTab.tsx
+++ b/dashboard/src/pages/Agent/Skills/components/SkillHubTab.tsx
@@ -62,10 +62,7 @@ function normalizeHubSkill(raw: Record<string, unknown>): SkillHubSkill {
   };
 }
 
-export default function SkillHubTab({
-  target,
-  onInstalled,
-}: SkillHubTabProps) {
+export default function SkillHubTab({ target, onInstalled }: SkillHubTabProps) {
   const { t } = useTranslation();
   const [hubSkills, setHubSkills] = useState<SkillHubSkill[]>([]);
   const [rankings, setRankings] = useState<Record<string, SkillHubSkill[]>>(
@@ -107,7 +104,6 @@ export default function SkillHubTab({
     }
     return null;
   }, [target?.type, agentId, packageId]);
-
 
   const fetchRankings = useCallback(
     async (force = false) => {

--- a/dashboard/src/pages/Agent/Skills/components/SkillImportModal.tsx
+++ b/dashboard/src/pages/Agent/Skills/components/SkillImportModal.tsx
@@ -145,11 +145,7 @@ export function SkillImportModal({
       keyboard={!busy}
       footer={
         <div style={{ textAlign: "right" }}>
-          <Button
-            onClick={onClose}
-            disabled={busy}
-            style={{ marginRight: 8 }}
-          >
+          <Button onClick={onClose} disabled={busy} style={{ marginRight: 8 }}>
             {t("common.cancel")}
           </Button>
           <Button
@@ -218,12 +214,8 @@ export function SkillImportModal({
           <div className={styles.importHintBlock}>
             <p className={styles.importHintTitle}>{t("skills.zipHintTitle")}</p>
             <div className={styles.importHintExamples}>
-              <code className={styles.importHintCode}>
-                skill-a/SKILL.md
-              </code>
-              <code className={styles.importHintCode}>
-                skill-b/SKILL.md
-              </code>
+              <code className={styles.importHintCode}>skill-a/SKILL.md</code>
+              <code className={styles.importHintCode}>skill-b/SKILL.md</code>
             </div>
             <p className={styles.importHintTitle} style={{ marginTop: 10 }}>
               {t("skills.zipHintDetail")}

--- a/dashboard/src/pages/Agent/Skills/components/SkillPackagesTab.tsx
+++ b/dashboard/src/pages/Agent/Skills/components/SkillPackagesTab.tsx
@@ -41,11 +41,7 @@ function PackageSkillIcon({
 }) {
   if (iconUrl) {
     return (
-      <img
-        src={iconUrl}
-        alt=""
-        className={styles.packageSkillRowIconImg}
-      />
+      <img src={iconUrl} alt="" className={styles.packageSkillRowIconImg} />
     );
   }
   if (emoji) {
@@ -66,8 +62,9 @@ export default function SkillPackagesTab({
   const [loading, setLoading] = useState(true);
   const [mountingId, setMountingId] = useState<string | null>(null);
   const [detailOpen, setDetailOpen] = useState(false);
-  const [detailPackage, setDetailPackage] =
-    useState<SkillPackageDetail | null>(null);
+  const [detailPackage, setDetailPackage] = useState<SkillPackageDetail | null>(
+    null,
+  );
   const [detailLoading, setDetailLoading] = useState(false);
 
   const hubSkillsBySlug = useMemo(() => hubInfoBySlugFromCache(), []);
@@ -75,7 +72,10 @@ export default function SkillPackagesTab({
   useEffect(() => {
     let cancelled = false;
     setLoading(true);
-    Promise.all([skillPackagesApi.list(), skillPackagesApi.listMounted(agentId)])
+    Promise.all([
+      skillPackagesApi.list(),
+      skillPackagesApi.listMounted(agentId),
+    ])
       .then(([packages, mounted]) => {
         if (cancelled) return;
         setCatalog(packages);
@@ -292,8 +292,7 @@ export default function SkillPackagesTab({
                     packageSkill.description ||
                     t("skills.noDescription");
                   const shadows = workspaceSlugs.has(packageSkill.slug);
-                  const canToggle =
-                    detailMounted && !!installed && !shadows;
+                  const canToggle = detailMounted && !!installed && !shadows;
 
                   return (
                     <div key={packageSkill.slug}>
@@ -306,10 +305,7 @@ export default function SkillPackagesTab({
                               background: iconUrl ? "transparent" : "#0596691a",
                             }}
                           >
-                            <PackageSkillIcon
-                              iconUrl={iconUrl}
-                              emoji={emoji}
-                            />
+                            <PackageSkillIcon iconUrl={iconUrl} emoji={emoji} />
                           </div>
                           <div className={styles.packageSkillRowMeta}>
                             <div className={styles.packageSkillRowLabel}>

--- a/dashboard/src/pages/Agent/Skills/components/SkillsTabs.tsx
+++ b/dashboard/src/pages/Agent/Skills/components/SkillsTabs.tsx
@@ -29,7 +29,9 @@ export default function SkillsTabs({ agentId }: SkillsTabsProps) {
   const { t } = useTranslation();
   const [activeTab, setActiveTab] = useState<SkillsTab>("custom");
   const onInstalledTab =
-    activeTab === "custom" || activeTab === "builtin" || activeTab === "packages";
+    activeTab === "custom" ||
+    activeTab === "builtin" ||
+    activeTab === "packages";
   const installedSkills = useSkills(agentId, { enabled: onInstalledTab });
 
   const noAgent = (
@@ -88,10 +90,7 @@ export default function SkillsTabs({ agentId }: SkillsTabsProps) {
             noAgent
           )
         ) : activeTab === "skillhub" && agentId ? (
-          <SkillHubTab
-            key={agentId}
-            target={{ type: "agent", agentId }}
-          />
+          <SkillHubTab key={agentId} target={{ type: "agent", agentId }} />
         ) : activeTab === "packages" && agentId ? (
           <SkillPackagesTab
             key={agentId}

--- a/dashboard/src/pages/Agent/Skills/components/parseSkillZip.test.ts
+++ b/dashboard/src/pages/Agent/Skills/components/parseSkillZip.test.ts
@@ -38,8 +38,8 @@ describe("parseSkillZip", () => {
     ]);
     expect(
       decodeBase64(
-        writer?.files.find((item) => item.path === "notes.txt")?.contentBase64 ??
-          "",
+        writer?.files.find((item) => item.path === "notes.txt")
+          ?.contentBase64 ?? "",
       ),
     ).toBe("hi");
   });
@@ -110,7 +110,9 @@ describe("parseSkillZip", () => {
       "archive.zip",
     );
 
-    const skills = await parseSkillZip(file, { rootSlugFallback: "custom-slug" });
+    const skills = await parseSkillZip(file, {
+      rootSlugFallback: "custom-slug",
+    });
     expect(skills).toHaveLength(1);
     expect(skills[0].slug).toBe("custom-slug");
   });

--- a/dashboard/src/pages/Agent/Skills/components/parseSkillZip.ts
+++ b/dashboard/src/pages/Agent/Skills/components/parseSkillZip.ts
@@ -25,8 +25,7 @@ function bytesToBase64(bytes: Uint8Array): string {
 function isSkippedPath(path: string): boolean {
   const lower = path.toLowerCase().replace(/\\/g, "/");
   return (
-    SKIP_MARKERS.some((marker) => lower.includes(marker)) ||
-    lower.endsWith("/")
+    SKIP_MARKERS.some((marker) => lower.includes(marker)) || lower.endsWith("/")
   );
 }
 
@@ -61,9 +60,7 @@ function stripOuterWrapper(
   entries: Array<{ zipPath: string; relPath: string }>,
 ): Array<{ zipPath: string; relPath: string }> {
   const tops = new Set(
-    entries
-      .map((entry) => entry.relPath.split("/")[0] || "")
-      .filter(Boolean),
+    entries.map((entry) => entry.relPath.split("/")[0] || "").filter(Boolean),
   );
   if (tops.size !== 1) return entries;
   const wrapper = [...tops][0];

--- a/dashboard/src/pages/Agent/Skills/index.module.less
+++ b/dashboard/src/pages/Agent/Skills/index.module.less
@@ -207,7 +207,6 @@
   flex-shrink: 0;
 }
 
-
 .skillsTable {
   width: 100%;
 

--- a/dashboard/src/pages/Agent/Skills/useSkills.ts
+++ b/dashboard/src/pages/Agent/Skills/useSkills.ts
@@ -73,8 +73,8 @@ const toSpec = (row: ServerSummary): SkillSpec => ({
     row.kind === "builtin"
       ? "builtin"
       : row.kind === "package"
-        ? "package"
-        : "workspace",
+      ? "package"
+      : "workspace",
   emoji: row.emoji,
   iconUrl: row.icon_url,
 });

--- a/dashboard/src/pages/Chat/chatBrowserPanel.partial.less
+++ b/dashboard/src/pages/Chat/chatBrowserPanel.partial.less
@@ -332,7 +332,10 @@
   color: var(--fn-text-secondary);
   cursor: pointer;
   opacity: 1;
-  transition: opacity 0.12s ease, background 0.12s ease, color 0.12s ease;
+  transition:
+    opacity 0.12s ease,
+    background 0.12s ease,
+    color 0.12s ease;
 
   &:hover:not(:disabled) {
     color: var(--fn-color-brand, #4f6ef7);

--- a/dashboard/src/pages/Chat/components/AssistantProcessSummary.tsx
+++ b/dashboard/src/pages/Chat/components/AssistantProcessSummary.tsx
@@ -41,14 +41,14 @@ function AssistantProcessSummary({
           defaultValue: "已调用 {{tools}} 次工具，{{thinking}} 次深度思考",
         })
       : toolCount > 0
-        ? t("chat.processSummaryToolsOnly", {
-            tools: toolCount,
-            defaultValue: "已调用 {{tools}} 次工具",
-          })
-        : t("chat.processSummaryThinkingOnly", {
-            thinking: thinkingCount,
-            defaultValue: "{{thinking}} 次深度思考",
-          });
+      ? t("chat.processSummaryToolsOnly", {
+          tools: toolCount,
+          defaultValue: "已调用 {{tools}} 次工具",
+        })
+      : t("chat.processSummaryThinkingOnly", {
+          thinking: thinkingCount,
+          defaultValue: "{{thinking}} 次深度思考",
+        });
 
   return (
     <div className={styles.processSummary}>

--- a/dashboard/src/pages/Chat/components/ChatDockFileList.tsx
+++ b/dashboard/src/pages/Chat/components/ChatDockFileList.tsx
@@ -237,9 +237,7 @@ export default function ChatDockFileList({
         URL.revokeObjectURL(a.href);
       } catch (err: unknown) {
         if (isNotFoundApiError(err)) {
-          message.warning(
-            t("workspace.fileMaybeDeleted", "文件可能已被删除"),
-          );
+          message.warning(t("workspace.fileMaybeDeleted", "文件可能已被删除"));
           return;
         }
         message.error(
@@ -258,10 +256,7 @@ export default function ChatDockFileList({
       <div className={styles.dockFileListEmpty}>
         <Empty
           image={Empty.PRESENTED_IMAGE_SIMPLE}
-          description={t(
-            "chat.dockFileListEmpty",
-            "暂无工具生成或发送的文件",
-          )}
+          description={t("chat.dockFileListEmpty", "暂无工具生成或发送的文件")}
         />
       </div>
     );

--- a/dashboard/src/pages/Chat/components/ChatDockPanels.tsx
+++ b/dashboard/src/pages/Chat/components/ChatDockPanels.tsx
@@ -67,8 +67,8 @@ export default function ChatDockPanels({
         slot === "bottom"
           ? "bottom"
           : dockMode === "right" && isMobile
-            ? "popup"
-            : dockMode
+          ? "popup"
+          : dockMode
       }
       onModeChange={onModeChange}
       onClose={onClose}
@@ -76,8 +76,8 @@ export default function ChatDockPanels({
         slot === "bottom"
           ? { height: panelSizes.bottomHeight }
           : dockMode === "right" && !isMobile
-            ? { width: panelSizes.rightWidth }
-            : undefined
+          ? { width: panelSizes.rightWidth }
+          : undefined
       }
       agentId={agentId}
       filePaths={filePaths}

--- a/dashboard/src/pages/Chat/components/ChatTitleBar.tsx
+++ b/dashboard/src/pages/Chat/components/ChatTitleBar.tsx
@@ -2,13 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Dropdown } from "antd";
 import type { MenuProps } from "antd";
 import { useTranslation } from "react-i18next";
-import {
-  MoreVertical,
-  Pin,
-  PinOff,
-  Pencil,
-  Trash2,
-} from "lucide-react";
+import { MoreVertical, Pin, PinOff, Pencil, Trash2 } from "lucide-react";
 import { showConfirmModal } from "../../../utils/confirmModal";
 import type { Session } from "../hooks/useSessions";
 import SessionChannelIcon from "./SessionChannelIcon";

--- a/dashboard/src/pages/Chat/components/FilePanelContent.tsx
+++ b/dashboard/src/pages/Chat/components/FilePanelContent.tsx
@@ -218,9 +218,7 @@ export default function FilePanelContent({
         {showPreviewToggle && (
           <Tooltip
             title={
-              previewMode
-                ? t("workspace.source", "源码")
-                : t("common.preview")
+              previewMode ? t("workspace.source", "源码") : t("common.preview")
             }
           >
             <button

--- a/dashboard/src/pages/Chat/components/GeneratingIndicator.tsx
+++ b/dashboard/src/pages/Chat/components/GeneratingIndicator.tsx
@@ -22,7 +22,11 @@ export default function GeneratingIndicator({
   const showTimer = Boolean(showElapsed && startedAt != null && startedAt > 0);
 
   return (
-    <div className={styles.generatingIndicator} role="status" aria-live="polite">
+    <div
+      className={styles.generatingIndicator}
+      role="status"
+      aria-live="polite"
+    >
       <span className={styles.thinkingDot} />
       <span className={styles.thinkingDot} />
       <span className={styles.thinkingDot} />

--- a/dashboard/src/pages/Chat/components/MessageList.tsx
+++ b/dashboard/src/pages/Chat/components/MessageList.tsx
@@ -10,11 +10,7 @@ import {
   type ReactNode,
 } from "react";
 import { Spin, Button } from "antd";
-import {
-  Virtuoso,
-  type Components,
-  type VirtuosoHandle,
-} from "react-virtuoso";
+import { Virtuoso, type Components, type VirtuosoHandle } from "react-virtuoso";
 import { useTranslation } from "react-i18next";
 import type { ChatMessage } from "../hooks/useChat";
 import type { ComposerTagLookups } from "./UserMessageComposerTags";

--- a/dashboard/src/pages/Chat/components/SessionChannelIcon.tsx
+++ b/dashboard/src/pages/Chat/components/SessionChannelIcon.tsx
@@ -52,7 +52,12 @@ export default function SessionChannelIcon({
       src={iconSrc}
       alt=""
       className={className}
-      style={{ width: size, height: size, objectFit: "contain", display: "block" }}
+      style={{
+        width: size,
+        height: size,
+        objectFit: "contain",
+        display: "block",
+      }}
       aria-label={label}
     />
   );

--- a/dashboard/src/pages/Chat/components/generatingGate.test.ts
+++ b/dashboard/src/pages/Chat/components/generatingGate.test.ts
@@ -1,8 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-  chatGeneratingPhase,
-  shouldShowGenerating,
-} from "./generatingGate";
+import { chatGeneratingPhase, shouldShowGenerating } from "./generatingGate";
 
 describe("shouldShowGenerating", () => {
   it("is true while streaming and not loading history", () => {

--- a/dashboard/src/pages/Chat/components/generatingGate.ts
+++ b/dashboard/src/pages/Chat/components/generatingGate.ts
@@ -20,8 +20,7 @@ export function chatGeneratingPhase(opts: {
 }): { showFooter: boolean; showElapsed: boolean } {
   const showFooter = shouldShowGenerating(opts);
   const showElapsed = Boolean(
-    showFooter &&
-      (!opts.lastMessageRole || opts.lastMessageRole === "user"),
+    showFooter && (!opts.lastMessageRole || opts.lastMessageRole === "user"),
   );
   return { showFooter, showElapsed };
 }

--- a/dashboard/src/pages/Chat/hooks/scrollFreeMode.test.ts
+++ b/dashboard/src/pages/Chat/hooks/scrollFreeMode.test.ts
@@ -3,26 +3,26 @@ import { shouldEnterFreeModeOnScrollUp } from "./scrollFreeMode";
 
 describe("shouldEnterFreeModeOnScrollUp", () => {
   it("ignores tiny dips while still near the bottom (Safari reflow)", () => {
-    expect(
-      shouldEnterFreeModeOnScrollUp({ upDelta: 2, atBottom: true }),
-    ).toBe(false);
+    expect(shouldEnterFreeModeOnScrollUp({ upDelta: 2, atBottom: true })).toBe(
+      false,
+    );
   });
 
   it("leaves follow on intentional upward scroll even near the bottom", () => {
-    expect(
-      shouldEnterFreeModeOnScrollUp({ upDelta: 20, atBottom: true }),
-    ).toBe(true);
+    expect(shouldEnterFreeModeOnScrollUp({ upDelta: 20, atBottom: true })).toBe(
+      true,
+    );
   });
 
   it("always leaves follow once outside the bottom sticky zone", () => {
-    expect(
-      shouldEnterFreeModeOnScrollUp({ upDelta: 3, atBottom: false }),
-    ).toBe(true);
+    expect(shouldEnterFreeModeOnScrollUp({ upDelta: 3, atBottom: false })).toBe(
+      true,
+    );
   });
 
   it("ignores non-upward movement", () => {
-    expect(
-      shouldEnterFreeModeOnScrollUp({ upDelta: 0, atBottom: false }),
-    ).toBe(false);
+    expect(shouldEnterFreeModeOnScrollUp({ upDelta: 0, atBottom: false })).toBe(
+      false,
+    );
   });
 });

--- a/dashboard/src/pages/Chat/hooks/sealPriorStreamingAssistants.test.ts
+++ b/dashboard/src/pages/Chat/hooks/sealPriorStreamingAssistants.test.ts
@@ -33,7 +33,12 @@ describe("sealPriorStreamingAssistants", () => {
   it("seals the previous text tail even when it is the last message", () => {
     const input = [
       msg({ id: "a1", role: "assistant", content: "hi", status: "done" }),
-      msg({ id: "a2", role: "assistant", content: "more", status: "streaming" }),
+      msg({
+        id: "a2",
+        role: "assistant",
+        content: "more",
+        status: "streaming",
+      }),
     ];
     const out = sealPriorStreamingAssistants(input);
     expect(out[1].status).toBe("done");

--- a/dashboard/src/pages/Chat/hooks/sealPriorStreamingAssistants.ts
+++ b/dashboard/src/pages/Chat/hooks/sealPriorStreamingAssistants.ts
@@ -12,11 +12,7 @@ export function sealPriorStreamingAssistants(
   if (messages.length === 0) return messages;
   let changed = false;
   const next = messages.map((m) => {
-    if (
-      m.role === "assistant" &&
-      m.status === "streaming" &&
-      !m.toolData
-    ) {
+    if (m.role === "assistant" && m.status === "streaming" && !m.toolData) {
       changed = true;
       return { ...m, status: "done" as const };
     }

--- a/dashboard/src/pages/Chat/hooks/useAutoScroll.ts
+++ b/dashboard/src/pages/Chat/hooks/useAutoScroll.ts
@@ -12,7 +12,13 @@
  *  programmatic via isProgrammaticScrollRef so handleScroll ignores them.
  */
 
-import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
 import type { VirtuosoHandle } from "react-virtuoso";
 import { shouldEnterFreeModeOnScrollUp } from "./scrollFreeMode";
 
@@ -416,10 +422,7 @@ export function useAutoScroll({
       }
       // Bottom overscroll refresh must work even under programmatic pin.
       if (e.deltaY > 0 && isAtBottom()) {
-        if (
-          !isProgrammaticRef.current &&
-          isAtBottom(FOLLOW_RESUME_THRESHOLD)
-        ) {
+        if (!isProgrammaticRef.current && isAtBottom(FOLLOW_RESUME_THRESHOLD)) {
           enterFollowMode();
         }
         accumulateOverscroll(e.deltaY);

--- a/dashboard/src/pages/Chat/hooks/useChatDockPanel.test.ts
+++ b/dashboard/src/pages/Chat/hooks/useChatDockPanel.test.ts
@@ -25,9 +25,9 @@ describe("useChatDockPanel tabs", () => {
       result.current.openFileAt("/.octop/agents/main/outbound/a.txt");
     });
     const fileId = dockFileTabId("outbound/a.txt", "main");
-    expect(result.current.openTabs.filter((t) => t.kind === "file")).toHaveLength(
-      1,
-    );
+    expect(
+      result.current.openTabs.filter((t) => t.kind === "file"),
+    ).toHaveLength(1);
     expect(result.current.activeTabId).toBe(fileId);
     expect(result.current.openTabs.map((t) => t.id)).toEqual([fileId]);
   });

--- a/dashboard/src/pages/Chat/hooks/useChatDockPanel.ts
+++ b/dashboard/src/pages/Chat/hooks/useChatDockPanel.ts
@@ -1,9 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import type { PanelMode } from "../../../components/BrowserWorkspace";
-import {
-  canonicalizeDockFilePath,
-  dockFileTabId,
-} from "../utils/dockFilePath";
+import { canonicalizeDockFilePath, dockFileTabId } from "../utils/dockFilePath";
 import { usePanelResize, type PanelSizes } from "./usePanelResize";
 
 const PANEL_MODE_KEY = "octop:chat-dock:mode";
@@ -86,10 +83,7 @@ function fallbackActiveId(
 /**
  * Shared chat dock with tabbed file list / file viewers / browser.
  */
-export function useChatDockPanel(
-  isMobile: boolean,
-  agentId?: string | null,
-) {
+export function useChatDockPanel(isMobile: boolean, agentId?: string | null) {
   const [dockOpen, setDockOpen] = useState(false);
   const [dockMode, setDockMode] = useState<PanelMode>(loadPanelMode);
   const [openTabs, setOpenTabs] = useState<DockTab[]>([]);
@@ -118,9 +112,7 @@ export function useChatDockPanel(
 
   const openFileAt = useCallback(
     (path?: string | null) => {
-      const normalized = path
-        ? canonicalizeDockFilePath(path, agentId)
-        : "";
+      const normalized = path ? canonicalizeDockFilePath(path, agentId) : "";
       if (!normalized) {
         openFileList();
         return;

--- a/dashboard/src/pages/Chat/hooks/useChatFileDetection.ts
+++ b/dashboard/src/pages/Chat/hooks/useChatFileDetection.ts
@@ -81,9 +81,7 @@ function pathFromArgs(raw: unknown): string {
 function pathFromText(text: string): string {
   if (!text) return "";
   // Prefer full absolute path ending at ``/.octop/agents/…`` (keep ``/home/…``).
-  const absMatch = text.match(
-    /(?:\/[\w.-]+)*\/\.octop\/agents\/[^\s"'<>]+/i,
-  );
+  const absMatch = text.match(/(?:\/[\w.-]+)*\/\.octop\/agents\/[^\s"'<>]+/i);
   if (absMatch) return absMatch[0];
   const outbound = text.match(
     /(?:^|[\s"'`])((?:outbound|inbound)\/[^\s"'<>]+)/i,
@@ -166,18 +164,10 @@ export function useChatFileDetection(
           m.attachments,
         );
         for (const file of media.files) {
-          addPath(
-            paths,
-            workspacePathFromAccessUrl(file.url) ?? null,
-            agentId,
-          );
+          addPath(paths, workspacePathFromAccessUrl(file.url) ?? null, agentId);
         }
         for (const img of media.images) {
-          addPath(
-            paths,
-            workspacePathFromAccessUrl(img.url) ?? null,
-            agentId,
-          );
+          addPath(paths, workspacePathFromAccessUrl(img.url) ?? null, agentId);
         }
         for (const video of media.videos) {
           addPath(

--- a/dashboard/src/pages/Chat/index.module.less
+++ b/dashboard/src/pages/Chat/index.module.less
@@ -179,7 +179,8 @@
 
   &:focus {
     border-color: var(--fn-color-brand, #4f6ef7);
-    box-shadow: 0 0 0 2px color-mix(in srgb, var(--fn-color-brand, #4f6ef7) 18%, transparent);
+    box-shadow: 0 0 0 2px
+      color-mix(in srgb, var(--fn-color-brand, #4f6ef7) 18%, transparent);
   }
 }
 

--- a/dashboard/src/pages/Chat/index.tsx
+++ b/dashboard/src/pages/Chat/index.tsx
@@ -691,101 +691,101 @@ function ChatPageInner() {
           </div>
 
           {!isMobile && !dockOpen && !agentProfileOpen && (
-              <div className={styles.chatFloatActions}>
-                {resolvedAgentId && (
-                  <Tooltip
-                    title={t("chat.agentProfile.open")}
-                    mouseEnterDelay={0.35}
-                    placement="left"
-                  >
-                    <span className={styles.chatFloatBtnWrap}>
-                      <button
-                        type="button"
-                        className={styles.agentProfileBtn}
-                        onClick={() => setAgentProfileOpen(true)}
-                        aria-label={t("chat.agentProfile.open")}
-                      >
-                        <GraduationCap size={20} strokeWidth={2.1} />
-                      </button>
-                    </span>
-                  </Tooltip>
-                )}
-                {panelFilePaths.length > 0 && (
-                  <Tooltip
-                    title={t("chat.modifiedFiles", {
-                      count: panelFilePaths.length,
-                      defaultValue: "已修改文件（{{count}}）",
-                    })}
-                    mouseEnterDelay={0.35}
-                    placement="left"
-                  >
-                    <span className={styles.chatFloatBtnWrap}>
-                      <button
-                        type="button"
-                        className={styles.chatFloatBtn}
-                        onClick={() => openFileList()}
-                        aria-label={t("chat.modifiedFiles", {
-                          count: panelFilePaths.length,
-                          defaultValue: "已修改文件（{{count}}）",
-                        })}
-                      >
-                        <FilePen size={20} strokeWidth={2.1} />
-                      </button>
-                      {panelFilePaths.length > 1 && (
-                        <span className={styles.chatFloatBadge}>
-                          {panelFilePaths.length > 99
-                            ? "99+"
-                            : panelFilePaths.length}
-                        </span>
-                      )}
-                    </span>
-                  </Tooltip>
-                )}
+            <div className={styles.chatFloatActions}>
+              {resolvedAgentId && (
                 <Tooltip
-                  title={
-                    browserSessionId
-                      ? t("browserWorkspace.browserStatusActive", {
-                          owner:
-                            browserControlOwner === "agent"
-                              ? t("browserWorkspace.agentControl")
-                              : t("browserWorkspace.userTakeover"),
-                        })
-                      : t("browserWorkspace.browserStatusIdle")
-                  }
+                  title={t("chat.agentProfile.open")}
                   mouseEnterDelay={0.35}
                   placement="left"
                 >
                   <span className={styles.chatFloatBtnWrap}>
                     <button
                       type="button"
-                      className={`${styles.browserStatusBtn} ${
-                        styles.browserStatusActive
-                      } ${
-                        browserSessionState === "awaiting_user_auth" ||
-                        browserSessionState === "authenticating"
-                          ? styles.browserStatusAuth
-                          : ""
-                      } ${
-                        browserControlOwner === "user"
-                          ? styles.browserStatusTakeover
-                          : ""
-                      }`}
-                      onClick={toggleBrowserPanel}
-                      aria-label={t("chat.openBrowser")}
+                      className={styles.agentProfileBtn}
+                      onClick={() => setAgentProfileOpen(true)}
+                      aria-label={t("chat.agentProfile.open")}
                     >
-                      <Globe size={20} strokeWidth={2.1} />
-                      {browserSessionId && (
-                        <span
-                          className={`${styles.browserStatusDot} ${
-                            styles[`browserStatus_${browserControlOwner}`]
-                          }`}
-                        />
-                      )}
+                      <GraduationCap size={20} strokeWidth={2.1} />
                     </button>
                   </span>
                 </Tooltip>
-              </div>
-            )}
+              )}
+              {panelFilePaths.length > 0 && (
+                <Tooltip
+                  title={t("chat.modifiedFiles", {
+                    count: panelFilePaths.length,
+                    defaultValue: "已修改文件（{{count}}）",
+                  })}
+                  mouseEnterDelay={0.35}
+                  placement="left"
+                >
+                  <span className={styles.chatFloatBtnWrap}>
+                    <button
+                      type="button"
+                      className={styles.chatFloatBtn}
+                      onClick={() => openFileList()}
+                      aria-label={t("chat.modifiedFiles", {
+                        count: panelFilePaths.length,
+                        defaultValue: "已修改文件（{{count}}）",
+                      })}
+                    >
+                      <FilePen size={20} strokeWidth={2.1} />
+                    </button>
+                    {panelFilePaths.length > 1 && (
+                      <span className={styles.chatFloatBadge}>
+                        {panelFilePaths.length > 99
+                          ? "99+"
+                          : panelFilePaths.length}
+                      </span>
+                    )}
+                  </span>
+                </Tooltip>
+              )}
+              <Tooltip
+                title={
+                  browserSessionId
+                    ? t("browserWorkspace.browserStatusActive", {
+                        owner:
+                          browserControlOwner === "agent"
+                            ? t("browserWorkspace.agentControl")
+                            : t("browserWorkspace.userTakeover"),
+                      })
+                    : t("browserWorkspace.browserStatusIdle")
+                }
+                mouseEnterDelay={0.35}
+                placement="left"
+              >
+                <span className={styles.chatFloatBtnWrap}>
+                  <button
+                    type="button"
+                    className={`${styles.browserStatusBtn} ${
+                      styles.browserStatusActive
+                    } ${
+                      browserSessionState === "awaiting_user_auth" ||
+                      browserSessionState === "authenticating"
+                        ? styles.browserStatusAuth
+                        : ""
+                    } ${
+                      browserControlOwner === "user"
+                        ? styles.browserStatusTakeover
+                        : ""
+                    }`}
+                    onClick={toggleBrowserPanel}
+                    aria-label={t("chat.openBrowser")}
+                  >
+                    <Globe size={20} strokeWidth={2.1} />
+                    {browserSessionId && (
+                      <span
+                        className={`${styles.browserStatusDot} ${
+                          styles[`browserStatus_${browserControlOwner}`]
+                        }`}
+                      />
+                    )}
+                  </button>
+                </span>
+              </Tooltip>
+            </div>
+          )}
 
           <ChatComposerChrome sessionUsageLabel={sessionUsageLabel} />
           <ChatInput

--- a/dashboard/src/pages/Chat/utils/dockFilePath.test.ts
+++ b/dashboard/src/pages/Chat/utils/dockFilePath.test.ts
@@ -38,9 +38,9 @@ describe("dockFilePath", () => {
         "main",
       ),
     ).toBe("generated/iron-man.pptx");
-    expect(
-      canonicalizeDockFilePath("generated/iron-man.pptx", "main"),
-    ).toBe("generated/iron-man.pptx");
+    expect(canonicalizeDockFilePath("generated/iron-man.pptx", "main")).toBe(
+      "generated/iron-man.pptx",
+    );
   });
 
   it("canonicalizes Windows agent-home paths", () => {
@@ -105,10 +105,10 @@ describe("dockFilePath", () => {
       "main",
     );
     expect(tree).toHaveLength(1);
-    expect(tree[0].name).toBe("home / wally / .octop / agents / main / generated");
-    expect(tree[0].path).toBe(
-      "/home/wally/.octop/agents/main/generated",
+    expect(tree[0].name).toBe(
+      "home / wally / .octop / agents / main / generated",
     );
+    expect(tree[0].path).toBe("/home/wally/.octop/agents/main/generated");
     expect(tree[0].children.map((c) => c.name)).toEqual(["iron-man.pptx"]);
   });
 
@@ -195,11 +195,7 @@ describe("dockFilePath", () => {
     const collapsed = new Set<string>(); // user collapsed a/b
     const second = buildDockPathTree(["a/b/one.txt", "c/d/two.txt"]);
     const folders2 = collectDockFolderPaths(second);
-    const merged = mergeDockExpandedFolders(
-      collapsed,
-      folders2,
-      initial.seen,
-    );
+    const merged = mergeDockExpandedFolders(collapsed, folders2, initial.seen);
     expect(merged.expanded.has("a/b")).toBe(false);
     expect(merged.expanded.has("c/d")).toBe(true);
   });

--- a/dashboard/src/pages/Chat/utils/dockFilePath.ts
+++ b/dashboard/src/pages/Chat/utils/dockFilePath.ts
@@ -44,10 +44,7 @@ export function canonicalizeDockFilePath(
   if (agentId) {
     const id = agentId.replace(/\\/g, "/");
     const idLower = id.toLowerCase();
-    const markers = [
-      `/.octop/agents/${idLower}/`,
-      `.octop/agents/${idLower}/`,
-    ];
+    const markers = [`/.octop/agents/${idLower}/`, `.octop/agents/${idLower}/`];
     for (const marker of markers) {
       const idx = lower.lastIndexOf(marker);
       if (idx >= 0) {
@@ -99,10 +96,7 @@ export function dockFileBasename(path: string): string {
 }
 
 /** Stable tab id for an open file path. */
-export function dockFileTabId(
-  path: string,
-  agentId?: string | null,
-): string {
+export function dockFileTabId(path: string, agentId?: string | null): string {
   return `file:${canonicalizeDockFilePath(path, agentId)}`;
 }
 
@@ -213,7 +207,8 @@ export function buildDockPathTree(
     for (let i = 0; i < parts.length; i++) {
       const part = parts[i];
       const isLast = i === parts.length - 1;
-      acc = acc === "" && abs ? `/${part}` : acc === "" ? part : `${acc}/${part}`;
+      acc =
+        acc === "" && abs ? `/${part}` : acc === "" ? part : `${acc}/${part}`;
       let child = node.children.get(part);
       if (!child) {
         child = {
@@ -241,12 +236,10 @@ export function buildDockPathTree(
       cur = [...cur.children.values()][0];
       names.push(cur.name);
     }
-    const children = [...cur.children.values()]
-      .map(collapse)
-      .sort((a, b) => {
-        if (a.isDir !== b.isDir) return a.isDir ? -1 : 1;
-        return a.name.localeCompare(b.name);
-      });
+    const children = [...cur.children.values()].map(collapse).sort((a, b) => {
+      if (a.isDir !== b.isDir) return a.isDir ? -1 : 1;
+      return a.name.localeCompare(b.name);
+    });
     return {
       name: names.filter(Boolean).join(" / "),
       path: cur.path,
@@ -255,18 +248,14 @@ export function buildDockPathTree(
     };
   }
 
-  return [...root.children.values()]
-    .map(collapse)
-    .sort((a, b) => {
-      if (a.isDir !== b.isDir) return a.isDir ? -1 : 1;
-      return a.name.localeCompare(b.name);
-    });
+  return [...root.children.values()].map(collapse).sort((a, b) => {
+    if (a.isDir !== b.isDir) return a.isDir ? -1 : 1;
+    return a.name.localeCompare(b.name);
+  });
 }
 
 /** Collect every directory node path from a dock tree. */
-export function collectDockFolderPaths(
-  nodes: DockPathTreeNode[],
-): Set<string> {
+export function collectDockFolderPaths(nodes: DockPathTreeNode[]): Set<string> {
   const out = new Set<string>();
   const walk = (list: DockPathTreeNode[]) => {
     for (const n of list) {

--- a/dashboard/src/pages/Control/RemoteDesktop/index.tsx
+++ b/dashboard/src/pages/Control/RemoteDesktop/index.tsx
@@ -959,7 +959,9 @@ export default function RemoteDesktopPage() {
     "pageShell.desktop.subtitle",
     "查看并操控 Octop 主机操作系统桌面",
   );
-  const setupMascot = <OctopEmptyMascot size={120} className={styles.setupMascot} />;
+  const setupMascot = (
+    <OctopEmptyMascot size={120} className={styles.setupMascot} />
+  );
 
   if (role === null) {
     return (

--- a/dashboard/src/pages/Control/TokenUsage/index.tsx
+++ b/dashboard/src/pages/Control/TokenUsage/index.tsx
@@ -93,7 +93,12 @@ const AXIS_TICK = { fontSize: 11, fill: "var(--fn-text-tertiary)" } as const;
 const AXIS_LINE = { stroke: "var(--fn-border-primary)" } as const;
 /** Plot insets: leave room for X ticks (bottom) and optional top legend. */
 const BAR_MARGIN = { top: 12, right: 16, bottom: 8, left: 4 } as const;
-const BAR_MARGIN_WITH_LEGEND = { top: 32, right: 16, bottom: 8, left: 4 } as const;
+const BAR_MARGIN_WITH_LEGEND = {
+  top: 32,
+  right: 16,
+  bottom: 8,
+  left: 4,
+} as const;
 
 const CHART_HEIGHT = {
   bar: 280,

--- a/dashboard/src/pages/Experts/components/CreateFromExpertDrawer.tsx
+++ b/dashboard/src/pages/Experts/components/CreateFromExpertDrawer.tsx
@@ -1,15 +1,7 @@
 // dashboard/src/pages/Experts/components/CreateFromExpertDrawer.tsx
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import {
-  Alert,
-  Collapse,
-  Drawer,
-  Form,
-  Input,
-  Select,
-  Spin,
-} from "antd";
+import { Alert, Collapse, Drawer, Form, Input, Select, Spin } from "antd";
 import { message } from "@/utils/antdMessage";
 
 import { request } from "../../../api/request";

--- a/dashboard/src/pages/Settings/AdvancedSettings/UpdateConfig.module.less
+++ b/dashboard/src/pages/Settings/AdvancedSettings/UpdateConfig.module.less
@@ -1,7 +1,58 @@
 .container {
   width: 100%;
   min-width: 0;
-  max-width: 720px;
+}
+
+/* ── Page layout: upgrade left, guide right ── */
+
+.layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1.15fr);
+  gap: 20px;
+  align-items: start;
+
+  @media (max-width: 960px) {
+    grid-template-columns: 1fr;
+  }
+}
+
+.panel {
+  min-width: 0;
+  border: 1px solid var(--fn-border-primary);
+  border-radius: 12px;
+  background: var(
+    --fn-bg-elevated,
+    var(--fn-bg-secondary, rgba(0, 0, 0, 0.02))
+  );
+  padding: 18px 20px;
+}
+
+.panelTitleRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+
+.panelTitle {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--fn-text-primary);
+  line-height: 1.35;
+}
+
+.panelTitleIcon {
+  display: flex;
+  color: var(--fn-text-secondary);
+  flex-shrink: 0;
+}
+
+.panelDesc {
+  margin: 0 0 16px;
+  font-size: 13px;
+  line-height: 1.55;
+  color: var(--fn-text-secondary);
 }
 
 /* ── Version cards ── */
@@ -10,9 +61,9 @@
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 12px;
-  margin-bottom: 20px;
+  margin-bottom: 16px;
 
-  @media (max-width: 600px) {
+  @media (max-width: 520px) {
     grid-template-columns: 1fr;
   }
 }
@@ -21,25 +72,26 @@
   display: flex;
   flex-direction: column;
   gap: 6px;
-  padding: 16px;
+  padding: 14px 16px;
   border: 1px solid var(--fn-border-primary);
-  border-radius: 8px;
-  background: var(--fn-bg-secondary, rgba(0, 0, 0, 0.03));
+  border-radius: 10px;
+  background: var(--fn-bg-primary, var(--fn-bg-base, #fff));
 }
 
 .versionLabel {
   font-size: 12px;
   color: var(--fn-text-tertiary);
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
+  letter-spacing: 0.02em;
   font-weight: 500;
 }
 
 .versionValue {
-  font-size: 18px;
+  font-size: 20px;
   font-weight: 700;
-  letter-spacing: -0.01em;
+  letter-spacing: -0.02em;
   font-variant-numeric: tabular-nums;
+  color: var(--fn-text-primary);
+  line-height: 1.25;
 }
 
 .notChecked {
@@ -74,6 +126,10 @@
   > svg {
     flex-shrink: 0;
     margin-top: 2px;
+  }
+
+  p {
+    margin: 0;
   }
 }
 
@@ -119,17 +175,17 @@
   display: flex;
   gap: 10px;
   flex-wrap: wrap;
-  margin-bottom: 16px;
+  margin-bottom: 4px;
 }
 
 .btnSecondary {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  padding: 7px 14px;
+  padding: 8px 14px;
   border: 1px solid var(--fn-border-primary);
-  border-radius: 6px;
-  background: transparent;
+  border-radius: 8px;
+  background: var(--fn-bg-primary, transparent);
   color: var(--fn-text-primary);
   font-size: 13px;
   font-weight: 500;
@@ -151,9 +207,9 @@
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  padding: 7px 16px;
+  padding: 8px 16px;
   border: none;
-  border-radius: 6px;
+  border-radius: 8px;
   background: var(--fn-color-brand);
   color: #fff;
   font-size: 13px;
@@ -174,7 +230,7 @@
 /* ── Progress bar ── */
 
 .progressSection {
-  margin-top: 4px;
+  margin-top: 14px;
 }
 
 .progressLabel {
@@ -213,8 +269,6 @@
     margin: 0;
   }
 
-  /* Keep the restart button at content width so it does not stretch
-     and leave empty space on the right side of the label. */
   button {
     align-self: flex-start;
   }
@@ -251,6 +305,84 @@ code {
   margin-top: 4px;
   font-size: 12px;
   opacity: 0.75;
+}
+
+.releaseNotes {
+  margin-top: 14px;
+
+  :global(.ant-collapse-header) {
+    align-items: center !important;
+  }
+}
+
+/* ── Upgrade guide (right column) ── */
+
+.guide {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.guideMethods {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.guideNote {
+  margin: 0 0 14px;
+  padding: 10px 12px;
+  border-radius: 8px;
+  font-size: 12.5px;
+  line-height: 1.55;
+  color: var(--fn-text-secondary);
+  background: color-mix(in srgb, var(--fn-color-brand) 8%, transparent);
+  border: 1px solid color-mix(in srgb, var(--fn-color-brand) 20%, transparent);
+}
+
+.guideMethod {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 12px 14px;
+  border-radius: 10px;
+  border: 1px solid var(--fn-border-primary);
+  background: var(--fn-bg-primary, var(--fn-bg-base, #fff));
+}
+
+.guideMethodTitle {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--fn-text-primary);
+}
+
+.guideMethodBody {
+  margin: 0;
+  font-size: 12.5px;
+  line-height: 1.55;
+  color: var(--fn-text-secondary);
+}
+
+.guideCode {
+  margin: 2px 0 0;
+  padding: 10px 12px;
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--fn-text-primary) 4%, transparent);
+  border: 1px solid var(--fn-border-secondary, var(--fn-border-primary));
+  font-family: var(
+    --fn-font-mono,
+    ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    Consolas,
+    monospace
+  );
+  font-size: 11.5px;
+  line-height: 1.55;
+  color: var(--fn-text-primary);
+  white-space: pre-wrap;
+  overflow-x: auto;
 }
 
 /* ── Spinner animation ── */

--- a/dashboard/src/pages/Settings/AdvancedSettings/UpdateConfig.tsx
+++ b/dashboard/src/pages/Settings/AdvancedSettings/UpdateConfig.tsx
@@ -2,11 +2,13 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Collapse } from "antd";
 import {
+  BookOpen,
   CheckCircle,
   RefreshCw,
   XCircle,
   AlertTriangle,
   Power,
+  Sparkles,
 } from "lucide-react";
 import {
   updateApi,
@@ -21,6 +23,126 @@ import {
 } from "../../../utils/updateStatusCache";
 import { TabPanelHeader } from "./TabPanelHeader";
 import styles from "./UpdateConfig.module.less";
+
+/** Shell snippets shown in the manual upgrade guide (commands are locale-agnostic). */
+const UPGRADE_GUIDE_CODE = {
+  installerUnix: `curl -fsSL https://finnie-1258344699.cos.ap-guangzhou.myqcloud.com/octop/install.sh | bash`,
+  installerWin: `irm https://finnie-1258344699.cos.ap-guangzhou.myqcloud.com/octop/install.ps1 | iex`,
+  cli: `octop update
+# or non-interactive:
+octop update --yes`,
+  pip: `pip install -U octop
+# optional extras, e.g. browser automation:
+# pip install -U "octop[browser]"`,
+  source: `cd Octop
+git pull
+make build-frontend
+# or: cd dashboard && npm ci && npm run build && cd ..
+pip install -e .
+# with dev deps: make install  /  pip install -e ".[dev]"`,
+  docker: `# Compose (from repo root; rebuild + recreate)
+docker compose -f docker/docker-compose.yml up -d --build
+
+# or rebuild the image then run with a persistent data volume
+bash docker/docker_build.sh
+docker run -d \\
+  --name octop \\
+  -p 8088:8088 \\
+  -v octop-data:/data/.octop \\
+  -e HOME=/data \\
+  octop:latest`,
+  restart: `# system service (systemd / launchd / Windows service)
+octop service restart
+
+# foreground process — stop the old process, then:
+octop run`,
+} as const;
+
+type GuideMethodKey =
+  | "ui"
+  | "installer"
+  | "cli"
+  | "pip"
+  | "source"
+  | "docker"
+  | "restart";
+
+const GUIDE_METHOD_ORDER: GuideMethodKey[] = [
+  "ui",
+  "installer",
+  "cli",
+  "pip",
+  "source",
+  "docker",
+  "restart",
+];
+
+function codeFor(key: GuideMethodKey): string | null {
+  switch (key) {
+    case "installer":
+      return [
+        `# macOS / Linux`,
+        UPGRADE_GUIDE_CODE.installerUnix,
+        ``,
+        `# Windows (PowerShell)`,
+        UPGRADE_GUIDE_CODE.installerWin,
+      ].join("\n");
+    case "cli":
+      return UPGRADE_GUIDE_CODE.cli;
+    case "pip":
+      return UPGRADE_GUIDE_CODE.pip;
+    case "source":
+      return UPGRADE_GUIDE_CODE.source;
+    case "docker":
+      return UPGRADE_GUIDE_CODE.docker;
+    case "restart":
+      return UPGRADE_GUIDE_CODE.restart;
+    default:
+      return null;
+  }
+}
+
+function UpgradeGuide() {
+  const { t } = useTranslation();
+
+  return (
+    <section
+      className={`${styles.panel} ${styles.guide}`}
+      aria-label={t("advancedSettings.update.guideTitle")}
+    >
+      <div className={styles.panelTitleRow}>
+        <span className={styles.panelTitleIcon}>
+          <BookOpen size={16} />
+        </span>
+        <h3 className={styles.panelTitle}>
+          {t("advancedSettings.update.guideTitle")}
+        </h3>
+      </div>
+      <p className={styles.panelDesc}>
+        {t("advancedSettings.update.guideIntro")}
+      </p>
+      <p className={styles.guideNote}>
+        {t("advancedSettings.update.guideDataNote")}
+      </p>
+      <div className={styles.guideMethods}>
+        {GUIDE_METHOD_ORDER.map((key) => {
+          const code = codeFor(key);
+          return (
+            <div key={key} className={styles.guideMethod}>
+              <p className={styles.guideMethodTitle}>
+                {t(`advancedSettings.update.guide.${key}.title`)}
+              </p>
+              <p className={styles.guideMethodBody}>
+                {t(`advancedSettings.update.guide.${key}.body`)}
+              </p>
+              {code && <pre className={styles.guideCode}>{code}</pre>}
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+}
 
 export default function UpdateConfig() {
   const { t } = useTranslation();
@@ -140,187 +262,203 @@ export default function UpdateConfig() {
         description={t("advancedSettings.update.description")}
       />
 
-      {/* Version info cards */}
-      <div className={styles.versionGrid}>
-        <div className={styles.versionCard}>
-          <span className={styles.versionLabel}>
-            {t("advancedSettings.update.currentVersion")}
-          </span>
-          <span className={styles.versionValue}>
-            {status?.current_version ?? "—"}
-          </span>
-        </div>
-        <div className={styles.versionCard}>
-          <span className={styles.versionLabel}>
-            {t("advancedSettings.update.latestVersion")}
-          </span>
-          <span className={styles.versionValue}>
-            {status?.latest_version ?? (
-              <span className={styles.notChecked}>
-                {t("advancedSettings.update.notChecked")}
-              </span>
-            )}
-          </span>
-          {status?.has_update && (
-            <span className={styles.badge}>
-              {t("advancedSettings.update.updateAvailable")}
-            </span>
-          )}
-        </div>
-      </div>
-
-      {/* Release notes collapse — only shown when an update is available and notes exist */}
-      {status?.has_update && status.release_notes && (
-        <Collapse
-          defaultActiveKey={["changelog"]}
-          style={{ marginBottom: 12 }}
-          items={[
-            {
-              key: "changelog",
-              label: t("advancedSettings.update.releaseNotes"),
-              children: (
-                <div style={{ maxHeight: 300, overflowY: "auto" }}>
-                  <Markdown content={status.release_notes} />
-                </div>
-              ),
-            },
-          ]}
-        />
-      )}
-
-      {/* Editable install warning */}
-      {status?.is_editable && (
-        <div className={`${styles.alert} ${styles.alertWarn}`}>
-          <AlertTriangle size={15} />
-          <span>{t("advancedSettings.update.editableHint")}</span>
-        </div>
-      )}
-
-      {/* Network error */}
-      {status?.error && (
-        <div className={`${styles.alert} ${styles.alertError}`}>
-          <XCircle size={15} />
-          <span>{status.error}</span>
-        </div>
-      )}
-
-      {/* Action buttons */}
-      <div className={styles.actions}>
-        <button
-          className={styles.btnSecondary}
-          onClick={handleCheck}
-          disabled={checking || upgrading || restartUiLocked}
+      <div className={styles.layout}>
+        {/* In-place version check & upgrade */}
+        <section
+          className={styles.panel}
+          aria-label={t("advancedSettings.update.panelTitle")}
         >
-          <RefreshCw
-            size={14}
-            className={checking ? styles.spinning : undefined}
-          />
-          {checking
-            ? t("advancedSettings.update.checking")
-            : t("advancedSettings.update.checkButton")}
-        </button>
+          <div className={styles.panelTitleRow}>
+            <span className={styles.panelTitleIcon}>
+              <Sparkles size={16} />
+            </span>
+            <h3 className={styles.panelTitle}>
+              {t("advancedSettings.update.panelTitle")}
+            </h3>
+          </div>
+          <p className={styles.panelDesc}>
+            {t("advancedSettings.update.panelDesc")}
+          </p>
 
-        {isServiceMode && (
-          <button
-            className={styles.btnSecondary}
-            onClick={requestRestart}
-            disabled={checking || upgrading || restartUiLocked}
-          >
-            <Power size={14} />
-            {isRestarting
-              ? t("advancedSettings.update.restarting")
-              : t("advancedSettings.update.restartServiceBtn")}
-          </button>
-        )}
-
-        {status?.has_update && !status.is_editable && !upgradeFinished && (
-          <button
-            className={styles.btnPrimary}
-            onClick={handleUpgrade}
-            disabled={upgrading}
-          >
-            {upgrading
-              ? t("advancedSettings.update.upgrading")
-              : t("advancedSettings.update.upgradeButton")}
-          </button>
-        )}
-      </div>
-
-      {/* Upgrade progress */}
-      {progress && (
-        <div className={styles.progressSection}>
-          {progress.status === "running" && (
-            <>
-              <div className={styles.progressLabel}>
-                <RefreshCw size={13} className={styles.spinning} />
-                <span>{stageLabel(progress.stage)}</span>
-              </div>
-              <div className={styles.progressBar}>
-                <div
-                  className={styles.progressFill}
-                  style={{ width: `${progress.percent ?? 10}%` }}
-                />
-              </div>
-            </>
-          )}
-
-          {progress.status === "complete" && (
-            <>
-              <div className={`${styles.alert} ${styles.alertSuccess}`}>
-                <CheckCircle size={15} />
-                <span>
-                  {t("advancedSettings.update.upgradeSuccess")}
-                  {progress.new_version && ` → v${progress.new_version}`}
+          <div className={styles.versionGrid}>
+            <div className={styles.versionCard}>
+              <span className={styles.versionLabel}>
+                {t("advancedSettings.update.currentVersion")}
+              </span>
+              <span className={styles.versionValue}>
+                {status?.current_version ?? "—"}
+              </span>
+            </div>
+            <div className={styles.versionCard}>
+              <span className={styles.versionLabel}>
+                {t("advancedSettings.update.latestVersion")}
+              </span>
+              <span className={styles.versionValue}>
+                {status?.latest_version ?? (
+                  <span className={styles.notChecked}>
+                    {t("advancedSettings.update.notChecked")}
+                  </span>
+                )}
+              </span>
+              {status?.has_update && (
+                <span className={styles.badge}>
+                  {t("advancedSettings.update.updateAvailable")}
                 </span>
-              </div>
+              )}
+            </div>
+          </div>
 
-              {/* Restart section */}
-              {restartPhase === "idle" &&
-                (isServiceMode ? (
-                  <div className={`${styles.alert} ${styles.alertInfo}`}>
-                    <AlertTriangle size={15} />
-                    <div className={styles.restartRow}>
-                      <p>{t("advancedSettings.update.restartHint")}</p>
-                      <button
-                        className={styles.btnPrimary}
-                        onClick={requestRestart}
-                      >
-                        <Power size={14} />
-                        {t("advancedSettings.update.restartServiceBtn")}
-                      </button>
-                    </div>
-                  </div>
-                ) : (
-                  <div className={`${styles.alert} ${styles.alertInfo}`}>
-                    <AlertTriangle size={15} />
-                    <div>
-                      <p>{t("advancedSettings.update.restartHint")}</p>
-                      <div className={styles.commandBlock}>
-                        <code>octop restart</code>
-                        <span className={styles.commandSep}>/</span>
-                        <code>octop run</code>
-                      </div>
-                    </div>
-                  </div>
-                ))}
-            </>
-          )}
-
-          {progress.status === "error" && (
-            <div className={`${styles.alert} ${styles.alertError}`}>
-              <XCircle size={15} />
-              <div>
-                <p>
-                  {t("advancedSettings.update.upgradeFailed")}: {progress.error}
-                </p>
-                <p className={styles.manualHint}>
-                  {t("advancedSettings.update.manualUpgradeHint")}
-                </p>
-              </div>
+          {status?.is_editable && (
+            <div className={`${styles.alert} ${styles.alertWarn}`}>
+              <AlertTriangle size={15} />
+              <span>{t("advancedSettings.update.editableHint")}</span>
             </div>
           )}
-        </div>
-      )}
+
+          {status?.error && (
+            <div className={`${styles.alert} ${styles.alertError}`}>
+              <XCircle size={15} />
+              <span>{status.error}</span>
+            </div>
+          )}
+
+          <div className={styles.actions}>
+            <button
+              type="button"
+              className={styles.btnSecondary}
+              onClick={handleCheck}
+              disabled={checking || upgrading || restartUiLocked}
+            >
+              <RefreshCw
+                size={14}
+                className={checking ? styles.spinning : undefined}
+              />
+              {checking
+                ? t("advancedSettings.update.checking")
+                : t("advancedSettings.update.checkButton")}
+            </button>
+
+            {isServiceMode && (
+              <button
+                type="button"
+                className={styles.btnSecondary}
+                onClick={requestRestart}
+                disabled={checking || upgrading || restartUiLocked}
+              >
+                <Power size={14} />
+                {isRestarting
+                  ? t("advancedSettings.update.restarting")
+                  : t("advancedSettings.update.restartServiceBtn")}
+              </button>
+            )}
+
+            {status?.has_update && !status.is_editable && !upgradeFinished && (
+              <button
+                type="button"
+                className={styles.btnPrimary}
+                onClick={handleUpgrade}
+                disabled={upgrading}
+              >
+                {upgrading
+                  ? t("advancedSettings.update.upgrading")
+                  : t("advancedSettings.update.upgradeButton")}
+              </button>
+            )}
+          </div>
+
+          {status?.has_update && status.release_notes && (
+            <Collapse
+              className={styles.releaseNotes}
+              defaultActiveKey={["changelog"]}
+              items={[
+                {
+                  key: "changelog",
+                  label: t("advancedSettings.update.releaseNotes"),
+                  children: <Markdown content={status.release_notes} />,
+                },
+              ]}
+            />
+          )}
+
+          {progress && (
+            <div className={styles.progressSection}>
+              {progress.status === "running" && (
+                <>
+                  <div className={styles.progressLabel}>
+                    <RefreshCw size={13} className={styles.spinning} />
+                    <span>{stageLabel(progress.stage)}</span>
+                  </div>
+                  <div className={styles.progressBar}>
+                    <div
+                      className={styles.progressFill}
+                      style={{ width: `${progress.percent ?? 10}%` }}
+                    />
+                  </div>
+                </>
+              )}
+
+              {progress.status === "complete" && (
+                <>
+                  <div className={`${styles.alert} ${styles.alertSuccess}`}>
+                    <CheckCircle size={15} />
+                    <span>
+                      {t("advancedSettings.update.upgradeSuccess")}
+                      {progress.new_version && ` → v${progress.new_version}`}
+                    </span>
+                  </div>
+
+                  {restartPhase === "idle" &&
+                    (isServiceMode ? (
+                      <div className={`${styles.alert} ${styles.alertInfo}`}>
+                        <AlertTriangle size={15} />
+                        <div className={styles.restartRow}>
+                          <p>{t("advancedSettings.update.restartHint")}</p>
+                          <button
+                            type="button"
+                            className={styles.btnPrimary}
+                            onClick={requestRestart}
+                          >
+                            <Power size={14} />
+                            {t("advancedSettings.update.restartServiceBtn")}
+                          </button>
+                        </div>
+                      </div>
+                    ) : (
+                      <div className={`${styles.alert} ${styles.alertInfo}`}>
+                        <AlertTriangle size={15} />
+                        <div>
+                          <p>{t("advancedSettings.update.restartHint")}</p>
+                          <div className={styles.commandBlock}>
+                            <code>octop service restart</code>
+                            <span className={styles.commandSep}>/</span>
+                            <code>octop run</code>
+                          </div>
+                        </div>
+                      </div>
+                    ))}
+                </>
+              )}
+
+              {progress.status === "error" && (
+                <div className={`${styles.alert} ${styles.alertError}`}>
+                  <XCircle size={15} />
+                  <div>
+                    <p>
+                      {t("advancedSettings.update.upgradeFailed")}:{" "}
+                      {progress.error}
+                    </p>
+                    <p className={styles.manualHint}>
+                      {t("advancedSettings.update.manualUpgradeHint")}
+                    </p>
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+        </section>
+
+        <UpgradeGuide />
+      </div>
     </div>
   );
 }

--- a/dashboard/src/pages/Settings/AdvancedSettings/index.tsx
+++ b/dashboard/src/pages/Settings/AdvancedSettings/index.tsx
@@ -31,7 +31,11 @@ type TabKey =
   | "updates";
 
 const TABS: { key: TabKey; labelKey: string; icon: ReactNode }[] = [
-  { key: "env-vars", labelKey: "nav.environments", icon: <Variable size={15} /> },
+  {
+    key: "env-vars",
+    labelKey: "nav.environments",
+    icon: <Variable size={15} />,
+  },
   { key: "search", labelKey: "nav.search", icon: <Search size={15} /> },
   { key: "voice", labelKey: "nav.voice", icon: <Mic2 size={15} /> },
   {
@@ -41,7 +45,11 @@ const TABS: { key: TabKey; labelKey: string; icon: ReactNode }[] = [
   },
   { key: "backup", labelKey: "nav.backupRestore", icon: <Archive size={15} /> },
   { key: "https", labelKey: "nav.https", icon: <Lock size={15} /> },
-  { key: "updates", labelKey: "nav.checkUpdates", icon: <RefreshCw size={15} /> },
+  {
+    key: "updates",
+    labelKey: "nav.checkUpdates",
+    icon: <RefreshCw size={15} />,
+  },
 ];
 
 function parseTab(raw: string | null): TabKey {

--- a/dashboard/src/pages/Settings/Embedding/index.tsx
+++ b/dashboard/src/pages/Settings/Embedding/index.tsx
@@ -1,14 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { useTranslation } from "react-i18next";
-import {
-  Select,
-  Input,
-  Button,
-  Spin,
-  Progress,
-  Alert,
-  Modal,
-} from "antd";
+import { Select, Input, Button, Spin, Progress, Alert, Modal } from "antd";
 import { message } from "@/utils/antdMessage";
 
 import { Download, CheckCircle, AlertCircle } from "lucide-react";

--- a/dashboard/src/pages/Settings/HttpsSettings/index.module.less
+++ b/dashboard/src/pages/Settings/HttpsSettings/index.module.less
@@ -1,0 +1,125 @@
+.container {
+  width: 100%;
+  min-width: 0;
+  max-width: 880px;
+}
+
+.statusStack {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-bottom: 20px;
+}
+
+.panel {
+  min-width: 0;
+  border: 1px solid var(--fn-border-primary);
+  border-radius: 12px;
+  background: var(
+    --fn-bg-elevated,
+    var(--fn-bg-secondary, rgba(0, 0, 0, 0.02))
+  );
+  padding: 20px 22px;
+}
+
+.steps {
+  margin-bottom: 22px;
+  padding-bottom: 4px;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 16px;
+  max-width: 520px;
+}
+
+.fieldLabel {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--fn-text-primary);
+}
+
+.stagingRow {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  margin-bottom: 18px;
+  max-width: 640px;
+}
+
+.stagingText {
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--fn-text-secondary);
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-bottom: 4px;
+}
+
+.checks {
+  margin-top: 20px;
+  padding-top: 18px;
+  border-top: 1px solid var(--fn-border-primary);
+}
+
+.checksTitle {
+  margin: 0 0 12px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--fn-text-primary);
+}
+
+.restartBlock {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-top: 4px;
+}
+
+.restartBlock p {
+  margin: 0;
+}
+
+.commandBlock {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.commandSep {
+  color: var(--fn-text-tertiary);
+  font-size: 12px;
+}
+
+.commandBlock code {
+  font-family: var(--fn-font-mono, "SFMono-Regular", Consolas, monospace);
+  font-size: 12px;
+  padding: 2px 6px;
+  border-radius: 4px;
+  background: color-mix(in srgb, var(--fn-text-primary) 10%, transparent);
+}
+
+.loading {
+  display: flex;
+  justify-content: center;
+  padding: 48px 0;
+}
+
+.pass {
+  color: #16a34a;
+  font-weight: 600;
+}
+
+.fail {
+  color: #dc2626;
+  font-weight: 600;
+}

--- a/dashboard/src/pages/Settings/HttpsSettings/index.tsx
+++ b/dashboard/src/pages/Settings/HttpsSettings/index.tsx
@@ -1,15 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import {
-  Alert,
-  Button,
-  Input,
-  Space,
-  Spin,
-  Steps,
-  Switch,
-  Table,
-  Typography,
-} from "antd";
+import { Alert, Button, Input, Spin, Steps, Switch, Table } from "antd";
 import { message } from "@/utils/antdMessage";
 
 import { Lock, Power, RefreshCw, ShieldCheck } from "lucide-react";
@@ -22,10 +12,7 @@ import {
 import { updateApi } from "../../../api/modules/update";
 import { useServiceRestartContext } from "../../../context/ServiceRestartContext";
 import { TabPanelHeader } from "../AdvancedSettings/TabPanelHeader";
-import updateStyles from "../AdvancedSettings/UpdateConfig.module.less";
-import tabStyles from "../AdvancedSettings/tabContent.module.less";
-
-const { Text } = Typography;
+import styles from "./index.module.less";
 
 const TASK_STEP_ORDER = [
   "idle",
@@ -37,11 +24,23 @@ const TASK_STEP_ORDER = [
   "active",
 ] as const;
 
-function taskStepIndex(state: string): number {
+/** Map task state → Steps `current` index (items omit idle). */
+function stepsCurrent(state: string): number {
   const idx = TASK_STEP_ORDER.indexOf(
     state as (typeof TASK_STEP_ORDER)[number],
   );
-  return idx >= 0 ? idx : 0;
+  if (idx <= 0) return 0;
+  // active (last in order) should highlight final step
+  return Math.min(idx - 1, 5);
+}
+
+function stepsStatus(state: string): "wait" | "process" | "finish" | "error" {
+  if (state === "failed") return "error";
+  if (state === "active") return "finish";
+  if (["preflight", "challenging", "issuing", "installing"].includes(state)) {
+    return "process";
+  }
+  return "wait";
 }
 
 export function HttpsSettingsPanel() {
@@ -185,7 +184,11 @@ export function HttpsSettingsPanel() {
       key: "ok",
       width: 100,
       render: (_: unknown, row: PreflightCheck) =>
-        row.ok ? t("tls.pass") : t("tls.fail"),
+        row.ok ? (
+          <span className={styles.pass}>{t("tls.pass")}</span>
+        ) : (
+          <span className={styles.fail}>{t("tls.fail")}</span>
+        ),
     },
     {
       title: t("tls.checkMessage"),
@@ -195,7 +198,7 @@ export function HttpsSettingsPanel() {
   ];
 
   return (
-    <>
+    <div className={styles.container}>
       <TabPanelHeader
         icon={<Lock size={22} />}
         title={t("tls.title")}
@@ -203,150 +206,143 @@ export function HttpsSettingsPanel() {
       />
 
       {loading && !status ? (
-        <Spin />
+        <div className={styles.loading}>
+          <Spin />
+        </div>
       ) : (
         <>
-          {tlsEnabled && status?.tls.expires_at && (
-            <Alert
-              type="success"
-              showIcon
-              icon={<ShieldCheck size={16} />}
-              message={t("tls.activeCert", {
-                expires: status.tls.expires_at,
-                httpPort: status.tls.http_port,
-              })}
-              style={{ marginBottom: 16 }}
-            />
-          )}
+          <div className={styles.statusStack}>
+            {tlsEnabled && status?.tls.expires_at && (
+              <Alert
+                type="success"
+                showIcon
+                icon={<ShieldCheck size={16} />}
+                message={t("tls.activeCert", {
+                  expires: status.tls.expires_at,
+                  httpPort: status.tls.http_port,
+                })}
+              />
+            )}
 
-          {taskState === "restart_required" && (
-            <Alert
-              type="warning"
-              showIcon
-              message={t("tls.restartRequired")}
-              description={
-                serviceMode ? (
-                  <div
-                    className={updateStyles.restartRow}
-                    style={{ marginTop: 8 }}
-                  >
-                    <p>{t("tls.restartRequiredHint")}</p>
-                    <Button
-                      type="primary"
-                      icon={<Power size={14} />}
-                      onClick={requestRestart}
-                      disabled={
-                        restartPhase !== "idle" && restartPhase !== "timeout"
-                      }
-                    >
-                      {t("advancedSettings.update.restartServiceBtn")}
-                    </Button>
-                  </div>
-                ) : (
-                  <div style={{ marginTop: 8 }}>
-                    <p style={{ margin: "0 0 8px" }}>
-                      {t("tls.restartRequiredHint")}
-                    </p>
-                    <div className={updateStyles.commandBlock}>
-                      <code>octop restart</code>
-                      <span className={updateStyles.commandSep}>/</span>
-                      <code>octop run</code>
+            {taskState === "restart_required" && (
+              <Alert
+                type="warning"
+                showIcon
+                message={t("tls.restartRequired")}
+                description={
+                  serviceMode ? (
+                    <div className={styles.restartBlock}>
+                      <p>{t("tls.restartRequiredHint")}</p>
+                      <span>
+                        <Button
+                          type="primary"
+                          icon={<Power size={14} />}
+                          onClick={requestRestart}
+                          disabled={
+                            restartPhase !== "idle" &&
+                            restartPhase !== "timeout"
+                          }
+                        >
+                          {t("advancedSettings.update.restartServiceBtn")}
+                        </Button>
+                      </span>
                     </div>
-                  </div>
-                )
-              }
-              style={{ marginBottom: 16 }}
+                  ) : (
+                    <div className={styles.restartBlock}>
+                      <p>{t("tls.restartRequiredHint")}</p>
+                      <div className={styles.commandBlock}>
+                        <code>octop service restart</code>
+                        <span className={styles.commandSep}>/</span>
+                        <code>octop run</code>
+                      </div>
+                    </div>
+                  )
+                }
+              />
+            )}
+
+            {taskState === "failed" && status?.task.error && (
+              <Alert type="error" showIcon message={status.task.error} />
+            )}
+
+            {!eligible && !tlsEnabled && (
+              <Alert type="info" showIcon message={t("tls.notEligible")} />
+            )}
+
+            {status?.tls.dual_listeners && (
+              <Alert
+                type="info"
+                showIcon
+                message={t("tls.dualPortActive", {
+                  httpPort: status.tls.http_port,
+                  httpsPort: status.tls.https_port ?? 443,
+                })}
+              />
+            )}
+          </div>
+
+          <div className={styles.panel}>
+            <Steps
+              className={styles.steps}
+              current={stepsCurrent(taskState)}
+              status={stepsStatus(taskState)}
+              size="small"
+              items={[
+                { title: t("tls.stepPreflight") },
+                { title: t("tls.stepChallenge") },
+                { title: t("tls.stepIssue") },
+                { title: t("tls.stepInstall") },
+                { title: t("tls.stepRestart") },
+                { title: t("tls.stepActive") },
+              ]}
             />
-          )}
 
-          {taskState === "failed" && status?.task.error && (
-            <Alert
-              type="error"
-              message={status.task.error}
-              style={{ marginBottom: 16 }}
-            />
-          )}
+            <div className={styles.field}>
+              <p className={styles.fieldLabel}>{t("tls.domainLabel")}</p>
+              <Input
+                value={domain}
+                onChange={(e) => setDomain(e.target.value)}
+                placeholder={t("tls.domainPlaceholder")}
+                disabled={formLocked}
+              />
+            </div>
 
-          {!eligible && !tlsEnabled && (
-            <Alert
-              type="info"
-              message={t("tls.notEligible")}
-              style={{ marginBottom: 16 }}
-            />
-          )}
+            <div className={styles.stagingRow}>
+              <Switch
+                checked={staging}
+                onChange={setStaging}
+                disabled={formLocked}
+              />
+              <p className={styles.stagingText}>{t("tls.stagingHint")}</p>
+            </div>
 
-          {status?.tls.dual_listeners && (
-            <Alert
-              type="info"
-              message={t("tls.dualPortActive", {
-                httpPort: status.tls.http_port,
-                httpsPort: status.tls.https_port ?? 443,
-              })}
-              style={{ marginBottom: 16 }}
-            />
-          )}
+            <div className={styles.actions}>
+              <Button
+                onClick={() => void handlePreflight()}
+                loading={checking}
+                disabled={formLocked}
+              >
+                {t("tls.runPreflight")}
+              </Button>
+              <Button
+                type="primary"
+                onClick={() => void handleIssue()}
+                loading={issuing || busy}
+                disabled={!eligible || (!preflightOk && checks.length > 0)}
+              >
+                {renewal ? t("tls.renewCert") : t("tls.startIssue")}
+              </Button>
+              <Button
+                icon={<RefreshCw size={14} />}
+                onClick={() => void fetchStatus()}
+              >
+                {t("tls.refresh")}
+              </Button>
+            </div>
 
-          <Steps
-            current={taskStepIndex(taskState)}
-            size="small"
-            style={{ marginBottom: 24 }}
-            items={[
-              { title: t("tls.stepPreflight") },
-              { title: t("tls.stepChallenge") },
-              { title: t("tls.stepIssue") },
-              { title: t("tls.stepInstall") },
-              { title: t("tls.stepRestart") },
-              { title: t("tls.stepActive") },
-            ]}
-          />
-
-          <div className={tabStyles.formFieldsWide}>
-            <Space direction="vertical" size="middle" style={{ width: "100%" }}>
-              <div>
-                <Text strong>{t("tls.domainLabel")}</Text>
-                <Input
-                  value={domain}
-                  onChange={(e) => setDomain(e.target.value)}
-                  placeholder={t("tls.domainPlaceholder")}
-                  disabled={formLocked}
-                  style={{ marginTop: 8 }}
-                />
-              </div>
-
-              <Space wrap>
-                <Switch
-                  checked={staging}
-                  onChange={setStaging}
-                  disabled={formLocked}
-                />
-                <Text type="secondary">{t("tls.stagingHint")}</Text>
-              </Space>
-
-              <Space wrap>
-                <Button
-                  onClick={() => void handlePreflight()}
-                  loading={checking}
-                  disabled={formLocked}
-                >
-                  {t("tls.runPreflight")}
-                </Button>
-                <Button
-                  type="primary"
-                  onClick={() => void handleIssue()}
-                  loading={issuing || busy}
-                  disabled={!eligible || (!preflightOk && checks.length > 0)}
-                >
-                  {renewal ? t("tls.renewCert") : t("tls.startIssue")}
-                </Button>
-                <Button
-                  icon={<RefreshCw size={14} />}
-                  onClick={() => void fetchStatus()}
-                >
-                  {t("tls.refresh")}
-                </Button>
-              </Space>
-
-              {checks.length > 0 && (
+            {checks.length > 0 && (
+              <div className={styles.checks}>
+                <p className={styles.checksTitle}>{t("tls.checksTitle")}</p>
                 <Table
                   size="small"
                   rowKey="id"
@@ -354,11 +350,11 @@ export function HttpsSettingsPanel() {
                   columns={checkColumns}
                   dataSource={checks}
                 />
-              )}
-            </Space>
+              </div>
+            )}
           </div>
         </>
       )}
-    </>
+    </div>
   );
 }

--- a/dashboard/src/pages/Settings/Models/components/modals/ModelListEditor.tsx
+++ b/dashboard/src/pages/Settings/Models/components/modals/ModelListEditor.tsx
@@ -5,15 +5,7 @@
  * Connectivity tests still hit the live provider endpoint.
  */
 import { useState } from "react";
-import {
-  Button,
-  Form,
-  Input,
-  InputNumber,
-  Modal,
-  Select,
-  Switch,
-} from "antd";
+import { Button, Form, Input, InputNumber, Modal, Select, Switch } from "antd";
 import { message } from "@/utils/antdMessage";
 
 import {

--- a/dashboard/src/pages/Settings/Observability/index.tsx
+++ b/dashboard/src/pages/Settings/Observability/index.tsx
@@ -1,13 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
-import {
-  Alert,
-  Button,
-  Form,
-  Input,
-  Space,
-  Switch,
-  Typography,
-} from "antd";
+import { Alert, Button, Form, Input, Space, Switch, Typography } from "antd";
 import { message } from "@/utils/antdMessage";
 
 import { Activity, CheckCircle2, RefreshCw } from "lucide-react";

--- a/dashboard/src/pages/Settings/SearchConfig/index.test.tsx
+++ b/dashboard/src/pages/Settings/SearchConfig/index.test.tsx
@@ -37,9 +37,7 @@ describe("<SearchConfigPage />", () => {
     render(<SearchConfigPage />);
     await waitFor(() => expect(api.listEnvs).toHaveBeenCalled());
 
-    expect(
-      screen.getByText("当前搜索源：内置搜索"),
-    ).toBeInTheDocument();
+    expect(screen.getByText("当前搜索源：内置搜索")).toBeInTheDocument();
   });
 
   it("shows the configured provider as the current search source", async () => {

--- a/dashboard/src/pages/Settings/SearchConfig/index.tsx
+++ b/dashboard/src/pages/Settings/SearchConfig/index.tsx
@@ -13,10 +13,7 @@ import {
 import { useTranslation } from "react-i18next";
 import { envsApi } from "../../../api/modules/env";
 import api from "../../../api";
-import {
-  customProviderLogo,
-  getProviderLogo,
-} from "../../../assets/providers";
+import { customProviderLogo, getProviderLogo } from "../../../assets/providers";
 import { apiErrorMessage } from "../../../utils/apiError";
 import { TabPanelHeader } from "../AdvancedSettings/TabPanelHeader";
 import styles from "./index.module.less";
@@ -430,9 +427,7 @@ export default function SearchConfigPage() {
                 </div>
               </div>
 
-              <p className={styles.description}>
-                {t(provider.descriptionKey)}
-              </p>
+              <p className={styles.description}>{t(provider.descriptionKey)}</p>
 
               <div className={styles.actions}>
                 <Button

--- a/dashboard/src/pages/Settings/Security/index.tsx
+++ b/dashboard/src/pages/Settings/Security/index.tsx
@@ -1,14 +1,6 @@
 import { useCallback, useEffect, useState, type ReactNode } from "react";
 import { useSearchParams } from "react-router-dom";
-import {
-  Button,
-  Form,
-  Input,
-  Modal,
-  Select,
-  Switch,
-  Typography,
-} from "antd";
+import { Button, Form, Input, Modal, Select, Switch, Typography } from "antd";
 import { message } from "@/utils/antdMessage";
 import {
   EyeOff,

--- a/dashboard/src/pages/Settings/Voice/index.tsx
+++ b/dashboard/src/pages/Settings/Voice/index.tsx
@@ -1,13 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import {
-  Button,
-  Divider,
-  Modal,
-  Space,
-  Typography,
-  Input,
-  Select,
-} from "antd";
+import { Button, Divider, Modal, Space, Typography, Input, Select } from "antd";
 import { message } from "@/utils/antdMessage";
 
 import { Mic2, RefreshCw, Check, Settings2 } from "lucide-react";
@@ -17,10 +9,7 @@ import {
   type VoicePreset,
   type VoiceProviderRow,
 } from "../../../api/modules/voice";
-import {
-  customProviderLogo,
-  getProviderLogo,
-} from "../../../assets/providers";
+import { customProviderLogo, getProviderLogo } from "../../../assets/providers";
 import { invalidateVoiceConfigCache } from "../../../hooks/useVoiceConfig";
 import { TabPanelHeader } from "../AdvancedSettings/TabPanelHeader";
 import styles from "./index.module.less";
@@ -121,8 +110,8 @@ export function VoiceSettingsPanel() {
               region: "ap-guangzhou",
             }
           : preset.kind === "edge"
-            ? { voice_id: "zh-CN-XiaoxiaoNeural" }
-            : { model: preset.kind === "openai" ? "whisper-1" : undefined };
+          ? { voice_id: "zh-CN-XiaoxiaoNeural" }
+          : { model: preset.kind === "openai" ? "whisper-1" : undefined };
       const payload = {
         name: preset.id,
         kind: preset.kind,

--- a/dashboard/src/pages/SkillPackages/PackageIcon.tsx
+++ b/dashboard/src/pages/SkillPackages/PackageIcon.tsx
@@ -14,9 +14,7 @@ export function PackageIcon({
   imageClassName?: string;
 }) {
   if (iconUrl) {
-    return (
-      <img src={iconUrl} alt="" className={imageClassName ?? className} />
-    );
+    return <img src={iconUrl} alt="" className={imageClassName ?? className} />;
   }
   return iconForName(iconName, size);
 }

--- a/dashboard/src/pages/SkillPackages/SkillsetFromHubDrawer.test.tsx
+++ b/dashboard/src/pages/SkillPackages/SkillsetFromHubDrawer.test.tsx
@@ -1,4 +1,12 @@
-import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
@@ -80,7 +88,9 @@ describe("<SkillsetFromHubDrawer />", () => {
     await user.click(importButton);
 
     await waitFor(() => {
-      expect(packagesApi.fromSkillHub).toHaveBeenCalledWith({ slug: "writing" });
+      expect(packagesApi.fromSkillHub).toHaveBeenCalledWith({
+        slug: "writing",
+      });
       expect(onCreated).toHaveBeenCalledWith(createdPackage);
     });
   });

--- a/dashboard/src/pages/SkillPackages/SkillsetFromHubDrawer.tsx
+++ b/dashboard/src/pages/SkillPackages/SkillsetFromHubDrawer.tsx
@@ -116,7 +116,10 @@ export function SkillsetFromHubDrawer({
                     </div>
                   </div>
                 </div>
-                <div className={styles.description} title={description || undefined}>
+                <div
+                  className={styles.description}
+                  title={description || undefined}
+                >
                   {description || t("skillPackages.noDescription")}
                 </div>
                 <div className={styles.footer}>

--- a/dashboard/src/pages/SkillPackages/index.module.less
+++ b/dashboard/src/pages/SkillPackages/index.module.less
@@ -73,14 +73,22 @@
     background 0.15s ease;
 
   &:hover {
-    border-color: color-mix(in srgb, var(--fn-color-brand) 45%, var(--fn-border-secondary)) !important;
+    border-color: color-mix(
+      in srgb,
+      var(--fn-color-brand) 45%,
+      var(--fn-border-secondary)
+    ) !important;
     box-shadow: var(--fn-shadow-sm);
     transform: translateY(-1px);
   }
 }
 
 .active {
-  border-color: color-mix(in srgb, var(--fn-color-brand) 65%, var(--fn-border-secondary)) !important;
+  border-color: color-mix(
+    in srgb,
+    var(--fn-color-brand) 65%,
+    var(--fn-border-secondary)
+  ) !important;
   box-shadow:
     0 0 0 1px color-mix(in srgb, var(--fn-color-brand) 30%, transparent),
     0 8px 20px color-mix(in srgb, var(--fn-color-brand) 10%, transparent);

--- a/dashboard/src/pages/SkillPackages/index.tsx
+++ b/dashboard/src/pages/SkillPackages/index.tsx
@@ -1,4 +1,10 @@
-import { useCallback, useEffect, useRef, useState, type CSSProperties } from "react";
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type CSSProperties,
+} from "react";
 import {
   Button,
   Drawer,
@@ -128,7 +134,9 @@ export default function SkillPackagesPage() {
         const rows = await skillPackagesApi.list();
         setPackages(rows);
         setSelected((current) =>
-          current && !rows.some((row) => row.id === current.id) ? null : current,
+          current && !rows.some((row) => row.id === current.id)
+            ? null
+            : current,
         );
         setSelectedId((currentId) =>
           currentId && !rows.some((row) => row.id === currentId)
@@ -179,7 +187,13 @@ export default function SkillPackagesPage() {
   }, [loadPackages]);
 
   useEffect(() => {
-    if (isMobile || loading || detailLoading || selectedId || packages.length === 0) {
+    if (
+      isMobile ||
+      loading ||
+      detailLoading ||
+      selectedId ||
+      packages.length === 0
+    ) {
       return;
     }
     void loadDetail(packages[0].id);
@@ -463,9 +477,9 @@ export default function SkillPackagesPage() {
       fill
     >
       <div
-        className={`${styles.layout}${isResizing ? ` ${styles.layoutResizing}` : ""}${
-          isMobile ? ` ${styles.layoutMobile}` : ""
-        }`}
+        className={`${styles.layout}${
+          isResizing ? ` ${styles.layoutResizing}` : ""
+        }${isMobile ? ` ${styles.layoutMobile}` : ""}`}
         style={
           {
             "--skill-packages-sidebar-width": `${sidebarWidth}px`,
@@ -559,150 +573,157 @@ export default function SkillPackagesPage() {
         ) : null}
 
         {showDetailPane ? (
-        <section className={styles.detail}>
-          {detailLoading ? (
-            <div className={styles.detailLoadingOverlay}>
-              <Spin />
-            </div>
-          ) : null}
-          {!selected && !detailLoading ? (
-            <Empty
-              className={styles.emptyDetail}
-              image={<OctopEmptyMascot />}
-              description={t("skillPackages.selectPackage")}
-            />
-          ) : !selected ? null : (
-            <>
-              <div className={styles.detailHeader}>
-                <div className={styles.detailTitleRow}>
-                  <div className={styles.detailTitleGroup}>
-                    {isMobile ? (
-                      <button
-                        type="button"
-                        className={styles.mobileBackBtn}
-                        onClick={() => setMobilePane("list")}
-                        aria-label={t("skillPackages.backToList")}
+          <section className={styles.detail}>
+            {detailLoading ? (
+              <div className={styles.detailLoadingOverlay}>
+                <Spin />
+              </div>
+            ) : null}
+            {!selected && !detailLoading ? (
+              <Empty
+                className={styles.emptyDetail}
+                image={<OctopEmptyMascot />}
+                description={t("skillPackages.selectPackage")}
+              />
+            ) : !selected ? null : (
+              <>
+                <div className={styles.detailHeader}>
+                  <div className={styles.detailTitleRow}>
+                    <div className={styles.detailTitleGroup}>
+                      {isMobile ? (
+                        <button
+                          type="button"
+                          className={styles.mobileBackBtn}
+                          onClick={() => setMobilePane("list")}
+                          aria-label={t("skillPackages.backToList")}
+                        >
+                          <ChevronLeft size={18} />
+                        </button>
+                      ) : null}
+                      <Typography.Title
+                        level={4}
+                        className={styles.detailTitle}
                       >
-                        <ChevronLeft size={18} />
-                      </button>
-                    ) : null}
-                    <Typography.Title level={4} className={styles.detailTitle}>
-                      {selected.name}
-                    </Typography.Title>
-                  </div>
-                  {canMutate ? (
-                    <div className={styles.actions}>
-                      <Button
-                        icon={<Pencil size={14} />}
-                        onClick={openEditPackage}
-                      >
-                        {t("common.edit")}
-                      </Button>
-                      <Popconfirm
-                        title={t("skillPackages.deletePackageConfirm")}
-                        description={t("skillPackages.deletePackageMountedHint")}
-                        okText={t("common.delete")}
-                        cancelText={t("common.cancel")}
-                        onConfirm={() => void deletePackage()}
-                      >
-                        <Button danger icon={<Trash2 size={14} />}>
-                          {t("common.delete")}
-                        </Button>
-                      </Popconfirm>
+                        {selected.name}
+                      </Typography.Title>
                     </div>
-                  ) : null}
-                </div>
-                <Typography.Paragraph
-                  type="secondary"
-                  className={styles.detailDescription}
-                >
-                  {selected.description || t("skillPackages.noDescription")}
-                </Typography.Paragraph>
-              </div>
-
-              <div className={styles.detailBody}>
-                <div className={skillStyles.gridToolbar}>
-                  <span className={skillStyles.gridCount}>
-                    {t("skills.totalCount", { count: skills.length })}
-                  </span>
-                  <div className={skillStyles.gridToolbarRight}>
-                    <Segmented
-                      size="small"
-                      value={viewMode}
-                      onChange={(value) =>
-                        setViewMode(value === "table" ? "table" : "card")
-                      }
-                      options={[
-                        {
-                          value: "card",
-                          label: (
-                            <span className={skillStyles.viewModeLabel}>
-                              <LayoutGrid size={14} />
-                              {t("experts.viewCard")}
-                            </span>
-                          ),
-                        },
-                        {
-                          value: "table",
-                          label: (
-                            <span className={skillStyles.viewModeLabel}>
-                              <ListIcon size={14} />
-                              {t("experts.viewTable")}
-                            </span>
-                          ),
-                        },
-                      ]}
-                    />
-                    <Tooltip title={t("common.refresh")}>
-                      <button
-                        type="button"
-                        className={skillStyles.toolbarIconBtn}
-                        onClick={() => void handleRefresh()}
-                        disabled={refreshing || detailLoading}
-                      >
-                        <RefreshCw
-                          size={14}
-                          className={
-                            refreshing ? skillStyles.spinning : undefined
-                          }
-                        />
-                      </button>
-                    </Tooltip>
                     {canMutate ? (
-                      <>
-                        <button
-                          type="button"
-                          className={skillStyles.toolbarBtn}
-                          onClick={() => setHubOpen(true)}
+                      <div className={styles.actions}>
+                        <Button
+                          icon={<Pencil size={14} />}
+                          onClick={openEditPackage}
                         >
-                          <Store size={14} />
-                          {t("skills.tencentSkillHub")}
-                        </button>
-                        <button
-                          type="button"
-                          className={skillStyles.toolbarBtn}
-                          onClick={() => setImportModalOpen(true)}
+                          {t("common.edit")}
+                        </Button>
+                        <Popconfirm
+                          title={t("skillPackages.deletePackageConfirm")}
+                          description={t(
+                            "skillPackages.deletePackageMountedHint",
+                          )}
+                          okText={t("common.delete")}
+                          cancelText={t("common.cancel")}
+                          onConfirm={() => void deletePackage()}
                         >
-                          <Download size={14} />
-                          {t("skills.importSkills")}
-                        </button>
-                        <button
-                          type="button"
-                          className={skillStyles.toolbarBtnPrimary}
-                          onClick={openCreateSkill}
-                        >
-                          <Plus size={14} />
-                          {t("skillPackages.createSkill")}
-                        </button>
-                      </>
+                          <Button danger icon={<Trash2 size={14} />}>
+                            {t("common.delete")}
+                          </Button>
+                        </Popconfirm>
+                      </div>
                     ) : null}
                   </div>
+                  <Typography.Paragraph
+                    type="secondary"
+                    className={styles.detailDescription}
+                  >
+                    {selected.description || t("skillPackages.noDescription")}
+                  </Typography.Paragraph>
                 </div>
-                <div className={skillStyles.skillsListArea}>{skillsContent}</div>
-              </div>
-            </>
-          )}
-        </section>
+
+                <div className={styles.detailBody}>
+                  <div className={skillStyles.gridToolbar}>
+                    <span className={skillStyles.gridCount}>
+                      {t("skills.totalCount", { count: skills.length })}
+                    </span>
+                    <div className={skillStyles.gridToolbarRight}>
+                      <Segmented
+                        size="small"
+                        value={viewMode}
+                        onChange={(value) =>
+                          setViewMode(value === "table" ? "table" : "card")
+                        }
+                        options={[
+                          {
+                            value: "card",
+                            label: (
+                              <span className={skillStyles.viewModeLabel}>
+                                <LayoutGrid size={14} />
+                                {t("experts.viewCard")}
+                              </span>
+                            ),
+                          },
+                          {
+                            value: "table",
+                            label: (
+                              <span className={skillStyles.viewModeLabel}>
+                                <ListIcon size={14} />
+                                {t("experts.viewTable")}
+                              </span>
+                            ),
+                          },
+                        ]}
+                      />
+                      <Tooltip title={t("common.refresh")}>
+                        <button
+                          type="button"
+                          className={skillStyles.toolbarIconBtn}
+                          onClick={() => void handleRefresh()}
+                          disabled={refreshing || detailLoading}
+                        >
+                          <RefreshCw
+                            size={14}
+                            className={
+                              refreshing ? skillStyles.spinning : undefined
+                            }
+                          />
+                        </button>
+                      </Tooltip>
+                      {canMutate ? (
+                        <>
+                          <button
+                            type="button"
+                            className={skillStyles.toolbarBtn}
+                            onClick={() => setHubOpen(true)}
+                          >
+                            <Store size={14} />
+                            {t("skills.tencentSkillHub")}
+                          </button>
+                          <button
+                            type="button"
+                            className={skillStyles.toolbarBtn}
+                            onClick={() => setImportModalOpen(true)}
+                          >
+                            <Download size={14} />
+                            {t("skills.importSkills")}
+                          </button>
+                          <button
+                            type="button"
+                            className={skillStyles.toolbarBtnPrimary}
+                            onClick={openCreateSkill}
+                          >
+                            <Plus size={14} />
+                            {t("skillPackages.createSkill")}
+                          </button>
+                        </>
+                      ) : null}
+                    </div>
+                  </div>
+                  <div className={skillStyles.skillsListArea}>
+                    {skillsContent}
+                  </div>
+                </div>
+              </>
+            )}
+          </section>
         ) : null}
       </div>
 
@@ -770,7 +791,9 @@ export default function SkillPackagesPage() {
                 label: (
                   <span className={styles.iconOption}>
                     {iconForName(name, 18)}
-                    <span>{t(`experts.iconLabels.${name}`, { defaultValue: name })}</span>
+                    <span>
+                      {t(`experts.iconLabels.${name}`, { defaultValue: name })}
+                    </span>
                   </span>
                 ),
               }))}

--- a/dashboard/src/utils/chatStreamError.test.ts
+++ b/dashboard/src/utils/chatStreamError.test.ts
@@ -20,9 +20,9 @@ describe("classifyChatStreamError", () => {
   });
 
   it("classifies rate limit and auth errors", () => {
-    expect(classifyChatStreamError("Error code: 429 - rate_limit_exceeded")).toBe(
-      "stream_errors.rate_limit",
-    );
+    expect(
+      classifyChatStreamError("Error code: 429 - rate_limit_exceeded"),
+    ).toBe("stream_errors.rate_limit");
     expect(
       classifyChatStreamError("Error code: 401 - Incorrect API key provided"),
     ).toBe("stream_errors.auth");
@@ -34,7 +34,8 @@ describe("classifyChatStreamError", () => {
   });
 
   it("formats known failures through i18n", () => {
-    const msg = "No streaming chunk received for 30.0s (model=x, chunks_received=1)";
+    const msg =
+      "No streaming chunk received for 30.0s (model=x, chunks_received=1)";
     expect(formatChatStreamError(msg, t)).toBe(
       "translated:stream_errors.stream_stall",
     );


### PR DESCRIPTION
## Summary
- Add install-method upgrade guide and dual-panel layout on **高级设置 → 更新** (`admin/advanced?tab=updates`).
- Polish **HTTPS** settings: clearer status/alerts, single-column certificate setup flow with preflight results.
- Make `make all` run **`format-all` first** (backend Ruff + dashboard Prettier); simplify pre-commit around `make all` + dashboard build, re-staging any reformatted files that were already staged.

## Test plan
- [x] Local pre-commit / `make all` + dashboard `npm run build` on commit
- [ ] Open `/admin/advanced?tab=updates` — version upgrade left, install-method guide right; zh/en copy
- [ ] Open `/admin/advanced?tab=https` — status stack, domain form, steps, preflight table
- [ ] Confirm `make all` runs format before lint; unstaged prettier-only touch-ups from a clean tree are unlikely after this pass


Made with [Cursor](https://cursor.com)