### PR TITLE
fix: add audio mime types to media/preview allowlist (#245)

### DIFF
--- a/src/octop/infra/gateway/media/backend_files.py
+++ b/src/octop/infra/gateway/media/backend_files.py
@@ -138,6 +138,9 @@ _PREVIEW_IMAGE = frozenset(
     {"image/png", "image/jpeg", "image/jpg", "image/gif", "image/webp", "image/svg+xml"}
 )
 _PREVIEW_VIDEO = frozenset({"video/mp4", "video/webm", "video/quicktime", "video/ogg"})
+_PREVIEW_AUDIO = frozenset(
+    {"audio/mpeg", "audio/wav", "audio/webm", "audio/ogg", "audio/flac", "audio/aac", "audio/x-wav"}
+)
 
 
 def file_url_to_abs_path(file_url: str) -> str:
@@ -285,7 +288,7 @@ def _guess_mime(path: str, hint: str = "") -> str:
 
 def is_previewable_mime(mime: str) -> bool:
     base = mime.split(";", 1)[0].strip().lower()
-    return base in _PREVIEW_IMAGE or base in _PREVIEW_VIDEO
+    return base in _PREVIEW_IMAGE or base in _PREVIEW_VIDEO or base in _PREVIEW_AUDIO
 
 
 def _abs_path_allowed(abs_path: str, *, workspace: Path) -> bool:


### PR DESCRIPTION
## Summary
为 `/api/agents/{agent_id}/media/preview` 端点添加音频 MIME 类型支持，这样通过 `send_file_to_user` 发送的音频文件（MP3/WAV 等）就可以内嵌预览，而不是显示“文件可能已被删除”。
<img width="1920" height="833" alt="634680204-0c143055-cbde-4917-bfae-979860f6a571" src="https://github.com/user-attachments/assets/55ccbe42-e135-481e-b544-0320e4ed7d88" />
改后：
<img width="869" height="526" alt="image" src="https://github.com/user-attachments/assets/30a1fee5-05b3-451f-b1ad-981483e88250" />
<img width="766" height="553" alt="image" src="https://github.com/user-attachments/assets/071396dd-b2b9-406b-8d06-602bd9350a4d" />

<!-- What does this PR change and why? -->
- 添加新的 `_PREVIEW_AUDIO` 常量，包含常见音频类型：`audio/mpeg`、`audio/wav`、`audio/webm`、`audio/ogg`、`audio/flac`、`audio/aac`、`audio/x-wav`
- 更新 `is_previewable_mime` 同时检查 `_PREVIEW_AUDIO`
## Target branch

- [x] Base is **`develop`** (feature / fix — default)
- [ ] Base is **`main`** (`release/*` or `hotfix/*` only)

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / chore
- [ ] Release / hotfix

## Test plan

<!-- How did you verify this? Include commands run (e.g. `make all`). -->
手动验证：
- `audio/mpeg`（MP3）返回 200，完整文件，`Content-Type: audio/mpeg`，`Content-Disposition: inline`
- 仪表盘预览窗口现在可以正常播放音频了（不再显示“文件可能已被删除”）
- [x] `make all` passes locally
- [ ] Added/updated tests

## Checklist

- [ ] Updated `CHANGELOG.md` (if user-facing)
- [ ] README / docs updated (if needed)
