### PR TITLE
fix: make expert edit/delete buttons visible by default (#187)

### DIFF
--- a/dashboard/src/pages/Experts/index.module.less
+++ b/dashboard/src/pages/Experts/index.module.less
@@ -97,7 +97,7 @@
 
 @media (hover: hover) {
   .agentCard2NameActions {
-    opacity: 0;
+    opacity: 1;
     transition: opacity 0.15s;
   }
 


### PR DESCRIPTION
  问题：专家卡片上的编辑和删除按钮默认不可见（opacity: 0），仅在鼠标悬停于名称行时才显示。用户难以发现这两个操作入口，可能误以为功能不存在。

  修复：将 dashboard/src/pages/Experts/index.module.less 中 .agentCard2NameActions 的 opacity 从 0 改为 1，使编辑（Pencil）和删除（Trash2）按钮始终可见。

## Summary

<!-- What does this PR change and why? -->

## Target branch

- [ ] Base is **`develop`** (feature / fix — default)
- [ ] Base is **`main`** (`release/*` or `hotfix/*` only)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / chore
- [ ] Release / hotfix

## Test plan

<!-- How did you verify this? Include commands run (e.g. `make all`). -->

- [ ] `make all` passes locally
- [ ] Added/updated tests

## Checklist

- [ ] Updated `CHANGELOG.md` (if user-facing)
- [ ] README / docs updated (if needed)
