### PR TITLE
fix: clean up agent workspace directory on delete

### DIFF
--- a/src/octop/cli/support/offline_ops.py
+++ b/src/octop/cli/support/offline_ops.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
+import shutil
 from pathlib import Path
 from typing import Any
 
@@ -18,6 +20,8 @@ from octop.infra.errors import ErrorCode, OctopError
 from octop.infra.gateway.threads import ThreadRegistry
 from octop.infra.users.password import hash_password
 from octop.infra.utils.ulid import new_cron_id, new_ulid
+
+logger = logging.getLogger(__name__)
 
 
 def _user_row_to_dict(row: Any) -> dict[str, Any]:
@@ -214,6 +218,14 @@ def delete_agent_offline(agent_id: str, *, home: Path | None = None) -> None:
     with open_cli_services(home) as svc:
         if svc.agent_repo.get(agent_id) is None:
             raise OctopError(ErrorCode.AGENT_NOT_FOUND, f"agent {agent_id!r} not found")
+        workspace_dir = svc.paths.agent_workspace(agent_id)
+        try:
+            if workspace_dir.exists():
+                shutil.rmtree(workspace_dir)
+        except OSError:
+            logger.exception(
+                "rmtree failed for %s; agent removed from DB anyway", workspace_dir
+            )
         svc.agent_repo.delete(agent_id)
 
 

--- a/src/octop/infra/agents/manager.py
+++ b/src/octop/infra/agents/manager.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import shutil
 from collections.abc import AsyncIterator, Callable, Sequence
 from dataclasses import dataclass, field, fields, replace
 from pathlib import Path
@@ -440,6 +441,12 @@ class AgentManager:
         """Remove agent from DB, harness runtime, and workspace directory."""
         async with self._lock:
             await self._harness_manager.aremove_agent(agent_id)  # type: ignore[union-attr]
+        workspace_dir = self._paths.agent_workspace(agent_id)
+        try:
+            if workspace_dir.exists():
+                shutil.rmtree(workspace_dir)
+        except OSError:
+            logger.exception("rmtree failed for %s; agent removed from DB anyway", workspace_dir)
         self._repos.agent_repo.delete(agent_id)
         self._repos.audit_repo.write(actor=ACTOR_SYSTEM, action="agent.delete", target=agent_id)
 

--- a/tests/unit/agents/test_agent_manager.py
+++ b/tests/unit/agents/test_agent_manager.py
@@ -415,6 +415,51 @@ async def test_reload_agent_clears_bootstrap_refresh_pending(manager: AgentManag
     harness_manager.aremove_agent.assert_awaited_once_with(agent_id)
 
 
+@pytest.mark.asyncio
+async def test_delete_removes_workspace_directory(manager: AgentManager) -> None:
+    """Deleting an agent must clean up its workspace directory on disk."""
+    agent_id = "AGT_DELETE_WS"
+    manager._repos.agent_repo.create(agent_id=agent_id, user_id=None, name="delete-ws")
+
+    workspace_dir = manager._paths.ensure_agent_workspace(agent_id)
+    assert workspace_dir.is_dir()
+    (workspace_dir / "MEMORY.md").write_text("old memory", encoding="utf-8")
+
+    harness_manager = MagicMock()
+    harness_manager.aremove_agent = AsyncMock()
+    manager._harness_manager = harness_manager
+
+    await manager.delete(agent_id)
+
+    harness_manager.aremove_agent.assert_awaited_once_with(agent_id)
+    assert manager.get_row(agent_id) is None
+    assert not workspace_dir.exists()
+
+
+@pytest.mark.asyncio
+async def test_delete_keeps_db_row_when_workspace_rmtree_fails(
+    manager: AgentManager, monkeypatch: Any
+) -> None:
+    """A failed workspace rmtree must not abort agent deletion (mirrors user removal)."""
+    import shutil
+
+    agent_id = "AGT_DELETE_ERR"
+    manager._repos.agent_repo.create(agent_id=agent_id, user_id=None, name="delete-err")
+
+    def _fail_rmtree(path: object) -> None:
+        raise OSError("permission denied")
+
+    monkeypatch.setattr(shutil, "rmtree", _fail_rmtree)
+
+    harness_manager = MagicMock()
+    harness_manager.aremove_agent = AsyncMock()
+    manager._harness_manager = harness_manager
+
+    await manager.delete(agent_id)
+
+    assert manager.get_row(agent_id) is None
+
+
 def test_bootstrap_pending_detects_unfinished_onboarding(tmp_path: Path) -> None:
     from harness_agent.backends import resolve_backend
     from harness_agent.backends.workspace import BackendWorkspace


### PR DESCRIPTION
# Fix: clean up agent workspace directory on delete

## Summary

修复删除 Agent 时工作区残留问题。之前删除 Agent 只移除 harness 运行时和数据库记录，`~/.octop/agents/<agent_id>/` 目录会残留在磁盘上，随时间积累大量孤儿文件（agent 记忆、会话等）。

### What does this PR change and why?

- 修复：AgentRegistry.delete() 删除 Agent 时同时清理工作区目录
- 修复：delete_agent_offline() 离线删除 Agent 时同样清理工作区目录
- 修复：清理失败（如文件被占用）时记录日志但不阻断数据库删除，与删除用户的既有逻辑保持一致
- 新增：两个单元测试覆盖工作区清理成功与 rmtree 失败两种情况

### Important Note

本次修改不涉及任何记忆层/数据库结构变更，仅补全删除 Agent 时应有的磁盘清理。
- 不调用任何新的后端删除接口
- 数据库结构与 Agent 记忆格式完全不变
- 若清理失败，Agent 仍会从数据库删除，目录保留待后续处理

## Target branch

- [x] Base is `main` (release/* or hotfix/* only)
- [ ] Base is `develop` (feature / fix - default)

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / chore
- [ ] Release / hotfix

## Detailed change list

### src/octop/infra/agents/manager.py

- 新增 `import shutil`
- AgentRegistry.delete()：在移除 harness 运行时、删除数据库记录前，调用 `shutil.rmtree` 清理 `~/.octop/agents/<agent_id>/` 工作区目录
- 清理失败时用 logger.exception 记录，不阻断数据库删除

### src/octop/cli/support/offline_ops.py

- 新增 `import logging`、`import shutil` 与模块级 logger
- delete_agent_offline()：删除数据库记录前同样清理工作区目录，失败记录日志不阻断

### tests/unit/agents/test_agent_manager.py

- 新增 test_delete_removes_workspace_directory：验证删除 Agent 后工作区目录被清理
- 新增 test_delete_keeps_db_row_when_workspace_rmtree_fails：验证 rmtree 失败不阻断数据库删除

## Test plan

### 运行测试

```bash
cd dashboard
npm run test
```

- [x] make all passes locally
- [x] 全部单元测试通过

### 功能验证

1. 创建测试 Agent -> 启动 -> 通过界面删除
2. 确认 `~/.octop/agents/<agent_id>/` 目录随 Agent 删除一并移除
3. 通过 CLI 离线删除同样验证目录被清理

## Checklist

- [ ] Updated CHANGELOG.md (if user-facing)
- [ ] README / docs updated (if needed)
- [x] 不涉及记忆层改动

## Security / Safety Notes

- 仅清理该 Agent 专属的工作区目录，不触碰其他 Agent 数据
- 删除用户的既有逻辑（users/manager.py）保持一致的行为模式
