### PR TITLE
fix(dashboard): 修复发版后 PWA 旧壳导致的白屏

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 ### 变更
 - 依赖新增 `python-docx==1.2.0`（含 `lxml`），用于工作区 `.docx` 的 Markdown 往返转换
 
+### 修复
+- 仪表盘发版后或长时间未打开时白屏：Service Worker 不再 Cache-First 钉死旧 `index.html`；hashed 资源改为 CacheFirst；入口脚本失败时清除 SW 缓存并自动刷新一次 (#236)
+
 ## [0.9.21] - 2026-08-11
 
 ### 新增

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -30,6 +30,64 @@
     <!-- Web App Manifest -->
     <link rel="manifest" href="/manifest.json" />
     <title>Octop</title>
+    <!--
+      Classic script (not type=module) so it runs even when hashed chunks 404.
+      Shares octop:chunk-reload with reloadOnStaleChunk.ts.
+    -->
+    <script>
+      (function () {
+        var KEY = "octop:chunk-reload";
+        function isAsset(url) {
+          return typeof url === "string" && url.indexOf("/assets/") !== -1;
+        }
+        function recover() {
+          try {
+            if (sessionStorage.getItem(KEY) === "1") {
+              sessionStorage.removeItem(KEY);
+              return;
+            }
+            sessionStorage.setItem(KEY, "1");
+          } catch (e) {}
+          var reload = function () {
+            location.reload();
+          };
+          var bust = Promise.resolve();
+          if ("serviceWorker" in navigator) {
+            bust = navigator.serviceWorker
+              .getRegistrations()
+              .then(function (regs) {
+                return Promise.all(
+                  regs.map(function (r) {
+                    return r.unregister();
+                  }),
+                );
+              });
+          }
+          if ("caches" in window) {
+            bust = bust.then(function () {
+              return caches.keys().then(function (keys) {
+                return Promise.all(
+                  keys.map(function (k) {
+                    return caches.delete(k);
+                  }),
+                );
+              });
+            });
+          }
+          bust.then(reload, reload);
+        }
+        window.addEventListener(
+          "error",
+          function (e) {
+            var t = e.target;
+            if (!t || !t.tagName) return;
+            if (t.tagName === "SCRIPT" && isAsset(t.src)) recover();
+            if (t.tagName === "LINK" && isAsset(t.href)) recover();
+          },
+          true,
+        );
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/dashboard/src/sw-register.test.ts
+++ b/dashboard/src/sw-register.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+type FakeWorker = {
+  state: string;
+  postMessage: ReturnType<typeof vi.fn>;
+  addEventListener: (type: string, fn: () => void) => void;
+};
+
+function mockRegistration(opts: {
+  waiting?: FakeWorker | null;
+  installing?: FakeWorker | null;
+  controller?: { scriptURL: string } | null;
+}) {
+  const listeners = new Map<string, Array<() => void>>();
+  const registration = {
+    waiting: opts.waiting ?? null,
+    installing: opts.installing ?? null,
+    addEventListener: (type: string, fn: () => void) => {
+      const list = listeners.get(type) ?? [];
+      list.push(fn);
+      listeners.set(type, list);
+    },
+    emit: (type: string) => {
+      for (const fn of listeners.get(type) ?? []) fn();
+    },
+    update: vi.fn(),
+  };
+  Object.defineProperty(navigator, "serviceWorker", {
+    configurable: true,
+    value: {
+      register: vi.fn().mockResolvedValue(registration),
+      getRegistrations: vi.fn().mockResolvedValue([]),
+      controller: opts.controller ?? null,
+    },
+  });
+  return registration;
+}
+
+describe("registerProductionSW", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("activates a waiting worker when the page is uncontrolled", async () => {
+    const waiting: FakeWorker = {
+      state: "installed",
+      postMessage: vi.fn(),
+      addEventListener: vi.fn(),
+    };
+    mockRegistration({ waiting, controller: null });
+
+    const { registerProductionSW } = await import("./sw-register");
+    await registerProductionSW();
+
+    expect(waiting.postMessage).toHaveBeenCalledWith({ type: "SKIP_WAITING" });
+    expect(navigator.serviceWorker.register).toHaveBeenCalledWith("/sw.js", {
+      scope: "/",
+      updateViaCache: "none",
+    });
+  });
+
+  it("prompts when a waiting worker exists and the page is controlled", async () => {
+    const waiting: FakeWorker = {
+      state: "installed",
+      postMessage: vi.fn(),
+      addEventListener: vi.fn(),
+    };
+    mockRegistration({
+      waiting,
+      controller: { scriptURL: "https://x/sw.js" },
+    });
+    const onReady = vi.fn();
+    window.addEventListener("pwa:update-ready", onReady);
+
+    const { registerProductionSW } = await import("./sw-register");
+    await registerProductionSW();
+
+    expect(waiting.postMessage).not.toHaveBeenCalled();
+    expect(onReady).toHaveBeenCalledOnce();
+  });
+});

--- a/dashboard/src/sw-register.ts
+++ b/dashboard/src/sw-register.ts
@@ -41,6 +41,53 @@ export function applyUpdate(): void {
   window.location.reload();
 }
 
+/** Production registration. Exported for unit tests (vitest always sets DEV). */
+export async function registerProductionSW(): Promise<void> {
+  const registration = await navigator.serviceWorker.register("/sw.js", {
+    scope: "/",
+    updateViaCache: "none",
+  });
+
+  // Intentionally no controllerchange → location.reload() listener.
+  // Chrome and Safari both pick up new assets via applyUpdate() instead.
+
+  const activateWaiting = (worker: ServiceWorker) => {
+    worker.postMessage({ type: "SKIP_WAITING" });
+  };
+
+  if (registration.waiting) {
+    if (navigator.serviceWorker.controller) {
+      pendingRegistration = registration;
+      notifyUpdateReady();
+    } else {
+      // Uncontrolled page (shift-reload): activate so the next visit is
+      // not handed back to the stale worker that caused the white screen.
+      activateWaiting(registration.waiting);
+    }
+  }
+
+  registration.addEventListener("updatefound", () => {
+    const installing = registration.installing;
+    if (!installing) return;
+    installing.addEventListener("statechange", () => {
+      if (installing.state !== "installed") return;
+      if (navigator.serviceWorker.controller) {
+        pendingRegistration = registration;
+        notifyUpdateReady();
+        return;
+      }
+      activateWaiting(installing);
+    });
+  });
+
+  setInterval(
+    () => {
+      void registration.update();
+    },
+    60 * 60 * 1000,
+  );
+}
+
 export async function registerSW(): Promise<void> {
   if (!("serviceWorker" in navigator)) return;
 
@@ -54,38 +101,7 @@ export async function registerSW(): Promise<void> {
   }
 
   try {
-    const registration = await navigator.serviceWorker.register("/sw.js", {
-      scope: "/",
-    });
-
-    // Intentionally no controllerchange → location.reload() listener.
-    // Chrome and Safari both pick up new assets via applyUpdate() instead.
-
-    if (registration.waiting) {
-      pendingRegistration = registration;
-      notifyUpdateReady();
-    }
-
-    registration.addEventListener("updatefound", () => {
-      const installing = registration.installing;
-      if (!installing) return;
-      installing.addEventListener("statechange", () => {
-        if (
-          installing.state === "installed" &&
-          navigator.serviceWorker.controller
-        ) {
-          pendingRegistration = registration;
-          notifyUpdateReady();
-        }
-      });
-    });
-
-    setInterval(
-      () => {
-        void registration.update();
-      },
-      60 * 60 * 1000,
-    );
+    await registerProductionSW();
   } catch (err) {
     console.error("[SW] Registration failed:", err);
   }

--- a/dashboard/src/utils/reloadOnStaleChunk.test.ts
+++ b/dashboard/src/utils/reloadOnStaleChunk.test.ts
@@ -1,5 +1,8 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  bustServiceWorkerAndReload,
   clearChunkReloadFlag,
   isChunkLoadError,
   tryReloadOnStaleChunk,
@@ -28,32 +31,38 @@ describe("isChunkLoadError", () => {
   });
 });
 
-describe("tryReloadOnStaleChunk", () => {
+function stubReload() {
   const reload = vi.fn();
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: { reload },
+  });
+  return reload;
+}
+
+describe("tryReloadOnStaleChunk", () => {
+  let reload: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     sessionStorage.clear();
-    Object.defineProperty(window, "location", {
-      configurable: true,
-      value: { reload },
-    });
-    reload.mockClear();
+    reload = stubReload();
   });
 
   afterEach(() => {
     clearChunkReloadFlag();
   });
 
-  it("reloads once on chunk error", () => {
+  it("reloads once on chunk error", async () => {
     const err = new Error("Failed to fetch dynamically imported module: /a.js");
     expect(tryReloadOnStaleChunk(err)).toBe(true);
-    expect(reload).toHaveBeenCalledOnce();
+    await vi.waitFor(() => expect(reload).toHaveBeenCalledOnce());
     expect(sessionStorage.getItem("octop:chunk-reload")).toBe("1");
   });
 
-  it("does not loop on a second consecutive chunk error", () => {
+  it("does not loop on a second consecutive chunk error", async () => {
     const err = new Error("Failed to fetch dynamically imported module: /a.js");
     expect(tryReloadOnStaleChunk(err)).toBe(true);
+    await vi.waitFor(() => expect(reload).toHaveBeenCalledOnce());
     reload.mockClear();
     expect(tryReloadOnStaleChunk(err)).toBe(false);
     expect(reload).not.toHaveBeenCalled();
@@ -63,6 +72,42 @@ describe("tryReloadOnStaleChunk", () => {
   it("ignores non-chunk errors", () => {
     expect(tryReloadOnStaleChunk(new Error("boom"))).toBe(false);
     expect(reload).not.toHaveBeenCalled();
+  });
+});
+
+describe("bustServiceWorkerAndReload", () => {
+  it("unregisters workers and drops caches before reloading", async () => {
+    const reload = stubReload();
+    const unregister = vi.fn().mockResolvedValue(true);
+    Object.defineProperty(navigator, "serviceWorker", {
+      configurable: true,
+      value: {
+        getRegistrations: vi.fn().mockResolvedValue([{ unregister }]),
+      },
+    });
+    const cachesDelete = vi.fn().mockResolvedValue(true);
+    Object.defineProperty(window, "caches", {
+      configurable: true,
+      value: {
+        keys: vi.fn().mockResolvedValue(["workbox-precache"]),
+        delete: cachesDelete,
+      },
+    });
+
+    await bustServiceWorkerAndReload();
+
+    expect(unregister).toHaveBeenCalledOnce();
+    expect(cachesDelete).toHaveBeenCalledWith("workbox-precache");
+    expect(reload).toHaveBeenCalledOnce();
+  });
+});
+
+describe("index.html boot recover", () => {
+  it("embeds a classic script that shares the chunk-reload flag", () => {
+    const html = readFileSync(resolve(__dirname, "../../index.html"), "utf8");
+    expect(html).toContain('var KEY = "octop:chunk-reload"');
+    expect(html).toContain("serviceWorker");
+    expect(html).not.toMatch(/<script type="module">[\s\S]*octop:chunk-reload/);
   });
 });
 
@@ -99,13 +144,13 @@ describe("navigation-aborted chunk errors", () => {
     expect(reload).not.toHaveBeenCalled();
   });
 
-  it("recovers again when the page is restored from bfcache", () => {
+  it("recovers again when the page is restored from bfcache", async () => {
     mod.installChunkLoadRecovery();
     window.dispatchEvent(new Event("pagehide"));
     window.dispatchEvent(new Event("pageshow"));
 
     const err = new Error("Failed to fetch dynamically imported module: /a.js");
     expect(mod.tryReloadOnStaleChunk(err)).toBe(true);
-    expect(reload).toHaveBeenCalledOnce();
+    await vi.waitFor(() => expect(reload).toHaveBeenCalledOnce());
   });
 });

--- a/dashboard/src/utils/reloadOnStaleChunk.ts
+++ b/dashboard/src/utils/reloadOnStaleChunk.ts
@@ -31,6 +31,23 @@ export function isChunkLoadError(error: unknown): boolean {
   return CHUNK_ERROR_RE.test(text);
 }
 
+/** Drop SW + Cache Storage so the next load is not served a stale shell. */
+export async function bustServiceWorkerAndReload(): Promise<void> {
+  try {
+    if (typeof navigator !== "undefined" && "serviceWorker" in navigator) {
+      const regs = await navigator.serviceWorker.getRegistrations();
+      await Promise.all(regs.map((r) => r.unregister()));
+    }
+    if (typeof caches !== "undefined") {
+      const keys = await caches.keys();
+      await Promise.all(keys.map((k) => caches.delete(k)));
+    }
+  } catch {
+    // Still reload — a soft refresh is better than staying on a blank page.
+  }
+  window.location.reload();
+}
+
 /** @returns true when a reload was triggered (caller should stop further handling). */
 export function tryReloadOnStaleChunk(error: unknown): boolean {
   if (typeof window === "undefined") return false;
@@ -48,7 +65,7 @@ export function tryReloadOnStaleChunk(error: unknown): boolean {
   }
 
   console.warn("[Octop] Stale chunk detected; reloading once.", error);
-  window.location.reload();
+  void bustServiceWorkerAndReload();
   return true;
 }
 
@@ -85,12 +102,22 @@ export function installChunkLoadRecovery(): void {
       const target = event.target;
       if (
         target instanceof HTMLScriptElement &&
-        typeof target.src === "string" &&
         target.src.includes("/assets/")
       ) {
         tryReloadOnStaleChunk(
           new Error(
             `Failed to fetch dynamically imported module: ${target.src}`,
+          ),
+        );
+        return;
+      }
+      if (
+        target instanceof HTMLLinkElement &&
+        target.href.includes("/assets/")
+      ) {
+        tryReloadOnStaleChunk(
+          new Error(
+            `Failed to fetch dynamically imported module: ${target.href}`,
           ),
         );
       }

--- a/dashboard/vite.config.ts
+++ b/dashboard/vite.config.ts
@@ -191,37 +191,48 @@ export default defineConfig(({ mode }) => {
           "apple-touch-icon.png",
         ],
         workbox: {
-          // Precache the SPA shell and critical vendor chunks only.
-          // Lazy route chunks are cached at runtime via NetworkFirst below.
+          // Precache hashed entry + vendor chunks. Do NOT precache index.html:
+          // Cache-First on the shell pins a stale HTML that points at deleted
+          // hashes after deploy (white screen until a hard refresh).
           globPatterns: [
-            "index.html",
             "assets/index.*.js",
-            "assets/vendor-react.*.js",
-            "assets/vendor-antd.*.js",
+            "assets/vendor-*.js",
             "assets/*.{css,woff2}",
           ],
-          // SPA fallback: navigate requests that miss the precache get index.html
-          // so React Router can handle the route client-side. This is the correct
-          // pattern for SPAs — do NOT use offline.html here or every route that
-          // isn't in the precache will show the offline page instead of the app.
-          navigateFallback: "/index.html",
-          // Keep API, SSE and WebSocket requests completely outside SW control.
-          navigateFallbackDenylist: [/^\/api/, /^\/ws/],
+          // FastAPI already serves the SPA fallback. A Workbox NavigationRoute
+          // would Cache-First the old shell; use NetworkFirst below instead.
+          navigateFallback: null,
           // Take control on first activation so Chrome can fire beforeinstallprompt.
           clientsClaim: true,
           // Do not activate updated workers until the user confirms (SKIP_WAITING).
           skipWaiting: false,
           runtimeCaching: [
             {
-              // JS/CSS chunks have no content-hash in their names (fixed names
-              // like assets/index.js). Use NetworkFirst so a new deployment is
-              // picked up immediately; fall back to cache only when offline.
-              urlPattern: /\/assets\/.*\.(js|css)$/,
+              // Always revalidate the HTML shell so a new deploy is picked up
+              // without a hard refresh. Last good copy is kept for offline.
+              urlPattern: ({ request }) => request.mode === "navigate",
               handler: "NetworkFirst",
               options: {
+                cacheName: "html-shell",
+                networkTimeoutSeconds: 3,
+                expiration: {
+                  maxEntries: 8,
+                  maxAgeSeconds: 24 * 60 * 60,
+                },
+              },
+            },
+            {
+              // Vite emits content-hashed assets (assets/name.[hash].js).
+              // CacheFirst is correct: a new deploy uses new URLs.
+              // NetworkFirst would prefer a post-deploy 404 over the cache.
+              urlPattern: /\/assets\/.*\.(js|css)$/,
+              handler: "CacheFirst",
+              options: {
                 cacheName: "static-chunks",
-                networkTimeoutSeconds: 5,
-                expiration: { maxAgeSeconds: 30 * 24 * 60 * 60 },
+                expiration: {
+                  maxEntries: 200,
+                  maxAgeSeconds: 30 * 24 * 60 * 60,
+                },
               },
             },
             {

--- a/src/octop/api/app.py
+++ b/src/octop/api/app.py
@@ -30,6 +30,28 @@ class _RouterMount:
     tags: Sequence[str]
 
 
+_NO_CACHE_DASHBOARD_NAMES = frozenset({"sw.js", "manifest.json", "index.html"})
+
+
+def dashboard_cache_control(full_path: str) -> str | None:
+    """Cache-Control for a dashboard SPA path, or ``None`` to leave unset."""
+    name = Path(full_path).name.lower() if full_path else "index.html"
+    if not full_path or name in _NO_CACHE_DASHBOARD_NAMES:
+        return "no-cache"
+    # Vite emits content-hashed files under assets/ — safe to pin forever.
+    if full_path.startswith("assets/"):
+        return "public, max-age=31536000, immutable"
+    return None
+
+
+def _dashboard_response(path: Path, full_path: str) -> FileResponse:
+    response = FileResponse(path)
+    cache_control = dashboard_cache_control(full_path)
+    if cache_control is not None:
+        response.headers["Cache-Control"] = cache_control
+    return response
+
+
 def _mount_routers(app: FastAPI, mounts: Sequence[_RouterMount]) -> None:
     for spec in mounts:
         app.include_router(spec.router, prefix=spec.prefix, tags=list(spec.tags))
@@ -224,24 +246,14 @@ def build_app(server: OctopServer) -> FastAPI:
                 if full_path.startswith(("api/", "ws/")):
                     raise HTTPException(status_code=404, detail="Not Found")
 
-                # PWA shell files must never be cached, otherwise browsers may
-                # pin the old service worker or stale manifest and break updates.
-                no_cache_names = {"sw.js", "manifest.json", "index.html"}
-
                 if full_path:
                     candidate = (dashboard_dir / full_path).resolve()
                     try:
                         candidate.relative_to(dashboard_dir.resolve())
                     except ValueError:
-                        return FileResponse(index_file)
+                        return _dashboard_response(index_file, "")
                     if candidate.is_file():
-                        response = FileResponse(candidate)
-                        if Path(full_path).name.lower() in no_cache_names:
-                            response.headers["Cache-Control"] = "no-cache"
-                        return response
-                response = FileResponse(index_file)
-                if "index.html" in no_cache_names:
-                    response.headers["Cache-Control"] = "no-cache"
-                return response
+                        return _dashboard_response(candidate, full_path)
+                return _dashboard_response(index_file, "")
 
     return app

--- a/tests/integration/test_dashboard_serve.py
+++ b/tests/integration/test_dashboard_serve.py
@@ -9,6 +9,8 @@ from fastapi.testclient import TestClient
 from octop.api.app import build_app
 from tests.support.app import octop_client
 
+_DASHBOARD = Path(__file__).resolve().parents[2] / "src" / "octop" / "dashboard"
+
 
 async def test_root_serves_dashboard_index(tmp_octop_home: Path) -> None:
     async with octop_client(tmp_octop_home) as (_client, srv):
@@ -18,3 +20,27 @@ async def test_root_serves_dashboard_index(tmp_octop_home: Path) -> None:
             assert r.status_code in (200, 404)
             r2 = c.get("/api/health")
             assert r2.status_code == 200
+
+
+async def test_dashboard_shell_is_not_cached(tmp_octop_home: Path) -> None:
+    async with octop_client(tmp_octop_home) as (_client, srv):
+        app = build_app(srv)
+        with TestClient(app) as c:
+            for path in ("/", "/index.html", "/sw.js", "/chat"):
+                r = c.get(path)
+                if r.status_code != 200:
+                    continue
+                assert "no-cache" in r.headers.get("cache-control", ""), path
+
+
+async def test_hashed_dashboard_assets_are_immutable(tmp_octop_home: Path) -> None:
+    asset_dir = _DASHBOARD / "assets"
+    sample = next(asset_dir.glob("*.js"), None)
+    if sample is None:
+        return
+    async with octop_client(tmp_octop_home) as (_client, srv):
+        app = build_app(srv)
+        with TestClient(app) as c:
+            r = c.get(f"/assets/{sample.name}")
+            assert r.status_code == 200
+            assert r.headers.get("cache-control") == "public, max-age=31536000, immutable"

--- a/tests/unit/api/test_dashboard_cache.py
+++ b/tests/unit/api/test_dashboard_cache.py
@@ -1,0 +1,27 @@
+"""Cache-Control for dashboard SPA shell vs hashed Vite assets."""
+
+from __future__ import annotations
+
+from octop.api.app import dashboard_cache_control
+
+
+def test_shell_files_are_revalidated() -> None:
+    assert dashboard_cache_control("") == "no-cache"
+    assert dashboard_cache_control("index.html") == "no-cache"
+    assert dashboard_cache_control("sw.js") == "no-cache"
+    assert dashboard_cache_control("manifest.json") == "no-cache"
+
+
+def test_hashed_assets_are_immutable() -> None:
+    assert (
+        dashboard_cache_control("assets/index.abc123.js") == "public, max-age=31536000, immutable"
+    )
+    assert (
+        dashboard_cache_control("assets/vendor-utils.Xyz.css")
+        == "public, max-age=31536000, immutable"
+    )
+
+
+def test_other_static_files_leave_cache_unset() -> None:
+    assert dashboard_cache_control("logo.svg") is None
+    assert dashboard_cache_control("offline.html") is None


### PR DESCRIPTION
## Summary
- 将 [#236](https://github.com/TencentCloud/Octop/pull/236) 的白屏修复合入 `develop`（原 PR 只进了 `release/0.9.21`，未进入 `main` / `develop`）。
- Service Worker 不再 Cache-First 钉死 `index.html`；导航改为 NetworkFirst，hashed `/assets` 改为 CacheFirst，启动必需的 `vendor-*` 打进 precache。
- `index.html` 内联恢复脚本：入口 JS / modulepreload 404 时注销 SW、清空 Cache Storage 后软刷新一次。
- CHANGELOG 记在 `[Unreleased]`（0.9.21 已发，不含此修复）。

## Test plan
- [x] 本地 pre-commit（`make all` + dashboard build）通过
- [x] 与 #236 相同的 vitest / pytest 覆盖
- [ ] CI 绿后合入 develop


Made with [Cursor](https://cursor.com)