### PR TITLE
fix: 保留技能 ZIP 导入时的空目录与根级技能的子文件夹

### DIFF
--- a/dashboard/src/pages/Agent/Skills/components/parseSkillZip.test.ts
+++ b/dashboard/src/pages/Agent/Skills/components/parseSkillZip.test.ts
@@ -5,10 +5,14 @@ import { parseSkillZip } from "./parseSkillZip";
 async function zipFromTree(
   tree: Record<string, string | Uint8Array>,
   filename = "skills.zip",
+  dirs: string[] = [],
 ): Promise<File> {
   const zip = new JSZip();
   for (const [path, content] of Object.entries(tree)) {
     zip.file(path, content);
+  }
+  for (const dir of dirs) {
+    zip.folder(dir);
   }
   const blob = await zip.generateAsync({ type: "blob" });
   return new File([blob], filename, { type: "application/zip" });
@@ -87,13 +91,14 @@ describe("parseSkillZip", () => {
     ]);
   });
 
-  it("does not attach sibling folders to a root-level skill", async () => {
-    // Nested folders without their own SKILL.md are ignored; only root files
-    // belong to the root skill group.
+  it("keeps supporting subfolders under a root-level skill", async () => {
+    // Subfolders without their own SKILL.md are supporting files of the
+    // root skill; they must be preserved with their nested paths.
     const file = await zipFromTree(
       {
         "SKILL.md": "---\nname: solo\n---\n",
         "helpers/util.py": "print(1)\n",
+        "scripts/run.py": "print(2)\n",
       },
       "solo.zip",
     );
@@ -101,7 +106,108 @@ describe("parseSkillZip", () => {
     const skills = await parseSkillZip(file);
     expect(skills).toHaveLength(1);
     expect(skills[0].slug).toBe("solo");
-    expect(skills[0].files.map((item) => item.path)).toEqual(["SKILL.md"]);
+    expect(skills[0].files.map((item) => item.path).sort()).toEqual([
+      "SKILL.md",
+      "helpers/util.py",
+      "scripts/run.py",
+    ]);
+  });
+
+  it("preserves empty directories inside a skill folder", async () => {
+    // The reported bug: a skill whose zip carries EMPTY folders (ai/, data/,
+    // scripts/) loses every folder during import. Empty dirs must survive.
+    const file = await zipFromTree(
+      {
+        "word-docx/SKILL.md": "---\nname: word-docx\n---\n",
+        "word-docx/index.html": "<html></html>",
+      },
+      "word-docx.zip",
+      ["word-docx/ai", "word-docx/data", "word-docx/scripts"],
+    );
+
+    const skills = await parseSkillZip(file);
+    expect(skills).toHaveLength(1);
+    expect(skills[0].slug).toBe("word-docx");
+    const paths = skills[0].files.map((item) => item.path).sort();
+    expect(paths).toEqual([
+      "SKILL.md",
+      "ai/",
+      "data/",
+      "index.html",
+      "scripts/",
+    ]);
+    const ai = skills[0].files.find((item) => item.path === "ai/");
+    expect(ai?.contentBase64).toBe("");
+  });
+
+  it("preserves empty directories under a root-level skill", async () => {
+    const file = await zipFromTree(
+      {
+        "SKILL.md": "---\nname: solo\n---\n",
+        "run.py": "print(1)\n",
+      },
+      "solo.zip",
+      ["scripts", "data"],
+    );
+
+    const skills = await parseSkillZip(file);
+    expect(skills).toHaveLength(1);
+    expect(skills[0].slug).toBe("solo");
+    expect(skills[0].files.map((item) => item.path).sort()).toEqual([
+      "SKILL.md",
+      "data/",
+      "run.py",
+      "scripts/",
+    ]);
+  });
+
+  it("drops empty dirs that belong to no skill", async () => {
+    // "stray/" is an empty folder with no SKILL.md and no root skill to hang
+    // under — it must not produce a bogus skill.
+    const file = await zipFromTree(
+      {
+        "good/SKILL.md": "---\nname: good\n---\n",
+      },
+      "skills.zip",
+      ["stray"],
+    );
+
+    const skills = await parseSkillZip(file);
+    expect(skills).toHaveLength(1);
+    expect(skills[0].slug).toBe("good");
+    expect(skills[0].files.map((item) => item.path).sort()).toEqual([
+      "SKILL.md",
+    ]);
+  });
+
+  it("keeps a separate skill beside a root-level skill", async () => {
+    // A sibling folder with its own SKILL.md stays its own skill, while
+    // folders without SKILL.md stay attached to the root skill.
+    const file = await zipFromTree(
+      {
+        "SKILL.md": "---\nname: root-skill\n---\n",
+        "shared/util.py": "print(1)\n",
+        "other/SKILL.md": "---\nname: other\n---\n",
+        "other/notes.txt": "hi",
+      },
+      "root-skill.zip",
+    );
+
+    const skills = await parseSkillZip(file);
+    expect(skills.map((skill) => skill.slug).sort()).toEqual([
+      "other",
+      "root-skill",
+    ]);
+    const root = skills.find((skill) => skill.slug === "root-skill");
+    expect(root?.files.map((item) => item.path).sort()).toEqual([
+      "SKILL.md",
+      "shared/util.py",
+    ]);
+    const other = skills.find((skill) => skill.slug === "other");
+    expect(other?.files.map((item) => item.path).sort()).toEqual([
+      "SKILL.md",
+      "notes.txt",
+    ]);
   });
 
   it("prefers rootSlugFallback for root-level skills", async () => {

--- a/dashboard/src/pages/Agent/Skills/components/parseSkillZip.ts
+++ b/dashboard/src/pages/Agent/Skills/components/parseSkillZip.ts
@@ -24,9 +24,9 @@ function bytesToBase64(bytes: Uint8Array): string {
 
 function isSkippedPath(path: string): boolean {
   const lower = path.toLowerCase().replace(/\\/g, "/");
-  return (
-    SKIP_MARKERS.some((marker) => lower.includes(marker)) || lower.endsWith("/")
-  );
+  // Note: directories are intentionally NOT skipped — an empty directory (no
+  // files underneath) must survive the import so it can be recreated.
+  return SKIP_MARKERS.some((marker) => lower.includes(marker));
 }
 
 function normalizeZipPath(path: string): string {
@@ -52,13 +52,13 @@ function fallbackSlugFromFilename(filename: string): string {
   return base.replace(/[\\/]+/g, "-");
 }
 
+type ZipEntry = { zipPath: string; relPath: string; isDir: boolean };
+
 /**
- * If every file sits under one outer folder and that folder is not itself a
+ * If every entry sits under one outer folder and that folder is not itself a
  * skill root, strip the wrapper so nested skill folders become top-level.
  */
-function stripOuterWrapper(
-  entries: Array<{ zipPath: string; relPath: string }>,
-): Array<{ zipPath: string; relPath: string }> {
+function stripOuterWrapper(entries: ZipEntry[]): ZipEntry[] {
   const tops = new Set(
     entries.map((entry) => entry.relPath.split("/")[0] || "").filter(Boolean),
   );
@@ -74,6 +74,7 @@ function stripOuterWrapper(
     .map((entry) => ({
       zipPath: entry.zipPath,
       relPath: entry.relPath.slice(wrapper.length + 1),
+      isDir: entry.isDir,
     }))
     .filter((entry) => entry.relPath.length > 0);
   return nested.length > 0 ? nested : entries;
@@ -88,24 +89,32 @@ export async function parseSkillZip(
   }
 
   const zip = await JSZip.loadAsync(file);
-  const rawEntries: Array<{ zipPath: string; relPath: string }> = [];
+  const rawEntries: ZipEntry[] = [];
   for (const [zipPath, zipObject] of Object.entries(zip.files)) {
-    if (zipObject.dir) continue;
     const relPath = normalizeZipPath(zipPath);
     if (!relPath || isSkippedPath(relPath)) continue;
-    rawEntries.push({ zipPath, relPath });
+    const isDir = Boolean(zipObject.dir) || relPath.endsWith("/");
+    rawEntries.push({
+      zipPath,
+      relPath: isDir && !relPath.endsWith("/") ? `${relPath}/` : relPath,
+      isDir,
+    });
   }
   if (rawEntries.length === 0) {
     throw new Error("ZIP_EMPTY");
   }
 
   const entries = stripOuterWrapper(rawEntries);
-  const groups = new Map<string, Array<{ zipPath: string; path: string }>>();
+  // A trailing "/" marks an empty directory entry; files carry their content.
+  type GroupFile = { zipPath: string; path: string; isDir: boolean };
+  const groups = new Map<string, GroupFile[]>();
 
+  // Pass 1: group file entries by their top-level folder.
   for (const entry of entries) {
+    if (entry.isDir) continue;
     if (!entry.relPath.includes("/")) {
       const list = groups.get("__root__") ?? [];
-      list.push({ zipPath: entry.zipPath, path: entry.relPath });
+      list.push({ zipPath: entry.zipPath, path: entry.relPath, isDir: false });
       groups.set("__root__", list);
       continue;
     }
@@ -114,8 +123,63 @@ export async function parseSkillZip(
     const path = entry.relPath.slice(slash + 1);
     if (!path) continue;
     const list = groups.get(slug) ?? [];
-    list.push({ zipPath: entry.zipPath, path });
+    list.push({ zipPath: entry.zipPath, path, isDir: false });
     groups.set(slug, list);
+  }
+
+  const isSkillGroup = (slug: string) =>
+    groups.get(slug)?.some((item) => item.path === "SKILL.md") ?? false;
+  const skillSlugs = new Set(
+    [...groups.keys()].filter((slug) => slug !== "__root__" && isSkillGroup(slug)),
+  );
+
+  // Pass 2: attach EMPTY directories so they survive the import. JSZip (and
+  // real zips) emit a dir entry for every folder — even ones that contain
+  // files — so only folders with no files underneath actually need a marker.
+  // A skill's own root folder is implied by the slug and must not be recreated.
+  const fileRelPaths = entries
+    .filter((entry) => !entry.isDir)
+    .map((entry) => entry.relPath);
+  const dirHasFiles = (dirRelPath: string): boolean => {
+    const prefix = `${dirRelPath.replace(/\/$/, "")}/`;
+    return fileRelPaths.some((p) => p.startsWith(prefix));
+  };
+  for (const entry of entries) {
+    if (!entry.isDir) continue;
+    if (dirHasFiles(entry.relPath)) continue;
+    const parts = entry.relPath.split("/").filter(Boolean);
+    if (parts.length === 0) continue;
+    if (parts.length === 1) {
+      if (skillSlugs.has(parts[0])) continue;
+      const list = groups.get("__root__") ?? [];
+      list.push({ zipPath: entry.zipPath, path: `${parts[0]}/`, isDir: true });
+      groups.set("__root__", list);
+      continue;
+    }
+    const slug = parts[0];
+    const path = `${parts.slice(1).join("/")}/`;
+    const list = groups.get(slug) ?? [];
+    list.push({ zipPath: entry.zipPath, path, isDir: true });
+    groups.set(slug, list);
+  }
+
+  // A root-level SKILL.md means the archive root is itself a skill. Subfolders
+  // that do not contain their own SKILL.md are supporting files and directories
+  // (scripts/, references/, images/, …) — keep them under the root skill
+  // instead of dropping them, so nested directories survive the import.
+  const rootGroup = groups.get("__root__");
+  if (rootGroup?.some((item) => item.path === "SKILL.md")) {
+    for (const [groupSlug, files] of groups) {
+      if (groupSlug === "__root__") continue;
+      if (files.some((item) => item.path === "SKILL.md")) continue;
+      for (const item of files) {
+        rootGroup.push({
+          zipPath: item.zipPath,
+          path: `${groupSlug}/${item.path}`,
+          isDir: item.isDir,
+        });
+      }
+    }
   }
 
   const skills: ParsedZipSkill[] = [];
@@ -132,6 +196,11 @@ export async function parseSkillZip(
 
     const parsedFiles: ParsedZipSkillFile[] = [];
     for (const item of files) {
+      if (item.isDir || item.path.endsWith("/")) {
+        // Empty directory — no content, only the trailing-"/" path marker.
+        parsedFiles.push({ path: item.path, contentBase64: "" });
+        continue;
+      }
       const zipFile = zip.file(item.zipPath);
       if (!zipFile) continue;
       const bytes = await zipFile.async("uint8array");

--- a/src/octop/api/routers/skills.py
+++ b/src/octop/api/routers/skills.py
@@ -35,6 +35,7 @@ import logging
 import os
 import shutil
 import tempfile
+from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, cast
@@ -595,6 +596,22 @@ class ImportSkillBody(BaseModel):
     overwrite: bool = False
 
 
+async def _write_skill_files(
+    workspace: Any,
+    skill_root: str,
+    files: Sequence[tuple[str, bytes]],
+) -> None:
+    """Write skill files into a workspace, creating empty directories first."""
+    dirs = [path for path, _content in files if path.endswith("/")]
+    payload = [(path, content) for path, content in files if not path.endswith("/")]
+    for path in dirs:
+        await workspace.amkdir(f"{skill_root}/{path}".rstrip("/"))
+    if payload:
+        await workspace.aupload_many(
+            [(f"{skill_root}/{path}", content) for path, content in payload]
+        )
+
+
 def _files_from_skill_body(
     *,
     content: str,
@@ -646,7 +663,7 @@ async def create_skill(
             raise OctopError(ErrorCode.SKILL_ALREADY_EXISTS, f"skill {name!r} already exists")
     with contextlib.suppress(Exception):
         await ctx.workspace.adelete(f"skills/{name}")
-    await ctx.workspace.aupload_many(package.workspace_uploads())
+    await _write_skill_files(ctx.workspace, f"skills/{name}", package.files)
     # Reinstall after disable/delete must clear skills_disabled (ZIP create
     # always installs as enabled, matching URL import with enable=True).
     disabled = _disabled_set(ctx.config)
@@ -694,7 +711,7 @@ async def update_skill(
 
     with contextlib.suppress(Exception):
         await ctx.workspace.adelete(f"skills/{slug}")
-    await ctx.workspace.aupload_many(package.workspace_uploads())
+    await _write_skill_files(ctx.workspace, f"skills/{slug}", package.files)
     skill_md = next(
         (content for path, content in package.files if path == "SKILL.md"),
         body.content.encode("utf-8"),
@@ -732,8 +749,7 @@ class _AgentWorkspaceInstallTarget:
         skill_root = f"skills/{slug}"
         with contextlib.suppress(Exception):
             await self._workspace.adelete(skill_root)
-        uploads = [(f"{skill_root}/{path}", content) for path, content in files]
-        await self._workspace.aupload_many(uploads)
+        await _write_skill_files(self._workspace, skill_root, files)
 
     async def after_install(self, slug: str, *, enable: bool | None = None) -> None:
         if not enable:

--- a/src/octop/infra/skills/skill_package_store.py
+++ b/src/octop/infra/skills/skill_package_store.py
@@ -142,6 +142,10 @@ class SkillPackageStore:
         skill_dir.mkdir(parents=True, exist_ok=True)
         for relative_path, content in normalized_files:
             path = skill_dir / relative_path
+            if relative_path.endswith("/"):
+                # Empty directory marker ("ai/"): recreate the folder, write nothing.
+                path.mkdir(parents=True, exist_ok=True)
+                continue
             path.parent.mkdir(parents=True, exist_ok=True)
             path.write_bytes(content)
         self._update_skill_count(pack_id)

--- a/src/octop/infra/skills/skill_packages.py
+++ b/src/octop/infra/skills/skill_packages.py
@@ -51,12 +51,17 @@ def validate_skill_slug(slug: str) -> str:
 def _normalize_relative_path(value: str) -> str:
     if not value or "\\" in value or "\x00" in value:
         raise SkillPackageError(f"invalid skill package path: {value}")
+    # A trailing "/" marks an empty directory that must be recreated on install
+    # (PurePosixPath would silently strip it, turning the dir into a file).
+    is_dir_marker = value.endswith("/")
     path = PurePosixPath(value)
     if path.is_absolute() or ".." in path.parts or (path.parts and path.parts[0].endswith(":")):
         raise SkillPackageError(f"unsafe skill package path: {value}")
     normalized = path.as_posix()
     if normalized in {"", "."}:
         raise SkillPackageError(f"invalid skill package path: {value}")
+    if is_dir_marker and not normalized.endswith("/"):
+        normalized = f"{normalized}/"
     return normalized
 
 

--- a/tests/integration/test_skills_api.py
+++ b/tests/integration/test_skills_api.py
@@ -467,6 +467,38 @@ async def test_create_skill_from_files_payload(env: Any) -> None:
     assert script == "print(1)\n"
 
 
+async def test_create_skill_preserves_empty_directories(env: Any) -> None:
+    """Empty folders from a local ZIP import are recreated in the workspace."""
+    c, srv, auth, aid = env
+    skill_md = "---\nname: word-docx\ndescription: from zip\n---\n\n# Word Docx\n"
+    r = await c.post(
+        f"/api/agents/{aid}/skills",
+        headers=auth,
+        json={
+            "name": "word-docx",
+            "files": [
+                {"path": "SKILL.md", "content_base64": _b64(skill_md)},
+                {"path": "index.html", "content_base64": _b64("<html></html>")},
+                {"path": "ai/", "content_base64": ""},
+                {"path": "data/", "content_base64": ""},
+                {"path": "scripts/", "content_base64": ""},
+            ],
+        },
+    )
+    assert r.status_code == 201, r.text
+    assert r.json()["name"] == "word-docx"
+
+    agent = srv.app_runtime.agent_registry.get_agent(aid)
+    index = await agent.workspace.aread_text("skills/word-docx/index.html")
+    assert index == "<html></html>"
+    for path in (
+        "skills/word-docx/ai",
+        "skills/word-docx/data",
+        "skills/word-docx/scripts",
+    ):
+        assert await agent.workspace.aexists(path), path
+
+
 async def test_create_skill_files_conflict_without_overwrite(env: Any) -> None:
     c, _srv, auth, aid = env
     await c.post(

--- a/tests/unit/agents/test_skill_package_store.py
+++ b/tests/unit/agents/test_skill_package_store.py
@@ -108,6 +108,31 @@ def test_skill_validation_errors_are_mapped_to_octop_errors(
     assert exc_info.value.code is ErrorCode.SLASH_BAD_ARGS
 
 
+def test_write_skill_recreates_empty_directories(store: SkillPackageStore) -> None:
+    row = store.create(name="P", description="", created_by="42")
+
+    store.write_skill(
+        row.id,
+        "word-docx",
+        [
+            ("SKILL.md", b"---\nname: word-docx\n---\n"),
+            ("ai/", b""),
+            ("data/", b""),
+            ("scripts/", b""),
+            ("index.html", b"<html></html>"),
+        ],
+    )
+
+    skill_dir = store.package_skills_dir(row.id) / "word-docx"
+    assert skill_dir.is_dir()
+    assert (skill_dir / "SKILL.md").read_bytes() == b"---\nname: word-docx\n---\n"
+    assert (skill_dir / "index.html").read_bytes() == b"<html></html>"
+    assert (skill_dir / "ai").is_dir()
+    assert (skill_dir / "data").is_dir()
+    assert (skill_dir / "scripts").is_dir()
+    assert list((skill_dir / "ai").iterdir()) == []
+
+
 def test_skill_count_excludes_skills_hidden_from_summaries(store: SkillPackageStore) -> None:
     row = store.create(name="P", description="", created_by="42")
     skills_dir = store.package_skills_dir(row.id)

--- a/tests/unit/agents/test_skill_packages.py
+++ b/tests/unit/agents/test_skill_packages.py
@@ -68,6 +68,55 @@ def test_resolve_package_rejects_unsafe_paths(path: str) -> None:
         )
 
 
+def test_resolve_package_preserves_empty_directory_markers() -> None:
+    package = skill_packages.resolve_skill_package(
+        slug="word-docx",
+        files=[
+            ("SKILL.md", b"---\nname: word-docx\n---\n"),
+            ("ai/", b""),
+            ("data/", b""),
+            ("scripts/", b""),
+            ("index.html", b"<html></html>"),
+        ],
+        source="zip",
+    )
+
+    assert list(package.files) == [
+        ("SKILL.md", b"---\nname: word-docx\n---\n"),
+        ("ai/", b""),
+        ("data/", b""),
+        ("scripts/", b""),
+        ("index.html", b"<html></html>"),
+    ]
+    assert package.workspace_uploads() == [
+        ("skills/word-docx/SKILL.md", b"---\nname: word-docx\n---\n"),
+        ("skills/word-docx/ai/", b""),
+        ("skills/word-docx/data/", b""),
+        ("skills/word-docx/scripts/", b""),
+        ("skills/word-docx/index.html", b"<html></html>"),
+    ]
+
+
+def test_normalize_relative_path_keeps_dir_marker_while_cleaning_others() -> None:
+    assert skill_packages._normalize_relative_path("ai/") == "ai/"
+    assert skill_packages._normalize_relative_path("nested/scripts/") == "nested/scripts/"
+    assert skill_packages._normalize_relative_path("scripts") == "scripts"
+    assert skill_packages._normalize_relative_path("./docs.md") == "docs.md"
+
+
+def test_resolve_import_preserves_empty_directory_markers() -> None:
+    package = skill_packages.resolve_workspace_uploads(
+        slug="gh-skill",
+        uploads=[
+            ("skills/gh-skill/SKILL.md", b"# skill"),
+            ("skills/gh-skill/empty/", b""),
+        ],
+        source="url",
+    )
+
+    assert list(package.files) == [("SKILL.md", b"# skill"), ("empty/", b"")]
+
+
 def test_resolve_import_rejects_files_outside_the_skill_root() -> None:
     with pytest.raises(skill_packages.SkillPackageError, match="outside"):
         skill_packages.resolve_workspace_uploads(


### PR DESCRIPTION
## Summary

技能 ZIP 导入时，仅含空目录（如 `ai/`、`data/`、`scripts/`）的技能会把目录全部丢失；根级技能下的子文件夹（无自己的 SKILL.md）此前也会被静默丢弃，导致嵌套目录/支撑文件无法随技能导入。

- **前端 `parseSkillZip`**：不再跳过目录条目。空目录转为带尾部 `/` 的路径标记（content 为空）保留下来；根级技能下的子文件夹（无自己的 SKILL.md）作为支撑文件一并保留，与兄弟技能正确共存。
- **`skill_packages._normalize_relative_path`**：保留尾随 `/` 目录标记，避免 `PurePosixPath` 把目录标记悄悄当成文件名。
- **`skill_package_store.write_skill`**：对目录标记执行 `mkdir`，在全局技能包中重建空目录。
- **skills 路由**：新增 `_write_skill_files`（先 `amkdir` 空目录，再批量上传文件），`create` / `update` / URL 导入统一走该函数。

## Target branch

- [x] Base is **`develop`** (feature / fix — default)
- [ ] Base is **`main`** (`release/*` or `hotfix/*` only)

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / chore
- [ ] Release / hotfix

## Test plan

- 新增单元测试：空目录标记在解析（`tests/unit/agents/test_skill_packages.py`）与包存储（`tests/unit/agents/test_skill_package_store.py`）中被保留/重建，孤立空目录不会产生伪技能。
- 新增集成测试 `test_create_skill_preserves_empty_directories`：ZIP 导入后 `ai/`、`data/`、`scripts/` 空目录在工作区中被重建。
- 本地验证：相关 unit 测试通过、`ruff` clean、前端 `parseSkillZip` 测试通过。
- 说明：本机 venv 与 develop 存在依赖版本差（缺少 `harness_agent.middleware.model_settings`），完整集成套件由 CI 运行。

- [ ] `make all` passes locally
- [x] Added/updated tests

## Checklist

- [ ] Updated `CHANGELOG.md` (if user-facing)
- [ ] README / docs updated (if needed)
