### PR TITLE
fix: center slide captcha text in visible area after verification

### DIFF
--- a/dashboard/src/pages/Login/SlideCaptcha.tsx
+++ b/dashboard/src/pages/Login/SlideCaptcha.tsx
@@ -173,8 +173,8 @@ export default function SlideCaptcha({
           display: "flex",
           alignItems: "center",
           justifyContent: "center",
-          paddingLeft: THUMB_SIZE,
-          paddingRight: 8,
+          paddingLeft: verified ? 8 : THUMB_SIZE,
+          paddingRight: verified ? THUMB_SIZE : 8,
           fontSize: 13,
           color: verified
             ? "var(--fn-success, #16a34a)"


### PR DESCRIPTION
When the slider reaches the right end upon successful verification, the hint text container still used paddingLeft=THUMB_SIZE which centers the text in the area to the right of the (now right-positioned) thumb. Swap the horizontal padding based on the verified state so the success label is centered in the visible area to the LEFT of the thumb, matching the visual position of the hint before verification.

## Summary

<!-- What does this PR change and why? -->

## Target branch

- [ ] Base is **`develop`** (feature / fix — default)
- [ ] Base is **`main`** (`release/*` or `hotfix/*` only)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / chore
- [ ] Release / hotfix

## Test plan

<!-- How did you verify this? Include commands run (e.g. `make all`). -->

- [ ] `make all` passes locally
- [ ] Added/updated tests

## Checklist

- [ ] Updated `CHANGELOG.md` (if user-facing)
- [ ] README / docs updated (if needed)
