### PR TITLE
feat: 添加消息删除模式

### DIFF
--- a/dashboard/src/pages/Chat/chatMessages.partial.less
+++ b/dashboard/src/pages/Chat/chatMessages.partial.less
@@ -1061,3 +1061,118 @@
     opacity: 1;
   }
 }
+
+/* ---------- Delete mode ---------- */
+.messageRow {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.messageRowUser {
+  /* For user messages: checkbox stays left, content pushes right */
+  justify-content: flex-start;
+
+  /* Push the actual bubble content to right */
+  > *:last-child {
+    margin-left: auto;
+  }
+}
+
+.messageCheckboxWrapper {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding-top: 6px;
+}
+
+.messageCheckbox {
+  width: 18px;
+  height: 18px;
+  cursor: pointer;
+  accent-color: var(--fn-color-brand);
+}
+
+.deleteModeToolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 24px;
+  border-top: 1px solid var(--fn-border-secondary);
+  background: var(--fn-bg-primary);
+
+  @media (max-width: 767px) {
+    padding: 12px 12px;
+  }
+}
+
+.deleteModeLeft,
+.deleteModeRight {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.deleteModeCenter {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.deleteModeSelectAll {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+  color: var(--fn-text-primary);
+  cursor: pointer;
+  user-select: none;
+}
+
+.deleteModeDeleteBtn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 18px;
+  border: none;
+  border-radius: 999px;
+  background: var(--fn-color-danger);
+  color: #fff;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition:
+    background var(--fn-transition-fast),
+    opacity var(--fn-transition-fast);
+
+  &:hover:not(:disabled) {
+    background: #d9213d;
+  }
+
+  &:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+}
+
+.deleteModeExitBtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border: none;
+  border-radius: var(--fn-radius-full);
+  background: transparent;
+  color: var(--fn-text-secondary);
+  cursor: pointer;
+  transition:
+    color var(--fn-transition-fast),
+    background var(--fn-transition-fast);
+
+  &:hover {
+    color: var(--fn-text-primary);
+    background: var(--fn-bg-hover);
+  }
+}

--- a/dashboard/src/pages/Chat/components/AssistantTurnView.tsx
+++ b/dashboard/src/pages/Chat/components/AssistantTurnView.tsx
@@ -34,6 +34,7 @@ interface AssistantTurnViewProps {
   shellCommandDisabled?: boolean;
   shellCommandDisabledTitle?: string;
   compactProcess?: boolean;
+  onDeleteMessage?: (messageId: string) => void;
 }
 
 export default function AssistantTurnView({
@@ -51,6 +52,7 @@ export default function AssistantTurnView({
   shellCommandDisabled,
   shellCommandDisabledTitle,
   compactProcess = false,
+  onDeleteMessage,
 }: AssistantTurnViewProps) {
   const { t } = useTranslation();
   const { activeAgentId } = useAgent();
@@ -114,6 +116,7 @@ export default function AssistantTurnView({
         <MessageBubble
           message={hitlMessage}
           onHitlDecision={onHitlDecision}
+          onDeleteMessage={onDeleteMessage}
           groupPosition="only"
         />
       ) : null}
@@ -142,6 +145,7 @@ export default function AssistantTurnView({
             message={toAnswerOnlyMessage(answerSplit.answerMessage)}
             onRegenerate={onRegenerate}
             onEditUserMessage={onEditUserMessage}
+            onDeleteMessage={onDeleteMessage}
             groupPosition="only"
             onRunShellCommand={onRunShellCommand}
             shellCommandDisabled={shellCommandDisabled}

--- a/dashboard/src/pages/Chat/components/MessageBubble.tsx
+++ b/dashboard/src/pages/Chat/components/MessageBubble.tsx
@@ -10,6 +10,7 @@ import {
   RotateCcw,
   Pencil,
   Volume2,
+  Trash2,
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import type { ChatAttachment, ChatMessage } from "../hooks/useChat";
@@ -53,6 +54,7 @@ interface MessageBubbleProps {
   onHitlDecision?: (
     decisions: Array<{ type: string; message?: string }>,
   ) => void;
+  onDeleteMessage?: (messageId: string) => void;
 
   /** When true, the outer bubble uses reduced spacing (part of a group). */
   compact?: boolean;
@@ -491,6 +493,7 @@ function MessageBubble({
   onRegenerate,
   onEditUserMessage,
   onHitlDecision,
+  onDeleteMessage,
   compact,
   groupPosition = "only",
   onRunShellCommand,
@@ -719,7 +722,7 @@ function MessageBubble({
                   )}
                   {message.content && <div>{message.content}</div>}
                 </div>
-                {(message.content || onEditUserMessage) && (
+                {(message.content || onEditUserMessage || onDeleteMessage) && (
                   <div className={styles.userMsgActions} role="group">
                     {message.content ? (
                       <CopyButton text={message.content} />
@@ -736,6 +739,17 @@ function MessageBubble({
                         aria-label={t("common.edit")}
                       >
                         <Pencil size={14} />
+                      </button>
+                    ) : null}
+                    {onDeleteMessage ? (
+                      <button
+                        className={styles.msgActionBtn}
+                        onClick={() => onDeleteMessage(message.id)}
+                        title={t("common.delete", "删除")}
+                        type="button"
+                        aria-label={t("common.delete", "删除")}
+                      >
+                        <Trash2 size={14} />
                       </button>
                     ) : null}
                   </div>
@@ -844,6 +858,16 @@ function MessageBubble({
                       type="button"
                     >
                       <RotateCcw size={13} />
+                    </button>
+                  )}
+                  {!isUser && !isStreaming && onDeleteMessage && (
+                    <button
+                      className={styles.msgActionBtn}
+                      onClick={() => onDeleteMessage(message.id)}
+                      title={t("common.delete", "删除")}
+                      type="button"
+                    >
+                      <Trash2 size={13} />
                     </button>
                   )}
                 </div>

--- a/dashboard/src/pages/Chat/components/MessageList.tsx
+++ b/dashboard/src/pages/Chat/components/MessageList.tsx
@@ -106,6 +106,10 @@ interface MessageListProps {
   shellCommandDisabled?: boolean;
   shellCommandDisabledTitle?: string;
   compactProcess?: boolean;
+  isDeleteMode?: boolean;
+  isMessageSelected?: (messageId: string) => boolean;
+  onToggleMessageSelection?: (messageId: string) => void;
+  onDeleteMessage?: (messageId: string) => void;
 }
 
 interface GroupRenderContext {
@@ -128,6 +132,10 @@ interface GroupRenderContext {
   shellCommandDisabledTitle?: string;
   compactProcess?: boolean;
   registerBubbleRef: (messageId: string, el: HTMLDivElement | null) => void;
+  isDeleteMode?: boolean;
+  isMessageSelected?: (messageId: string) => boolean;
+  onToggleMessageSelection?: (messageId: string) => void;
+  onDeleteMessage?: (messageId: string) => void;
 }
 
 function renderMessageGroup(
@@ -146,6 +154,35 @@ function renderMessageGroup(
     lastUserGroupIndex: ctx.lastUserGroupIndex,
   });
 
+  const groupMessageId = group.messages[0]?.id ?? "";
+
+  const renderCheckbox = (messageId: string) => (
+    <div className={styles.messageCheckboxWrapper}>
+      <input
+        type="checkbox"
+        checked={ctx.isMessageSelected?.(messageId) ?? false}
+        onChange={(e) => {
+          e.stopPropagation();
+          ctx.onToggleMessageSelection?.(messageId);
+        }}
+        className={styles.messageCheckbox}
+      />
+    </div>
+  );
+
+  // Only wrap in the flex row when delete mode is active. In normal browsing
+  // this would otherwise become a flex item and shrink assistant bubbles to
+  // content width, changing the existing layout.
+  const messageContent = (messageId: string, content: React.ReactNode, { isUser = false } = {}) => {
+    if (!ctx.isDeleteMode) return content;
+    return (
+      <div className={`${styles.messageRow} ${isUser ? styles.messageRowUser : ""}`}>
+        {renderCheckbox(messageId)}
+        {content}
+      </div>
+    );
+  };
+
   if (!group.isGroup || group.messages.length === 1) {
     const msg = group.messages[0];
     if (msg.role === "assistant") {
@@ -155,21 +192,25 @@ function renderMessageGroup(
             ctx.registerBubbleRef(msg.id, el);
           }}
         >
-          <AssistantTurnView
-            messages={[msg]}
-            agentId={ctx.agentId}
-            isTurnInProgress={isTurnInProgress}
-            onRegenerate={ctx.onRegenerate}
-            onEditUserMessage={ctx.onEditUserMessage}
-            onAcpPermissionSelect={ctx.onAcpPermissionSelect}
-            onHitlDecision={ctx.onHitlDecision}
-            onOpenBrowser={openBrowserHandler}
-            onEditFile={ctx.onEditFile}
-            onRunShellCommand={ctx.onRunShellCommand}
-            shellCommandDisabled={ctx.shellCommandDisabled}
-            shellCommandDisabledTitle={ctx.shellCommandDisabledTitle}
-            compactProcess={ctx.compactProcess}
-          />
+          {messageContent(
+            msg.id,
+            <AssistantTurnView
+              messages={[msg]}
+              agentId={ctx.agentId}
+              isTurnInProgress={isTurnInProgress}
+              onRegenerate={ctx.onRegenerate}
+              onEditUserMessage={ctx.onEditUserMessage}
+              onAcpPermissionSelect={ctx.onAcpPermissionSelect}
+              onHitlDecision={ctx.onHitlDecision}
+              onOpenBrowser={openBrowserHandler}
+              onEditFile={ctx.onEditFile}
+              onRunShellCommand={ctx.onRunShellCommand}
+              shellCommandDisabled={ctx.shellCommandDisabled}
+              shellCommandDisabledTitle={ctx.shellCommandDisabledTitle}
+              compactProcess={ctx.compactProcess}
+              onDeleteMessage={ctx.onDeleteMessage}
+            />
+          )}
         </div>
       );
     }
@@ -179,13 +220,18 @@ function renderMessageGroup(
           ctx.registerBubbleRef(msg.id, el);
         }}
       >
-        <MessageBubble
-          message={msg}
-          agentId={ctx.agentId}
-          composerLookups={ctx.composerLookups}
-          onRegenerate={ctx.onRegenerate}
-          onEditUserMessage={ctx.onEditUserMessage}
-        />
+        {messageContent(
+          msg.id,
+          <MessageBubble
+            message={msg}
+            agentId={ctx.agentId}
+            composerLookups={ctx.composerLookups}
+            onRegenerate={ctx.onRegenerate}
+            onEditUserMessage={ctx.onEditUserMessage}
+            onDeleteMessage={ctx.onDeleteMessage}
+          />,
+          { isUser: msg.role === "user" }
+        )}
       </div>
     );
   }
@@ -200,21 +246,25 @@ function renderMessageGroup(
         }
       }}
     >
-      <AssistantTurnView
-        messages={group.messages}
-        agentId={ctx.agentId}
-        isTurnInProgress={isTurnInProgress}
-        onRegenerate={ctx.onRegenerate}
-        onEditUserMessage={ctx.onEditUserMessage}
-        onAcpPermissionSelect={ctx.onAcpPermissionSelect}
-        onHitlDecision={ctx.onHitlDecision}
-        onOpenBrowser={openBrowserHandler}
-        onEditFile={ctx.onEditFile}
-        onRunShellCommand={ctx.onRunShellCommand}
-        shellCommandDisabled={ctx.shellCommandDisabled}
-        shellCommandDisabledTitle={ctx.shellCommandDisabledTitle}
-        compactProcess={ctx.compactProcess}
-      />
+      {messageContent(
+        groupMessageId,
+        <AssistantTurnView
+          messages={group.messages}
+          agentId={ctx.agentId}
+          isTurnInProgress={isTurnInProgress}
+          onRegenerate={ctx.onRegenerate}
+          onEditUserMessage={ctx.onEditUserMessage}
+          onAcpPermissionSelect={ctx.onAcpPermissionSelect}
+          onHitlDecision={ctx.onHitlDecision}
+          onOpenBrowser={openBrowserHandler}
+          onEditFile={ctx.onEditFile}
+          onRunShellCommand={ctx.onRunShellCommand}
+          shellCommandDisabled={ctx.shellCommandDisabled}
+          shellCommandDisabledTitle={ctx.shellCommandDisabledTitle}
+          compactProcess={ctx.compactProcess}
+          onDeleteMessage={ctx.onDeleteMessage}
+        />
+      )}
     </div>
   );
 }
@@ -244,6 +294,10 @@ export default function MessageList(props: MessageListProps) {
     shellCommandDisabled,
     shellCommandDisabledTitle,
     compactProcess,
+    isDeleteMode = false,
+    isMessageSelected,
+    onToggleMessageSelection,
+    onDeleteMessage,
   } = props;
 
   const { t } = useTranslation();
@@ -670,6 +724,10 @@ export default function MessageList(props: MessageListProps) {
       shellCommandDisabledTitle,
       compactProcess,
       registerBubbleRef,
+      isDeleteMode,
+      isMessageSelected,
+      onToggleMessageSelection,
+      onDeleteMessage,
     }),
     [
       agentId,
@@ -689,6 +747,10 @@ export default function MessageList(props: MessageListProps) {
       shellCommandDisabledTitle,
       compactProcess,
       registerBubbleRef,
+      isDeleteMode,
+      isMessageSelected,
+      onToggleMessageSelection,
+      onDeleteMessage,
     ],
   );
 

--- a/dashboard/src/pages/Chat/hooks/chatStore.ts
+++ b/dashboard/src/pages/Chat/hooks/chatStore.ts
@@ -33,6 +33,7 @@ import {
   shouldForceSealStream,
   shouldResumeStreamAfterClose,
 } from "./wsResumeGate";
+import { groupConsecutiveAssistantMessages } from "../utils/messageGrouping";
 
 // ── Focused chat session (reconnect thrash only for the visible tab) ──────
 
@@ -121,6 +122,318 @@ export function consumePendingPrefillText(): string {
   const val = _pendingPrefillText;
   _pendingPrefillText = "";
   return val;
+}
+
+// ── Delete mode state ────────────────────────────────────────────────────
+// Tracks whether we're in delete mode and which messages are selected.
+// Delete mode is session-specific.
+
+interface DeleteModeState {
+  isDeleteMode: boolean;
+  selectedMessageIds: Set<string>;
+}
+
+const deleteModeStates = new Map<string, DeleteModeState>();
+
+function getDeleteModeState(sessionId: string): DeleteModeState {
+  let state = deleteModeStates.get(sessionId);
+  if (!state) {
+    state = {
+      isDeleteMode: false,
+      selectedMessageIds: new Set(),
+    };
+    deleteModeStates.set(sessionId, state);
+  }
+  return state;
+}
+
+/** Enter or exit delete mode for a session. */
+export function setDeleteMode(sessionId: string, isDeleteMode: boolean): void {
+  const deleteState = getDeleteModeState(sessionId);
+  if (deleteState.isDeleteMode !== isDeleteMode) {
+    deleteState.isDeleteMode = isDeleteMode;
+    deleteState.selectedMessageIds.clear();
+    const chatState = sessionStates.get(sessionId);
+    if (chatState) notify(chatState);
+  }
+}
+
+/** Check if we're in delete mode for a session. */
+export function isDeleteMode(sessionId: string): boolean {
+  return getDeleteModeState(sessionId).isDeleteMode;
+}
+
+/** Toggle a message's selected state in delete mode. */
+export function toggleMessageSelection(
+  sessionId: string,
+  messageId: string,
+): void {
+  const deleteState = getDeleteModeState(sessionId);
+  const chatState = sessionStates.get(sessionId);
+
+  // Find all messages in the same group as the clicked message
+  if (chatState) {
+    const groups = groupConsecutiveAssistantMessages(chatState.messages);
+    const targetGroup = groups.find((g) =>
+      g.messages.some((m) => m.id === messageId)
+    );
+
+    // Only apply group selection logic to ASSISTANT/TOOL message groups
+    // NEVER apply it to user messages (single user message groups)
+    if (
+      targetGroup &&
+      targetGroup.isGroup &&
+      targetGroup.messages.every((m) => m.role === "assistant" || m.role === "tool")
+    ) {
+      // This is a grouped assistant message - toggle the whole group
+      const groupIds = targetGroup.messages.map((m) => m.id);
+      // Check if all are already selected
+      const allSelected = groupIds.every((id) =>
+        deleteState.selectedMessageIds.has(id)
+      );
+
+      if (allSelected) {
+        // Deselect all in group
+        groupIds.forEach((id) => deleteState.selectedMessageIds.delete(id));
+      } else {
+        // Select all in group
+        groupIds.forEach((id) => deleteState.selectedMessageIds.add(id));
+      }
+    } else {
+      // Single message (user/system) - toggle just this one
+      if (deleteState.selectedMessageIds.has(messageId)) {
+        deleteState.selectedMessageIds.delete(messageId);
+      } else {
+        deleteState.selectedMessageIds.add(messageId);
+      }
+    }
+  } else {
+    // No chat state - just toggle the single message
+    if (deleteState.selectedMessageIds.has(messageId)) {
+      deleteState.selectedMessageIds.delete(messageId);
+    } else {
+      deleteState.selectedMessageIds.add(messageId);
+    }
+  }
+
+  if (chatState) notify(chatState);
+}
+
+/** Select or deselect all messages in delete mode. */
+export function setAllMessagesSelected(
+  sessionId: string,
+  messages: ChatMessage[],
+  selected: boolean,
+): void {
+  const deleteState = getDeleteModeState(sessionId);
+  deleteState.selectedMessageIds.clear();
+  if (selected) {
+    for (const msg of messages) {
+      deleteState.selectedMessageIds.add(msg.id);
+    }
+  }
+  const chatState = sessionStates.get(sessionId);
+  if (chatState) notify(chatState);
+}
+
+/** Check if all messages are selected. */
+export function areAllMessagesSelected(
+  sessionId: string,
+  messages: ChatMessage[],
+): boolean {
+  const deleteState = getDeleteModeState(sessionId);
+  return (
+    messages.length > 0 &&
+    messages.every((msg) => deleteState.selectedMessageIds.has(msg.id))
+  );
+}
+
+/** Get the set of selected message ids. */
+export function getSelectedMessageIds(sessionId: string): Set<string> {
+  const deleteState = getDeleteModeState(sessionId);
+  return new Set(deleteState.selectedMessageIds);
+}
+
+/** Delete selected messages from the session (surface only, no backend).
+ *
+ * The backend thread still owns the messages, so re-fetched history would
+ * normally bring them back (overscroll refresh, load-more, hard reload). We
+ * remember the deleted ids per session and filter them out of every history
+ * re-apply, so the deletion sticks without touching the agent memory layer.
+ */
+export function deleteSelectedMessages(sessionId: string): void {
+  const deleteState = getDeleteModeState(sessionId);
+  const chatState = sessionStates.get(sessionId);
+  if (!chatState || deleteState.selectedMessageIds.size === 0) return;
+
+  const selectedIds = deleteState.selectedMessageIds;
+  const { ids, fingerprints } = loadDeletedMessages(sessionId);
+  for (const msg of chatState.messages) {
+    if (selectedIds.has(msg.id)) {
+      ids.add(msg.id);
+      const fp = messageDeleteFingerprint(msg);
+      if (fp) fingerprints.add(fp);
+    }
+  }
+  persistDeletedMessages(sessionId);
+
+  chatState.messages = chatState.messages.filter((msg) => !selectedIds.has(msg.id));
+
+  // Exit delete mode after deletion
+  deleteState.isDeleteMode = false;
+  deleteState.selectedMessageIds.clear();
+
+  notify(chatState);
+}
+
+/** Check if a message is selected. */
+export function isMessageSelected(sessionId: string, messageId: string): boolean {
+  const deleteState = getDeleteModeState(sessionId);
+  return deleteState.selectedMessageIds.has(messageId);
+}
+
+// ── Surface-deleted messages (persistent) ────────────────────────────────
+// Delete mode removes messages from the local store only. To keep them gone
+// across overscroll-refresh / load-more / hard reloads, persist the deleted
+// ids per session and filter them out whenever history is re-applied.
+//
+// Live-streamed messages only ever carry a client-generated id (the backend
+// never echoes its own checkpoint id), so a reload would re-apply them under
+// a different id. To keep those deleted too, we also record a text fingerprint
+// per deleted message and match on id OR fingerprint.
+
+const DELETED_MESSAGES_STORAGE_PREFIX = "octop:deleted-messages:";
+
+const deletedMessageIds = new Map<string, Set<string>>();
+const deletedMessageFingerprints = new Map<string, Set<string>>();
+
+/**
+ * Checks if this message ID looks like a client-generated temporary ID
+ * (e.g., streamed messages before the server echoes back a real ID).
+ */
+function isTemporaryMessageId(id: string): boolean {
+  // Client-generated IDs: {timestamp}-{random}
+  if (/^\d+-\w+$/.test(id)) return true;
+  // Legacy call-* IDs from history conversion
+  if (id.startsWith("call-")) return true;
+  return false;
+}
+
+/**
+ * Signature used to re-identify a message after a reload — ONLY FOR
+ * CLIENT-GENERATED TEMPORARY MESSAGES (streamed content before server echo).
+ *
+ * For messages with stable backend IDs, we rely entirely on ID matching
+ * to avoid accidentally deleting unrelated messages with identical content.
+ */
+function messageDeleteFingerprint(message: ChatMessage): string {
+  // Only generate fingerprints for messages with temporary client IDs
+  if (!isTemporaryMessageId(message.id)) return "";
+
+  const role = message.role;
+
+  if (message.toolData?.name) {
+    return `${role}|tool:${message.toolData.name}:${message.toolData.callId ?? ""}:${message.timestamp}`;
+  }
+
+  let text = "";
+  if (message.contentBlocks) {
+    for (const block of message.contentBlocks) {
+      if (block.type === "text" && typeof block.content === "string") {
+        text += block.content;
+      }
+    }
+  } else if (typeof message.content === "string") {
+    text = message.content;
+  }
+  if (text.trim()) return `${role}|${text}|${message.timestamp}`;
+
+  if (message.contentBlocks && message.contentBlocks.length > 0) {
+    const payload = message.contentBlocks
+      .map((b) =>
+        typeof b.content === "string"
+          ? b.content
+          : JSON.stringify(b.content ?? ""),
+      )
+      .join("\n");
+    return `${role}|blocks:${payload}|${message.timestamp}`;
+  }
+
+  return "";
+}
+
+function loadDeletedMessages(
+  sessionId: string,
+): { ids: Set<string>; fingerprints: Set<string> } {
+  let ids = deletedMessageIds.get(sessionId);
+  let fingerprints = deletedMessageFingerprints.get(sessionId);
+  if (!ids || !fingerprints) {
+    ids = new Set<string>();
+    fingerprints = new Set<string>();
+    deletedMessageIds.set(sessionId, ids);
+    deletedMessageFingerprints.set(sessionId, fingerprints);
+    try {
+      const raw = localStorage.getItem(
+        `${DELETED_MESSAGES_STORAGE_PREFIX}${sessionId}`,
+      );
+      if (raw) {
+        const parsed = JSON.parse(raw);
+        if (Array.isArray(parsed)) {
+          // Legacy format: bare id list.
+          for (const id of parsed) {
+            if (typeof id === "string" && id) ids.add(id);
+          }
+        } else if (parsed && typeof parsed === "object") {
+          if (Array.isArray(parsed.ids)) {
+            for (const id of parsed.ids) {
+              if (typeof id === "string" && id) ids.add(id);
+            }
+          }
+          if (Array.isArray(parsed.fingerprints)) {
+            for (const fp of parsed.fingerprints) {
+              if (typeof fp === "string" && fp) fingerprints.add(fp);
+            }
+          }
+        }
+      }
+    } catch {
+      // ignore corrupt / unavailable storage
+    }
+  }
+  return { ids, fingerprints };
+}
+
+function persistDeletedMessages(sessionId: string): void {
+  try {
+    const ids = deletedMessageIds.get(sessionId) ?? new Set<string>();
+    const fingerprints =
+      deletedMessageFingerprints.get(sessionId) ?? new Set<string>();
+    localStorage.setItem(
+      `${DELETED_MESSAGES_STORAGE_PREFIX}${sessionId}`,
+      JSON.stringify({ ids: [...ids], fingerprints: [...fingerprints] }),
+    );
+  } catch {
+    // ignore quota / private-mode errors
+  }
+}
+
+/** Filter surface-deleted messages out of a history payload. */
+function filterDeletedMessages(
+  sessionId: string,
+  messages: ChatMessage[],
+): ChatMessage[] {
+  const { ids, fingerprints } = loadDeletedMessages(sessionId);
+  if (ids.size === 0 && fingerprints.size === 0) return messages;
+  return messages.filter((message) => {
+    if (ids.has(message.id)) return false;
+    // Only apply fingerprint matching to temporary client-generated IDs
+    // For real backend IDs, rely entirely on ID matching to avoid collateral deletion
+    if (fingerprints.size > 0 && isTemporaryMessageId(message.id)) {
+      const fp = messageDeleteFingerprint(message);
+      if (fp && fingerprints.has(fp)) return false;
+    }
+    return true;
+  });
 }
 
 // ── Composer draft (sessionStorage) ───────────────────────────────────────
@@ -478,7 +791,7 @@ export function getSnapshot(sessionId: string): SessionSnapshot {
 /** Directly set messages for a session (e.g. from loadHistory). */
 export function setMessages(sessionId: string, messages: ChatMessage[]) {
   const state = getOrCreate(sessionId);
-  state.messages = messages;
+  state.messages = filterDeletedMessages(sessionId, messages);
   state.runUsage = null;
   notify(state);
 }
@@ -490,7 +803,7 @@ export function setHistoryPage(
   opts: { hasMore: boolean; nextOffset: number },
 ) {
   const state = getOrCreate(sessionId);
-  state.messages = messages;
+  state.messages = filterDeletedMessages(sessionId, messages);
   state.runUsage = null;
   state.historyHasMore = opts.hasMore;
   state.historyNextOffset = opts.nextOffset;
@@ -515,7 +828,10 @@ export function prependHistoryMessages(
   opts: { hasMore: boolean; nextOffset: number },
 ) {
   const state = getOrCreate(sessionId);
-  const uniqueOlder = dedupePrependMessages(older, state.messages);
+  const uniqueOlder = dedupePrependMessages(
+    filterDeletedMessages(sessionId, older),
+    state.messages,
+  );
   if (uniqueOlder.length > 0) {
     state.messages = [...uniqueOlder, ...state.messages];
   }
@@ -685,6 +1001,16 @@ export function removeSession(sessionId: string) {
   clearStreamActivity(sessionId);
   clearStreamWatchdog(sessionId);
   closeLiveSocket(sessionId, { intentional: true, userCancelled: true });
+  // Surface-deleted message tracking is scoped to this session — drop it so a
+  // recreated thread with the same id starts clean.
+  deleteModeStates.delete(sessionId);
+  deletedMessageIds.delete(sessionId);
+  deletedMessageFingerprints.delete(sessionId);
+  try {
+    localStorage.removeItem(`${DELETED_MESSAGES_STORAGE_PREFIX}${sessionId}`);
+  } catch {
+    // ignore
+  }
 }
 
 /** Rename a cached session's key (e.g. temp id → real UUID).
@@ -717,6 +1043,23 @@ export function renameSessionKey(oldId: string, newId: string) {
     if (wd != null) {
       streamWatchdogs.delete(oldId);
       streamWatchdogs.set(newId, wd);
+    }
+    // Surface-deleted message tracking must follow the session key so the
+    // renamed thread keeps its deleted-message filter across the remount.
+    const dmIds = deletedMessageIds.get(oldId);
+    if (dmIds) {
+      deletedMessageIds.set(newId, dmIds);
+      deletedMessageIds.delete(oldId);
+    }
+    const dmFps = deletedMessageFingerprints.get(oldId);
+    if (dmFps) {
+      deletedMessageFingerprints.set(newId, dmFps);
+      deletedMessageFingerprints.delete(oldId);
+    }
+    const dmState = deleteModeStates.get(oldId);
+    if (dmState) {
+      deleteModeStates.set(newId, dmState);
+      deleteModeStates.delete(oldId);
     }
     if (focusedChatSessionId === oldId) {
       focusedChatSessionId = newId;

--- a/dashboard/src/pages/Chat/index.tsx
+++ b/dashboard/src/pages/Chat/index.tsx
@@ -8,6 +8,8 @@ import {
   Globe,
   FilePen,
   Terminal,
+  Trash2,
+  X,
 } from "lucide-react";
 import { Tooltip } from "antd";
 import { message as antMessage } from "@/utils/antdMessage";
@@ -558,6 +560,55 @@ function ChatPageInner() {
     [activeThreadId, editAndResend, resolvedAgentId],
   );
 
+  // Delete mode handlers
+  const isDeleteMode = activeThreadId ? chatStore.isDeleteMode(activeThreadId) : false;
+
+  const handleExitDeleteMode = useCallback(() => {
+    if (!activeThreadId) return;
+    chatStore.setDeleteMode(activeThreadId, false);
+  }, [activeThreadId]);
+
+  const handleToggleMessageSelection = useCallback(
+    (messageId: string) => {
+      if (!activeThreadId) return;
+      chatStore.toggleMessageSelection(activeThreadId, messageId);
+    },
+    [activeThreadId],
+  );
+
+  const handleSelectAllMessages = useCallback(() => {
+    if (!activeThreadId) return;
+    const allSelected = chatStore.areAllMessagesSelected(activeThreadId, messages);
+    chatStore.setAllMessagesSelected(activeThreadId, messages, !allSelected);
+  }, [activeThreadId, messages]);
+
+  const handleDeleteSelectedMessages = useCallback(() => {
+    if (!activeThreadId) return;
+    chatStore.deleteSelectedMessages(activeThreadId);
+  }, [activeThreadId]);
+
+  const handleIsMessageSelected = useCallback(
+    (messageId: string) => {
+      if (!activeThreadId) return false;
+      return chatStore.isMessageSelected(activeThreadId, messageId);
+    },
+    [activeThreadId],
+  );
+
+  // Handle clicking delete button on a message: enter delete mode and select that message
+  const handleDeleteMessage = useCallback(
+    (messageId: string) => {
+      if (!activeThreadId) return;
+      // Enter delete mode first
+      chatStore.setDeleteMode(activeThreadId, true);
+      // Then select the message that was clicked
+      chatStore.toggleMessageSelection(activeThreadId, messageId);
+    },
+    [activeThreadId],
+  );
+
+  const areAllSelected = activeThreadId ? chatStore.areAllMessagesSelected(activeThreadId, messages) : false;
+
   const hasMessages = messages.length > 0;
   // On hard refresh / deep-link into a thread, messages start empty. Showing
   // Welcome until history returns looks like a full page flash. Keep the list
@@ -711,6 +762,10 @@ function ChatPageInner() {
                     ? openFileList
                     : undefined
                 }
+                isDeleteMode={isDeleteMode}
+                isMessageSelected={handleIsMessageSelected}
+                onToggleMessageSelection={handleToggleMessageSelection}
+                onDeleteMessage={handleDeleteMessage}
               />
             )}
           </div>
@@ -832,40 +887,78 @@ function ChatPageInner() {
             </div>
           )}
 
-          <ChatComposerChrome sessionUsageLabel={sessionUsageLabel} />
-          <ChatInput
-            ref={chatInputRef}
-            onSend={wrappedHandleSend}
-            onQueue={enqueueQueued}
-            queuedItems={queuedItems}
-            onRemoveQueued={removeQueued}
-            onReclaimQueued={reclaimQueued}
-            onCancel={cancelStream}
-            onNewChat={handleNewChat}
-            isStreaming={isStreaming}
-            disabled={!agentChatReady || noAgents}
-            initialText={prefillInputRef.current}
-            onComposerCleared={() => {
-              prefillInputRef.current = "";
-            }}
-            availableModels={availableModels}
-            selectedModel={selectedModel}
-            onModelChange={setSelectedModel}
-            availableConnectors={chatConnectors}
-            selectedConnectors={selectedConnectors}
-            onConnectorsChange={handleConnectorsChange}
-            availableSkills={chatSkills}
-            selectedSkills={selectedSkills}
-            onSkillsChange={handleSkillsChange}
-            availableAgents={chatAgentOptions}
-            selectedTargetAgents={selectedTargetAgents}
-            onTargetAgentsChange={setSelectedTargetAgents}
-            agentId={resolvedAgentId}
-            threadId={activeThreadId}
-            defaultModel={activeAgent?.default_model ?? null}
-            contextUsedTokens={contextUsedTokens}
-            contextMaxTokens={contextMaxTokens}
-          />
+          {!isDeleteMode ? (
+            <>
+              <ChatComposerChrome sessionUsageLabel={sessionUsageLabel} />
+              <ChatInput
+                ref={chatInputRef}
+                onSend={wrappedHandleSend}
+                onQueue={enqueueQueued}
+                queuedItems={queuedItems}
+                onRemoveQueued={removeQueued}
+                onReclaimQueued={reclaimQueued}
+                onCancel={cancelStream}
+                onNewChat={handleNewChat}
+                isStreaming={isStreaming}
+                disabled={!agentChatReady || noAgents}
+                initialText={prefillInputRef.current}
+                onComposerCleared={() => {
+                  prefillInputRef.current = "";
+                }}
+                availableModels={availableModels}
+                selectedModel={selectedModel}
+                onModelChange={setSelectedModel}
+                availableConnectors={chatConnectors}
+                selectedConnectors={selectedConnectors}
+                onConnectorsChange={handleConnectorsChange}
+                availableSkills={chatSkills}
+                selectedSkills={selectedSkills}
+                onSkillsChange={handleSkillsChange}
+                availableAgents={chatAgentOptions}
+                selectedTargetAgents={selectedTargetAgents}
+                onTargetAgentsChange={setSelectedTargetAgents}
+                agentId={resolvedAgentId}
+                threadId={activeThreadId}
+                defaultModel={activeAgent?.default_model ?? null}
+                contextUsedTokens={contextUsedTokens}
+                contextMaxTokens={contextMaxTokens}
+              />
+            </>
+          ) : (
+            <div className={styles.deleteModeToolbar}>
+              {/* Left: Select all checkbox */}
+              <div className={styles.deleteModeLeft}>
+                <label className={styles.deleteModeSelectAll}>
+                  <input
+                    type="checkbox"
+                    checked={areAllSelected}
+                    onChange={handleSelectAllMessages}
+                  />
+                  <span>{t("chat.delete.selectAll", "全选")}</span>
+                </label>
+              </div>
+              {/* Center: Delete button */}
+              <div className={styles.deleteModeCenter}>
+                <button
+                  className={styles.deleteModeDeleteBtn}
+                  onClick={handleDeleteSelectedMessages}
+                  disabled={chatStore.getSelectedMessageIds(activeThreadId ?? "").size === 0}
+                >
+                  <Trash2 size={18} />
+                  <span>{t("chat.delete.delete", "删除")}</span>
+                </button>
+              </div>
+              {/* Right: Exit button */}
+              <div className={styles.deleteModeRight}>
+                <button
+                  className={styles.deleteModeExitBtn}
+                  onClick={handleExitDeleteMode}
+                >
+                  <X size={18} />
+                </button>
+              </div>
+            </div>
+          )}
         </div>
 
         <ChatDockPanels


### PR DESCRIPTION
---

# Add chat delete mode (UI only, no memory layer changes)

## Summary

添加聊天消息删除模式，支持在界面上选择删除聊天消息，完全不触碰记忆层（后端数据库/Agent记忆），仅做前端过滤。

### What does this PR change and why?

- 新增：聊天删除模式，支持勾选单条/多条/全部消息进行删除
- 新增：每条消息添加删除按钮，点击可直接进入删除模式并选中该消息
- 新增：成组的 Assistant 消息会自动全组选中/删除（工具调用+文本回复）
- 新增：删除记录持久化（localStorage），刷新/加载更多历史时不会重新出现
- 修复：非删除模式下保持原布局完全不变
- 修复：仅对临时客户端 ID 消息做指纹匹配，避免误删
- 修复：会话移除/重命名时正确清理/迁移删除记录

### Important Note (初版说明)

这是删除模式的第一版，完全没有触碰记忆层
- 不调用任何后端删除接口
- 后端数据库保持完整
- Agent 记忆完全不受影响
- 只做前端 UI 隐藏，用户随时可以通过清除 localStorage 让消息重新显示

---

## Target branch

- [x] Base is `develop` (feature / fix - default)
- [ ] Base is `main` (release/* or hotfix/* only)

---

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / chore
- [ ] Release / hotfix

---

## Detailed change list

### dashboard/src/pages/Chat/hooks/chatStore.ts

- 新增 DeleteModeState 用于管理删除模式和选中状态
  - setDeleteMode(sessionId, isDeleteMode)：切换删除模式
  - toggleMessageSelection(sessionId, messageId)：切换单条选中状态
  - setAllMessagesSelected(sessionId, messages, isSelected)：全选/取消全选
  - deleteSelectedMessages(sessionId)：删除所有选中消息
  - isMessageSelected(sessionId, messageId)：检查是否选中

- 新增 表面删除记录持久化
  - DELETED_MESSAGES_STORAGE_PREFIX = "octop:deleted-messages:"
  - loadDeletedMessages(sessionId)：读取已删除消息
  - persistDeletedMessages(sessionId)：保存已删除记录
  - filterDeletedMessages(sessionId, messages)：过滤历史消息

- 新增 消息指纹（用于流式消息 reload 后匹配）
  - isTemporaryMessageId(messageId)：识别是否为临时客户端ID
  - messageDeleteFingerprint(message)：
    - 工具消息：{role}|tool:{toolName}:{callId}:{timestamp}
    - 文本消息：{role}|{text}:{timestamp}
    - 仅对临时 ID 生成指纹避免误删

- 更新 会话生命周期管理
  - removeSession(sessionId)：同时清理删除记录
  - renameSessionKey(oldId, newId)：同时迁移删除记录
  - setHistoryPage/setMessages/prependHistoryMessages：均调用过滤

### dashboard/src/pages/Chat/components/MessageList.tsx

- 新增 删除模式 props: isDeleteMode, isMessageSelected, onToggleMessageSelection, onDeleteMessage
- 新增 renderCheckbox(messageId)：渲染复选框
- 新增 messageContent(messageId, content, {isUser})：仅在删除模式下包裹 flex 布局
- 更新 renderMessageGroup()：成组的 Assistant 消息点击会选中整个组

### dashboard/src/pages/Chat/components/MessageBubble.tsx

- 新增 onDeleteMessage? prop
- 新增 删除按钮：用户消息在操作区，Assistant 消息在时间戳旁边
- 新增 Trash2 icon import

### dashboard/src/pages/Chat/components/AssistantTurnView.tsx

- 新增 onDeleteMessage? prop，透传给 MessageBubble

### dashboard/src/pages/Chat/chatMessages.partial.less

- 新增 .messageRow：删除模式下的 flex 容器
- 新增 .messageRowUser：用户消息对齐
- 新增 .messageCheckboxWrapper / .messageCheckbox：复选框样式
- 新增 .deleteModeToolbar：底部删除工具栏
- 新增 .deleteModeSelectAll / .deleteModeDeleteBtn / .deleteModeExitBtn

### dashboard/src/pages/Chat/index.tsx

- 新增 删除模式状态和回调
- 新增 条件渲染：删除模式下显示删除工具栏，否则显示原有输入框
- 新增 全选/删除/退出按钮
- 新增 Trash2 / X icons import

---

## Test plan

### 功能验证

1. 单条删除：
   - Hover 消息点击删除按钮 -> 进入删除模式并选中该条
   - 点击底部删除 -> 消息消失
   - 刷新页面 -> 消息保持删除
   - 向上滑动加载更多历史 -> 消息仍然保持删除

2. 多条选择：
   - 进入删除模式 -> 手动勾选多条消息
   - 点击删除 -> 全部选中消息消失

3. 全选删除：
   - 进入删除模式 -> 点击"全选"复选框
   - 点击删除 -> 所有消息消失

4. 成组 Assistant 消息：
   - 发送带工具调用的消息
   - 点击成组中任意一条消息的复选框 -> 整组选中
   - 点击删除 -> 成组的所有消息一起删除

5. 非删除模式下布局无影响：
   - 退出删除模式 -> 检查所有消息布局与之前完全一致
   - 用户消息右对齐，Assistant 消息左对齐
   - 气泡尺寸、间距无变化

6. 删除持久化隔离：
   - 会话A中删除几条消息
   - 切换到会话B -> 会话B的消息完整不受影响
   - 切换回会话A -> 删除的消息保持删除

7. 会话重命名/删除：
   - 在会话中删除几条消息
   - 重命名会话 -> 删除记录正确迁移
   - 删除会话 -> 删除记录正确清理

## Checklist

- [ ] Updated `CHANGELOG.md` (if user-facing)
- [ ] README / docs updated (if needed)
- [x] 不涉及记忆层改动 

## Security / Safety Notes
完全不触碰记忆层：

不调用任何后端删除接口
后端数据库保持完整
Agent 记忆完全不受影响
只做前端 UI 隐藏，用户随时可以通过清除 localStorage 找回消息

这是第一版，后续可以考虑加上：

- Undo 删除撤销
- 批量管理删除记录
- 更细粒度的过滤控制