### PR TITLE
ci: set git identity for Sync Main Into Develop

### DIFF
--- a/.github/workflows/sync-main-to-develop.yml
+++ b/.github/workflows/sync-main-to-develop.yml
@@ -50,6 +50,8 @@ jobs:
           TAG: ${{ github.event.release.tag_name || github.event.workflow_run.head_branch || 'manual' }}
         run: |
           set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           version="${TAG#v}"
           sync_branch="chore/sync-develop-after-${version}"
           git fetch origin main develop
@@ -77,7 +79,9 @@ jobs:
             git checkout -B "${sync_branch}"
             git push -u origin "${sync_branch}" --force
           else
-            git merge --abort
+            if [ -f .git/MERGE_HEAD ]; then
+              git merge --abort
+            fi
             echo "Merge conflict — rebuilding develop on main tip."
 
             git diff --name-only origin/main "${saved_develop}" > /tmp/diff_files.txt || true


### PR DESCRIPTION
## Summary
- Sync Main Into Develop 从 `main` 上的 workflow 定义执行（Release / `workflow_dispatch --ref main`）。
- Runner 没有 `user.name` / `user.email`，merge commit 会在处理冲突前失败。
- 在 merge/commit 前设置 `github-actions[bot]` 身份；仅在存在 `MERGE_HEAD` 时 `merge --abort`。

`develop` 已通过 #237 带上同一修复。合入本 PR 后需再把新的 `main` tip 同步回 `develop`，以保持祖先关系。

## Test plan
- [x] 本地 pre-commit（`make all` + dashboard build）通过
- [ ] 合入后手动 Re-run / `workflow_dispatch` 不再出现 empty ident
- [ ] 合入后把新的 `main` tip 同步回 `develop`


Made with [Cursor](https://cursor.com)