### PR TITLE
feat: add conversational skill manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@
 
 ## [Unreleased]
 
+### 新增
+
+- Octop-owned built-in `skill-manager` for conversational Skill lifecycle
+  management from uploaded files, archives, Git/GitHub or web URLs, and
+  SkillHub. It is seeded into every agent instance without modifying
+  harness-agent and installs user Skills only under that agent's `skills/`.
+
 ## [0.9.22] - 2026-08-11
 
 ### 新增

--- a/src/octop/infra/agents/builtin_skills/__init__.py
+++ b/src/octop/infra/agents/builtin_skills/__init__.py
@@ -1,0 +1,60 @@
+"""Octop-owned built-in Skills seeded into every agent workspace."""
+
+from __future__ import annotations
+
+from importlib import resources
+from importlib.resources.abc import Traversable
+from typing import Any
+
+OCTOP_BUILTIN_SKILLS_ROOT = "_builtin_skills"
+RETIRED_BUILTIN_SKILLS = ("install-skill",)
+_WORKSPACE_TOKEN = b"{{OCTOP_WORKSPACE}}"
+_PACKAGE = "octop.infra.agents.builtin_skills"
+
+
+def _collect_files(source: Traversable, prefix: str, out: list[tuple[str, bytes]]) -> None:
+    for entry in source.iterdir():
+        if entry.name.startswith((".", "__")):
+            continue
+        path = f"{prefix}/{entry.name}"
+        if entry.is_dir():
+            _collect_files(entry, path, out)
+        else:
+            out.append((path, entry.read_bytes()))
+
+
+async def sync_octop_builtin_skills(workspace: Any) -> list[str]:
+    """Overwrite Octop-owned built-ins and remove superseded runtime copies."""
+    # DeepAgents scans both roots on the first turn. Keep the writable root
+    # present even before the user installs their first Skill so that scan is
+    # clean on fresh expert instances.
+    await workspace.amkdir("skills")
+
+    package_root = resources.files(_PACKAGE)
+    uploads: list[tuple[str, bytes]] = []
+    skill_names: list[str] = []
+    for entry in package_root.iterdir():
+        if entry.name.startswith((".", "__")) or not entry.is_dir():
+            continue
+        if not entry.joinpath("SKILL.md").is_file():
+            continue
+        skill_names.append(entry.name)
+        _collect_files(entry, f"{OCTOP_BUILTIN_SKILLS_ROOT}/{entry.name}", uploads)
+
+    # Render the exact backend-visible workspace path into the instructions.
+    # This prevents an agent from confusing Octop's per-expert workspace with
+    # a legacy ~/.harness-agent/workspace directory discovered through HOME.
+    workspace_path = workspace.resolve_path(".").encode("utf-8")
+    uploads = [(path, data.replace(_WORKSPACE_TOKEN, workspace_path)) for path, data in uploads]
+
+    if uploads:
+        await workspace.aupload_many(uploads)
+
+    for name in RETIRED_BUILTIN_SKILLS:
+        path = f"{OCTOP_BUILTIN_SKILLS_ROOT}/{name}"
+        if await workspace.aexists(path):
+            await workspace.adelete(path)
+    return sorted(skill_names)
+
+
+__all__ = ["OCTOP_BUILTIN_SKILLS_ROOT", "sync_octop_builtin_skills"]

--- a/src/octop/infra/agents/builtin_skills/skill-manager/SKILL.md
+++ b/src/octop/infra/agents/builtin_skills/skill-manager/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: skill-manager
+description: 必须用于通过对话管理当前专家实例的 Skill，包括查找、检查、安装、导入、更新、编辑、列出、恢复或删除。支持 skillhub.cn/skills/... 页面 URL、SkillHub CLI、本地及上传文件、SKILL.md、ZIP/TAR、Git/GitHub 和普通下载 URL；也用于把 PDF、Markdown、文档、代码、图片等任意资料整理成新 Skill。Must use for conversational Skill management from files, URLs, Git repositories, archives, or SkillHub.
+---
+
+# Skill Manager
+
+只管理当前实例的 `{{OCTOP_WORKSPACE}}/skills/`。当前实例工作区固定为 `{{OCTOP_WORKSPACE}}`；上传文件通常位于其中的 `inbound/`。不要用 `pwd`、`$HOME`、`~/.harness-agent/workspace`、记忆文件或搜索结果重新猜测工作区。不要改其他实例、全局 Skill 目录或 `_builtin_skills/`。
+
+## 操作入口
+
+使用内置脚本完成检查、下载、安全解包、安装、列出和删除：
+
+```bash
+python "{{OCTOP_WORKSPACE}}/_builtin_skills/skill-manager/scripts/manage_skills.py" <command>
+```
+
+```bash
+# 列出已安装技能
+... list
+
+# 检查来源，不写入 skills/
+... inspect "<file-directory-url-or-skillhub:slug>"
+
+# 安装；仓库或压缩包内的多个 Skill 可一次安装
+... install "<source>" [--subpath "path/in/repo"] [--name "slug"]
+
+# 仅在用户明确同意替换后覆盖
+... install "<source>" --force
+
+# SkillHub 搜索；结果可用 skillhub:<slug> 检查或安装
+... skillhub-search "<query>" --limit 10
+
+# 仅在用户明确同意删除后执行；实际移动到 skills/.trash/
+... remove "<slug>" --yes
+
+# 从回收站恢复
+... restore "<trash-name>"
+```
+
+## 来源处理
+
+1. **现成 Skill、目录或 ZIP/TAR**：先 `inspect`；检查通过且用户已要求安装时执行 `install`。
+2. **Git/GitHub URL**：可直接处理仓库、GitHub `tree` 子目录和指向 `SKILL.md` 的 `blob` URL。复杂仓库使用 `git+<url>` 和 `--subpath`。
+3. **SkillHub 页面 URL**：`https://skillhub.cn/skills/<namespace>/<slug>` 可直接传给 `inspect` 或 `install`；脚本会解析 namespace 和 slug。不要自行安装/升级 CLI，不要直接运行 `skillhub install`。
+4. **普通 HTTP(S) URL**：脚本处理直接文件和压缩包。若 URL 是其他介绍网页，先用现有网页工具读取并找到公开仓库、下载地址或 `SKILL.md`，再交给脚本。不得绕过登录、付费墙或访问控制。
+5. **SkillHub 搜索**：用户只描述能力时，先搜索并给出 1–3 个候选的 slug、名称、用途和来源，让用户选择；用户已点名具体 Skill 时，可直接检查并安装。
+6. **任意非 Skill 文件**：普通资料不会因复制而自动成为 Skill。先读取和理解材料，再使用内置 `skill-creator` 工作流，将可复用知识、步骤和必要资源整理为合法 Skill，写入 `{{OCTOP_WORKSPACE}}/skills/<slug>/`，然后执行 `inspect` 校验。
+
+## 变更规则
+
+- 新安装请求本身即表示同意新增；目标已存在时停止并说明冲突，只有获得明确同意才使用 `--force`。
+- 编辑现有 Skill 前先读取其 `SKILL.md` 和相关资源，只改该 Skill 目录；修改后重新 `inspect`。
+- 删除前点名目标并取得明确确认。使用 `remove --yes`，不要直接 `rm -rf`。需要恢复时使用 `restore`。
+- 安装后报告 slug 和最终路径。新安装、更新或删除的 Skill 通常从下一次新会话开始完整生效。
+
+## 安全边界
+
+- 脚本限制下载及解包体积、文件数，拒绝路径穿越和符号链接，并通过暂存目录安装。
+- 不执行、导入或 source 下载包中的代码。安装表示部署 Skill 内容，不代表第三方代码已通过安全审计。
+- 不在输出中回显 URL 凭据；私有来源只使用环境中已有的 Git 或 SkillHub 凭据。
+- 若当前实例没有 Shell 执行能力，仍可用文件工具处理简单文本 Skill，但必须说明 URL 下载、安全解包和 SkillHub CLI 无法完成，不能假装成功。

--- a/src/octop/infra/agents/builtin_skills/skill-manager/scripts/manage_skills.py
+++ b/src/octop/infra/agents/builtin_skills/skill-manager/scripts/manage_skills.py
@@ -204,6 +204,14 @@ def _run(command: list[str], *, timeout: int = 120) -> subprocess.CompletedProce
     return result
 
 
+def _command(name: str, *args: str) -> list[str]:
+    """Resolve a CLI entry point, including Windows ``.cmd`` shims."""
+    executable = shutil.which(name)
+    if executable is None:
+        raise SkillManagerError(f"required command is not installed: {name}")
+    return [executable, *args]
+
+
 def _github_source(source: str) -> tuple[str, str, str] | None:
     parsed = urlparse(source)
     if parsed.hostname not in {"github.com", "www.github.com"}:
@@ -291,7 +299,7 @@ def _materialize(source: str, target: Path) -> Path:
         slug, namespace = skillhub_source
         installed = target / "skillhub"
         installed.mkdir()
-        command = ["skillhub", "--skip-self-upgrade", "install", slug]
+        command = _command("skillhub", "--skip-self-upgrade", "install", slug)
         if namespace:
             command.extend(["--namespace", namespace])
         command.extend(["--dir", str(installed), "--json"])
@@ -564,7 +572,7 @@ def _install_source(
 
 def _skillhub_search(query: str, limit: int) -> None:
     result = _run(
-        [
+        _command(
             "skillhub",
             "--skip-self-upgrade",
             "search",
@@ -572,7 +580,7 @@ def _skillhub_search(query: str, limit: int) -> None:
             "--search-limit",
             str(max(1, min(limit, 100))),
             query,
-        ],
+        ),
         timeout=30,
     )
     try:

--- a/src/octop/infra/agents/builtin_skills/skill-manager/scripts/manage_skills.py
+++ b/src/octop/infra/agents/builtin_skills/skill-manager/scripts/manage_skills.py
@@ -1,0 +1,652 @@
+#!/usr/bin/env python3
+"""Safely inspect, install, list, remove, and restore workspace Skills."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import stat
+import subprocess
+import sys
+import tarfile
+import tempfile
+import urllib.request
+import zipfile
+from pathlib import Path, PurePosixPath
+from typing import Any
+from urllib.parse import unquote, urlparse
+
+import yaml
+
+MAX_FILES = 2_000
+MAX_BYTES = 64 * 1024 * 1024
+MAX_DOWNLOAD_BYTES = 256 * 1024 * 1024
+RESERVED_SKILL_SLUGS = frozenset({"skill-manager"})
+_SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
+_NAMESPACE_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$")
+
+
+class SkillManagerError(RuntimeError):
+    """A safe, user-facing Skill management failure."""
+
+
+def _emit(payload: Any) -> None:
+    print(json.dumps(payload, ensure_ascii=False, indent=2))
+
+
+def _redact_urls(value: str) -> str:
+    return re.sub(r"(?i)\b(?:https?|ssh|git)://[^\s'\"]+", "<redacted-url>", value)
+
+
+def _slug(value: str) -> str:
+    normalized = re.sub(r"[^a-z0-9_-]+", "-", value.strip().lower()).strip("-_")
+    if not _SLUG_RE.fullmatch(normalized):
+        raise SkillManagerError(f"invalid skill name: {value!r}")
+    return normalized
+
+
+def _workspace(value: str) -> Path:
+    path = Path(value).expanduser()
+    if not path.is_absolute():
+        raise SkillManagerError("--workspace must be an absolute path")
+    path = path.resolve()
+    if path == Path(path.anchor):
+        raise SkillManagerError("refusing to use a filesystem root as the workspace")
+    if not path.is_dir():
+        raise SkillManagerError(f"workspace does not exist: {path}")
+    return path
+
+
+def _default_workspace() -> Path:
+    """Infer the workspace only from this deployed built-in's location."""
+    script = Path(__file__).resolve()
+    try:
+        workspace = script.parents[3]
+    except IndexError as exc:  # pragma: no cover - installed layout always has these parents
+        raise SkillManagerError("cannot infer workspace from the manager script path") from exc
+    if script.parents[1].name != "skill-manager" or script.parents[2].name != "_builtin_skills":
+        raise SkillManagerError("--workspace is required outside a deployed expert workspace")
+    return _workspace(str(workspace))
+
+
+def _skillhub_source(source: str) -> tuple[str, str] | None:
+    """Return ``(slug, namespace)`` for SkillHub shorthand or page URLs."""
+    if source.startswith("skillhub:"):
+        value = source.partition(":")[2].strip().strip("/")
+        parts = value.split("/")
+        if len(parts) == 1:
+            return _slug(parts[0]), ""
+        if len(parts) == 2:
+            namespace, slug = parts
+            if not _NAMESPACE_RE.fullmatch(namespace):
+                raise SkillManagerError(f"invalid SkillHub namespace: {namespace!r}")
+            return _slug(slug), namespace
+        raise SkillManagerError(
+            "SkillHub source must be skillhub:<slug> or skillhub:<namespace>/<slug>"
+        )
+
+    parsed = urlparse(source)
+    if parsed.hostname not in {"skillhub.cn", "www.skillhub.cn"}:
+        return None
+    parts = [unquote(part) for part in parsed.path.strip("/").split("/") if part]
+    if len(parts) != 3 or parts[0] != "skills":
+        raise SkillManagerError(
+            "unsupported SkillHub URL; expected https://skillhub.cn/skills/<namespace>/<slug>"
+        )
+    namespace, slug = parts[1:]
+    if not _NAMESPACE_RE.fullmatch(namespace):
+        raise SkillManagerError(f"invalid SkillHub namespace: {namespace!r}")
+    return _slug(slug), namespace
+
+
+def _safe_relative(name: str) -> Path:
+    if not name or "\\" in name or "\x00" in name:
+        raise SkillManagerError(f"unsafe archive path: {name!r}")
+    path = PurePosixPath(name)
+    if path.is_absolute() or ".." in path.parts:
+        raise SkillManagerError(f"unsafe archive path: {name!r}")
+    parts = [part for part in path.parts if part not in {"", "."}]
+    if not parts:
+        raise SkillManagerError(f"invalid archive path: {name!r}")
+    return Path(*parts)
+
+
+def _safe_target(root: Path, name: str) -> Path:
+    target = (root / _safe_relative(name)).resolve()
+    try:
+        target.relative_to(root.resolve())
+    except ValueError as exc:
+        raise SkillManagerError(f"archive path escapes destination: {name!r}") from exc
+    return target
+
+
+def _extract_zip(source: Path, target: Path) -> None:
+    with zipfile.ZipFile(source) as archive:
+        infos = archive.infolist()
+        files = [info for info in infos if not info.is_dir()]
+        if len(files) > MAX_FILES:
+            raise SkillManagerError("archive contains too many files")
+        if sum(info.file_size for info in files) > MAX_BYTES:
+            raise SkillManagerError("archive expands beyond 64 MB")
+        for info in infos:
+            if stat.S_ISLNK(info.external_attr >> 16):
+                raise SkillManagerError(f"archive contains a symlink: {info.filename}")
+            destination = _safe_target(target, info.filename)
+            if info.is_dir():
+                destination.mkdir(parents=True, exist_ok=True)
+                continue
+            if info.compress_size and info.file_size / info.compress_size > 1_000:
+                raise SkillManagerError(f"suspicious compression ratio: {info.filename}")
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            with archive.open(info) as src, destination.open("wb") as dst:
+                shutil.copyfileobj(src, dst)
+
+
+def _extract_tar(source: Path, target: Path) -> None:
+    with tarfile.open(source) as archive:
+        members = archive.getmembers()
+        files = [member for member in members if member.isfile()]
+        if len(files) > MAX_FILES:
+            raise SkillManagerError("archive contains too many files")
+        if sum(member.size for member in files) > MAX_BYTES:
+            raise SkillManagerError("archive expands beyond 64 MB")
+        for member in members:
+            destination = _safe_target(target, member.name)
+            if member.isdir():
+                destination.mkdir(parents=True, exist_ok=True)
+                continue
+            if not member.isfile():
+                raise SkillManagerError(f"unsupported archive entry: {member.name}")
+            stream = archive.extractfile(member)
+            if stream is None:
+                raise SkillManagerError(f"cannot read archive entry: {member.name}")
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            with stream, destination.open("wb") as dst:
+                shutil.copyfileobj(stream, dst)
+
+
+def _download(url: str, target: Path) -> None:
+    request = urllib.request.Request(url, headers={"User-Agent": "octop-skill-manager/1.0"})
+    total = 0
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response, target.open("wb") as output:
+            while chunk := response.read(1024 * 1024):
+                total += len(chunk)
+                if total > MAX_DOWNLOAD_BYTES:
+                    raise SkillManagerError("download exceeds 256 MB")
+                output.write(chunk)
+    except SkillManagerError:
+        raise
+    except OSError as exc:
+        host = urlparse(url).hostname or "remote host"
+        raise SkillManagerError(f"download failed from {host}") from exc
+
+
+def _run(command: list[str], *, timeout: int = 120) -> subprocess.CompletedProcess[str]:
+    try:
+        result = subprocess.run(
+            command,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except FileNotFoundError as exc:
+        raise SkillManagerError(f"required command is not installed: {command[0]}") from exc
+    except subprocess.TimeoutExpired as exc:
+        raise SkillManagerError(f"command timed out: {command[0]}") from exc
+    if result.returncode:
+        detail = result.stderr.strip() or result.stdout.strip() or f"exit {result.returncode}"
+        raise SkillManagerError(_redact_urls(detail))
+    return result
+
+
+def _github_source(source: str) -> tuple[str, str, str] | None:
+    parsed = urlparse(source)
+    if parsed.hostname not in {"github.com", "www.github.com"}:
+        return None
+    parts = [unquote(part) for part in parsed.path.strip("/").split("/") if part]
+    if len(parts) < 2:
+        return None
+    owner, repo = parts[0], parts[1].removesuffix(".git")
+    ref = ""
+    subpath = ""
+    if len(parts) >= 4 and parts[2] in {"tree", "blob"}:
+        ref = parts[3]
+        subpath = "/".join(parts[4:])
+        if parts[2] == "blob" and subpath.endswith("/SKILL.md"):
+            subpath = subpath[: -len("/SKILL.md")]
+        elif parts[2] == "blob" and subpath == "SKILL.md":
+            subpath = ""
+    return f"https://github.com/{owner}/{repo}.git", ref, subpath
+
+
+def _clone(source: str, target: Path, *, ref: str = "") -> None:
+    command = ["git", "clone", "--depth", "1"]
+    if ref:
+        command.extend(["--branch", ref])
+    command.extend([source, str(target)])
+    _run(command)
+
+
+def _manifest(text: str) -> dict[str, Any]:
+    match = re.match(r"^---\s*\n(.*?)\n---(?:\s*\n|$)", text, re.DOTALL)
+    if match is None:
+        raise SkillManagerError("SKILL.md is missing YAML frontmatter")
+    try:
+        metadata = yaml.safe_load(match.group(1)) or {}
+    except yaml.YAMLError as exc:
+        raise SkillManagerError(f"SKILL.md frontmatter is invalid: {exc}") from exc
+    if not isinstance(metadata, dict):
+        raise SkillManagerError("SKILL.md frontmatter must be a mapping")
+    for field in ("name", "description"):
+        if not str(metadata.get(field) or "").strip():
+            raise SkillManagerError(f"SKILL.md frontmatter is missing {field}")
+    return metadata
+
+
+def _materialize_file(source: Path, target: Path) -> Path:
+    if zipfile.is_zipfile(source):
+        unpacked = target / "unpacked"
+        unpacked.mkdir()
+        _extract_zip(source, unpacked)
+        return unpacked
+    if tarfile.is_tarfile(source):
+        unpacked = target / "unpacked"
+        unpacked.mkdir()
+        _extract_tar(source, unpacked)
+        return unpacked
+    try:
+        text = source.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        raise SkillManagerError(
+            "input is not a Skill directory, SKILL.md, ZIP, TAR, or readable text"
+        ) from exc
+    _manifest(text)
+    single = target / "single"
+    single.mkdir()
+    shutil.copy2(source, single / "SKILL.md")
+    return single
+
+
+def _select_subpath(root: Path, subpath: str) -> Path:
+    if not subpath:
+        return root
+    selected = (root / _safe_relative(subpath)).resolve()
+    try:
+        selected.relative_to(root.resolve())
+    except ValueError as exc:
+        raise SkillManagerError(f"subpath escapes source: {subpath!r}") from exc
+    if not selected.exists():
+        raise SkillManagerError(f"subpath does not exist: {subpath}")
+    return selected.parent if selected.is_file() and selected.name == "SKILL.md" else selected
+
+
+def _materialize(source: str, target: Path) -> Path:
+    skillhub_source = _skillhub_source(source)
+    if skillhub_source is not None:
+        slug, namespace = skillhub_source
+        installed = target / "skillhub"
+        installed.mkdir()
+        command = ["skillhub", "--skip-self-upgrade", "install", slug]
+        if namespace:
+            command.extend(["--namespace", namespace])
+        command.extend(["--dir", str(installed), "--json"])
+        _run(command)
+        return installed
+
+    local = Path(source).expanduser()
+    if local.exists():
+        resolved = local.resolve()
+        return resolved if resolved.is_dir() else _materialize_file(resolved, target)
+
+    parsed = urlparse(source.removeprefix("git+"))
+    if parsed.scheme not in {"http", "https", "ssh", "git"}:
+        raise SkillManagerError("source does not exist and is not a supported URL")
+    if parsed.scheme in {"http", "https"} and (parsed.username or parsed.password):
+        raise SkillManagerError("credentials embedded in URLs are not supported")
+
+    github = _github_source(source)
+    if github is not None:
+        repo_url, ref, subpath = github
+        checkout = target / "repo"
+        _clone(repo_url, checkout, ref=ref)
+        return _select_subpath(checkout, subpath)
+
+    if source.startswith("git+") or source.endswith(".git"):
+        checkout = target / "repo"
+        _clone(source.removeprefix("git+"), checkout)
+        return checkout
+
+    downloaded = target / "download"
+    _download(source, downloaded)
+    return _materialize_file(downloaded, target)
+
+
+def _skill_roots(root: Path) -> list[Path]:
+    direct = root / "SKILL.md"
+    manifests = [direct] if direct.is_file() else sorted(root.rglob("SKILL.md"))
+    selected: list[Path] = []
+    for manifest in manifests:
+        relative = manifest.relative_to(root)
+        if any(part.startswith(".") or part == "__MACOSX" for part in relative.parts):
+            continue
+        candidate = manifest.parent.resolve()
+        if any(candidate == parent or candidate.is_relative_to(parent) for parent in selected):
+            continue
+        selected.append(candidate)
+    if not selected:
+        raise SkillManagerError("no SKILL.md was found in the source")
+    return selected
+
+
+def _validate_tree(root: Path) -> dict[str, Any]:
+    if root.is_symlink() or not root.is_dir():
+        raise SkillManagerError(f"skill root is not a regular directory: {root}")
+    manifest_path = root / "SKILL.md"
+    try:
+        metadata = _manifest(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError) as exc:
+        raise SkillManagerError(f"cannot read {manifest_path}") from exc
+    count = 0
+    total = 0
+    for current, dirnames, filenames in os.walk(root, followlinks=False):
+        current_path = Path(current)
+        for dirname in list(dirnames):
+            child = current_path / dirname
+            if child.is_symlink():
+                raise SkillManagerError(f"skill contains a symlink: {child}")
+            if dirname == ".git":
+                dirnames.remove(dirname)
+        for filename in filenames:
+            child = current_path / filename
+            if child.is_symlink() or not child.is_file():
+                raise SkillManagerError(f"skill contains an unsupported file: {child}")
+            count += 1
+            total += child.stat().st_size
+            if count > MAX_FILES:
+                raise SkillManagerError("skill contains too many files")
+            if total > MAX_BYTES:
+                raise SkillManagerError("skill exceeds 64 MB")
+    return {
+        "name": str(metadata["name"]),
+        "description": str(metadata["description"]),
+        "files": count,
+        "bytes": total,
+    }
+
+
+def _discover(source_root: Path, *, subpath: str = "", name: str = "") -> list[dict[str, Any]]:
+    roots = _skill_roots(_select_subpath(source_root, subpath))
+    if name and len(roots) != 1:
+        raise SkillManagerError("--name can only be used when the source contains one skill")
+    found: list[dict[str, Any]] = []
+    slugs: set[str] = set()
+    for root in roots:
+        summary = _validate_tree(root)
+        slug = _slug(name or str(summary["name"]) or root.name)
+        if slug in slugs:
+            raise SkillManagerError(f"duplicate skill name in source: {slug}")
+        slugs.add(slug)
+        found.append({"slug": slug, "root": root, **summary})
+    return found
+
+
+def _copy_skill(source: Path, target: Path) -> None:
+    def ignore(_directory: str, names: list[str]) -> set[str]:
+        return {name for name in names if name == ".git"}
+
+    shutil.copytree(source, target, symlinks=False, ignore=ignore)
+    _validate_tree(target)
+
+
+def _install(workspace: Path, skills: list[dict[str, Any]], *, force: bool) -> list[dict[str, Any]]:
+    skills_dir = workspace / "skills"
+    skills_dir.mkdir(parents=True, exist_ok=True)
+    reserved = [item["slug"] for item in skills if item["slug"] in RESERVED_SKILL_SLUGS]
+    if reserved:
+        raise SkillManagerError(
+            "cannot replace an Octop-owned built-in skill: " + ", ".join(reserved)
+        )
+    conflicts = [item["slug"] for item in skills if (skills_dir / item["slug"]).exists()]
+    if conflicts and not force:
+        raise SkillManagerError(
+            "already installed; ask before using --force: " + ", ".join(conflicts)
+        )
+
+    staging = Path(tempfile.mkdtemp(prefix=".skill-manager-stage-", dir=skills_dir))
+    backup = Path(tempfile.mkdtemp(prefix=".skill-manager-backup-", dir=skills_dir))
+    installed: list[Path] = []
+    moved_backups: list[tuple[Path, Path]] = []
+    try:
+        for item in skills:
+            _copy_skill(item["root"], staging / item["slug"])
+        for item in skills:
+            slug = item["slug"]
+            destination = skills_dir / slug
+            if destination.exists():
+                saved = backup / slug
+                os.replace(destination, saved)
+                moved_backups.append((destination, saved))
+            os.replace(staging / slug, destination)
+            installed.append(destination)
+    except Exception:
+        for destination in reversed(installed):
+            if destination.exists():
+                shutil.rmtree(destination)
+        for destination, saved in reversed(moved_backups):
+            if saved.exists():
+                os.replace(saved, destination)
+        raise
+    finally:
+        shutil.rmtree(staging, ignore_errors=True)
+        shutil.rmtree(backup, ignore_errors=True)
+
+    return [
+        {
+            "slug": item["slug"],
+            "path": str(skills_dir / item["slug"]),
+            "files": item["files"],
+            "bytes": item["bytes"],
+        }
+        for item in skills
+    ]
+
+
+def _list(workspace: Path) -> list[dict[str, Any]]:
+    skills_dir = workspace / "skills"
+    if not skills_dir.is_dir():
+        return []
+    rows: list[dict[str, Any]] = []
+    for entry in sorted(skills_dir.iterdir()):
+        if not entry.is_dir() or entry.name.startswith("."):
+            continue
+        try:
+            summary = _validate_tree(entry)
+        except SkillManagerError as exc:
+            rows.append({"slug": entry.name, "valid": False, "error": str(exc)})
+            continue
+        rows.append({"slug": entry.name, "valid": True, **summary})
+    return rows
+
+
+def _remove(workspace: Path, name: str, *, confirmed: bool) -> dict[str, str]:
+    if not confirmed:
+        raise SkillManagerError("removal requires --yes after explicit user confirmation")
+    slug = _slug(name)
+    skills_dir = workspace / "skills"
+    source = skills_dir / slug
+    if source.is_symlink():
+        raise SkillManagerError(f"refusing to remove a symlinked skill: {slug}")
+    if not source.is_dir():
+        raise SkillManagerError(f"skill is not installed: {slug}")
+    trash = skills_dir / ".trash"
+    trash.mkdir(parents=True, exist_ok=True)
+    destination = trash / slug
+    suffix = 1
+    while destination.exists():
+        destination = trash / f"{slug}-{suffix}"
+        suffix += 1
+    os.replace(source, destination)
+    (destination / ".skill-manager-trash.json").write_text(
+        json.dumps({"slug": slug}),
+        encoding="utf-8",
+    )
+    return {"removed": slug, "trash_name": destination.name, "trash": str(destination)}
+
+
+def _restore(workspace: Path, trash_name: str) -> dict[str, str]:
+    safe_name = _slug(trash_name)
+    skills_dir = workspace / "skills"
+    source = skills_dir / ".trash" / safe_name
+    if source.is_symlink():
+        raise SkillManagerError(f"refusing to restore a symlinked trash entry: {safe_name}")
+    if not source.is_dir():
+        raise SkillManagerError(f"trash entry does not exist: {safe_name}")
+    _validate_tree(source)
+    metadata_path = source / ".skill-manager-trash.json"
+    slug = safe_name
+    if metadata_path.is_file():
+        try:
+            metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+            slug = _slug(str(metadata.get("slug") or safe_name))
+        except (OSError, json.JSONDecodeError, SkillManagerError) as exc:
+            raise SkillManagerError(f"trash metadata is invalid: {safe_name}") from exc
+    destination = skills_dir / slug
+    if destination.exists():
+        raise SkillManagerError(f"cannot restore because skill is installed: {slug}")
+    if metadata_path.exists():
+        metadata_path.unlink()
+    os.replace(source, destination)
+    return {"restored": slug, "path": str(destination)}
+
+
+def _effective_name(source: str, name: str) -> str:
+    if name:
+        return name
+    skillhub_source = _skillhub_source(source)
+    return skillhub_source[0] if skillhub_source is not None else ""
+
+
+def _inspect(source: str, *, subpath: str, name: str) -> list[dict[str, Any]]:
+    with tempfile.TemporaryDirectory(prefix="skill-manager-source-") as tmp:
+        root = _materialize(source, Path(tmp))
+        return [
+            {key: value for key, value in item.items() if key != "root"}
+            for item in _discover(
+                root,
+                subpath=subpath,
+                name=_effective_name(source, name),
+            )
+        ]
+
+
+def _install_source(
+    workspace: Path,
+    source: str,
+    *,
+    subpath: str,
+    name: str,
+    force: bool,
+) -> list[dict[str, Any]]:
+    with tempfile.TemporaryDirectory(prefix="skill-manager-source-") as tmp:
+        root = _materialize(source, Path(tmp))
+        found = _discover(
+            root,
+            subpath=subpath,
+            name=_effective_name(source, name),
+        )
+        return _install(workspace, found, force=force)
+
+
+def _skillhub_search(query: str, limit: int) -> None:
+    result = _run(
+        [
+            "skillhub",
+            "--skip-self-upgrade",
+            "search",
+            "--json",
+            "--search-limit",
+            str(max(1, min(limit, 100))),
+            query,
+        ],
+        timeout=30,
+    )
+    try:
+        _emit(json.loads(result.stdout))
+    except json.JSONDecodeError as exc:
+        raise SkillManagerError("SkillHub returned invalid JSON") from exc
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--workspace",
+        default="",
+        help="absolute current agent workspace (normally inferred from the deployed script path)",
+    )
+    commands = parser.add_subparsers(dest="command", required=True)
+
+    commands.add_parser("list", help="list installed workspace skills")
+
+    for command in ("inspect", "install"):
+        item = commands.add_parser(
+            command,
+            help=f"{command} a file, directory, URL, or skillhub:slug",
+        )
+        item.add_argument("source")
+        item.add_argument("--subpath", default="")
+        item.add_argument("--name", default="")
+        if command == "install":
+            item.add_argument("--force", action="store_true")
+
+    remove = commands.add_parser("remove", help="move an installed skill to skills/.trash")
+    remove.add_argument("name")
+    remove.add_argument("--yes", action="store_true")
+
+    restore = commands.add_parser("restore", help="restore an entry from skills/.trash")
+    restore.add_argument("trash_name")
+
+    search = commands.add_parser("skillhub-search", help="search with the SkillHub CLI")
+    search.add_argument("query")
+    search.add_argument("--limit", type=int, default=10)
+    return parser
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    try:
+        workspace = _workspace(args.workspace) if args.workspace else _default_workspace()
+        if args.command == "list":
+            _emit(_list(workspace))
+        elif args.command == "inspect":
+            _emit(_inspect(args.source, subpath=args.subpath, name=args.name))
+        elif args.command == "install":
+            _emit(
+                _install_source(
+                    workspace,
+                    args.source,
+                    subpath=args.subpath,
+                    name=args.name,
+                    force=args.force,
+                )
+            )
+        elif args.command == "remove":
+            _emit(_remove(workspace, args.name, confirmed=args.yes))
+        elif args.command == "restore":
+            _emit(_restore(workspace, args.trash_name))
+        elif args.command == "skillhub-search":
+            _skillhub_search(args.query, args.limit)
+        else:
+            raise SkillManagerError(f"unknown command: {args.command}")
+    except SkillManagerError as exc:
+        _emit({"error": str(exc)})
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/octop/infra/agents/manager.py
+++ b/src/octop/infra/agents/manager.py
@@ -1580,6 +1580,23 @@ class AgentManager:
             sorted(tool_set)[:8],
         )
         ws = agent.workspace
+        try:
+            from octop.infra.agents.builtin_skills import (  # noqa: PLC0415
+                sync_octop_builtin_skills,
+            )
+
+            synced_skills = await sync_octop_builtin_skills(ws)
+            logger.info(
+                "Agent %s: synced Octop built-in skills=%s",
+                row.agent_id,
+                synced_skills,
+            )
+        except Exception:
+            logger.warning(
+                "Agent %s: failed to sync Octop built-in skills",
+                row.agent_id,
+                exc_info=True,
+            )
         if self._plugin_manager is not None:
             await asyncio.to_thread(self._plugin_manager.sync_skills_to_workspace, ws)
 

--- a/tests/integration/test_skills_api.py
+++ b/tests/integration/test_skills_api.py
@@ -111,6 +111,10 @@ async def test_list_includes_builtin_skills(env: Any) -> None:
     assert ws["enabled"] is True
     assert ws["emoji"] == "🔍"
 
+    manager = next(row for row in builtin if row["name"] == "skill-manager")
+    assert manager["enabled"] is True
+    assert "SkillHub" in manager["description"]
+
 
 async def test_get_builtin_skill_detail(env: Any) -> None:
     c, _srv, auth, aid = env
@@ -140,6 +144,20 @@ async def test_delete_builtin_skill_rejected(env: Any) -> None:
     await _seed_builtin_skill(env)
 
     r = await c.delete(f"/api/agents/{aid}/skills/web-search", headers=auth)
+    assert r.status_code == 404
+
+
+async def test_octop_skill_manager_detail_and_delete_protection(env: Any) -> None:
+    c, _srv, auth, aid = env
+
+    r = await c.get(f"/api/agents/{aid}/skills/skill-manager", headers=auth)
+    assert r.status_code == 200
+    body = r.json()
+    assert body["kind"] == "builtin"
+    assert body["frontmatter"]["name"] == "skill-manager"
+    assert "manage_skills.py" in body["body"]
+
+    r = await c.delete(f"/api/agents/{aid}/skills/skill-manager", headers=auth)
     assert r.status_code == 404
 
 

--- a/tests/unit/agents/test_agent_manager.py
+++ b/tests/unit/agents/test_agent_manager.py
@@ -926,7 +926,9 @@ async def test_update_config_json_still_schedules_reload(
 
 
 @pytest.mark.asyncio
-async def test_reload_agent_does_not_block_event_loop(tmp_path: Path) -> None:
+async def test_reload_agent_does_not_block_event_loop(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Harness create/remove must run off the event loop (MCP init blocks the loop)."""
     import asyncio
     import time
@@ -944,28 +946,42 @@ async def test_reload_agent_does_not_block_event_loop(tmp_path: Path) -> None:
     fake_hm = MagicMock()
     fake_entry = MagicMock()
     fake_entry.agent = MagicMock()
+    fake_hm.shared_factory = object()
+    fake_hm.acreate_agent = AsyncMock(return_value=fake_entry)
+
+    rebuild_started = asyncio.Event()
+    rebuild_finished = asyncio.Event()
+    post_start_finished = asyncio.Event()
 
     async def slow_rebuild(*_args: object, **_kwargs: object) -> MagicMock:
+        rebuild_started.set()
         await asyncio.to_thread(time.sleep, 0.15)
+        rebuild_finished.set()
         return fake_entry
+
+    async def fake_post_start(*_args: object, **_kwargs: object) -> None:
+        post_start_finished.set()
 
     fake_hm.arebuild_agent = AsyncMock(side_effect=slow_rebuild)
     fake_hm.aremove_agent = AsyncMock()
     registry._harness_manager = fake_hm
+    monkeypatch.setattr(registry, "_post_start_agent", fake_post_start)
 
     row = await registry.create(AgentCreateSpec(name="block-test"))
+    post_start_finished.clear()
 
     tick = asyncio.Event()
 
     async def ticker() -> None:
-        await asyncio.sleep(0.05)
+        await rebuild_started.wait()
         tick.set()
 
-    asyncio.create_task(ticker())
+    ticker_task = asyncio.create_task(ticker())
     await registry.update(row.agent_id, name="block-test-v2")
-    await asyncio.wait_for(tick.wait(), timeout=0.2)
-    # Background reload may still be running; wait for it to finish.
-    await asyncio.sleep(0.3)
+    await asyncio.wait_for(tick.wait(), timeout=1.0)
+    assert not rebuild_finished.is_set()
+    await asyncio.wait_for(post_start_finished.wait(), timeout=1.0)
+    await ticker_task
 
 
 def test_build_mcp_configs_registers_gateway_without_transport(manager: AgentManager) -> None:

--- a/tests/unit/agents/test_agent_registry.py
+++ b/tests/unit/agents/test_agent_registry.py
@@ -219,9 +219,14 @@ async def test_create_registers_with_harness(tmp_path: Path) -> None:
     fake_hm = _make_fake_hm()
     registry = _make_registry(services, fake_hm=fake_hm)
 
-    await registry.create(AgentCreateSpec(name="bot"))
+    row = await registry.create(AgentCreateSpec(name="bot"))
 
     fake_hm.acreate_agent.assert_called_once()
+    manager_skill = await registry.get_agent(row.agent_id).workspace.aread_text(
+        "_builtin_skills/skill-manager/SKILL.md"
+    )
+    assert manager_skill is not None
+    assert "name: skill-manager" in manager_skill
 
 
 @pytest.mark.asyncio

--- a/tests/unit/agents/test_octop_builtin_skills.py
+++ b/tests/unit/agents/test_octop_builtin_skills.py
@@ -1,0 +1,219 @@
+"""Tests for Octop-owned built-in Skills and the Skill Manager helper."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import zipfile
+from importlib import resources
+from pathlib import Path
+
+import pytest
+from tests.support.fakes import FakeHarnessAgent
+
+from octop.infra.agents.builtin_skills import sync_octop_builtin_skills
+
+_PACKAGE = "octop.infra.agents.builtin_skills"
+
+
+def _manager_script() -> Path:
+    script = (
+        resources.files(_PACKAGE)
+        .joinpath("skill-manager")
+        .joinpath("scripts")
+        .joinpath("manage_skills.py")
+    )
+    return Path(str(script))
+
+
+def _run_manager(workspace: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(_manager_script()), "--workspace", str(workspace), *args],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_sync_seeds_manager_and_retires_old_installer(tmp_path: Path) -> None:
+    agent = FakeHarnessAgent(workspace_dir=tmp_path, virtual_mode=False)
+    await agent.workspace.awrite_text(
+        "_builtin_skills/install-skill/SKILL.md",
+        "---\nname: install-skill\ndescription: old\n---\n",
+        force=True,
+    )
+
+    synced = await sync_octop_builtin_skills(agent.workspace)
+
+    assert synced == ["skill-manager"]
+    assert await agent.workspace.aexists("skills")
+    assert await agent.workspace.aread_text("_builtin_skills/install-skill/SKILL.md") is None
+    manager = await agent.workspace.aread_text("_builtin_skills/skill-manager/SKILL.md")
+    script = await agent.workspace.aread_text(
+        "_builtin_skills/skill-manager/scripts/manage_skills.py"
+    )
+    assert manager is not None and "name: skill-manager" in manager
+    assert str(tmp_path) in manager
+    assert "{{OCTOP_WORKSPACE}}" not in manager
+    assert script is not None and "def main()" in script
+
+    deployed = tmp_path / "_builtin_skills/skill-manager/scripts/manage_skills.py"
+    inferred = subprocess.run(
+        [sys.executable, str(deployed), "list"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert inferred.returncode == 0, inferred.stderr or inferred.stdout
+    assert json.loads(inferred.stdout) == []
+
+
+def test_manager_script_compiles() -> None:
+    script = _manager_script()
+    assert script.is_file()
+    compile(script.read_text(encoding="utf-8"), "manage_skills.py", "exec")
+
+
+def test_manager_installs_lists_removes_and_restores_zip(tmp_path: Path) -> None:
+    archive = tmp_path / "example.zip"
+    with zipfile.ZipFile(archive, "w") as bundle:
+        bundle.writestr(
+            "example/SKILL.md",
+            "---\nname: example\ndescription: Example test skill.\n---\n\n# Example\n",
+        )
+        bundle.writestr("example/references/note.md", "hello\n")
+
+    inspected = _run_manager(tmp_path, "inspect", str(archive))
+    assert inspected.returncode == 0, inspected.stderr or inspected.stdout
+    assert json.loads(inspected.stdout)[0]["slug"] == "example"
+
+    installed = _run_manager(tmp_path, "install", str(archive))
+    assert installed.returncode == 0, installed.stderr or installed.stdout
+    assert (tmp_path / "skills" / "example" / "references" / "note.md").is_file()
+
+    listed = _run_manager(tmp_path, "list")
+    assert listed.returncode == 0, listed.stderr or listed.stdout
+    assert json.loads(listed.stdout)[0]["valid"] is True
+
+    unconfirmed = _run_manager(tmp_path, "remove", "example")
+    assert unconfirmed.returncode == 1
+    assert (tmp_path / "skills" / "example").is_dir()
+
+    removed = _run_manager(tmp_path, "remove", "example", "--yes")
+    assert removed.returncode == 0, removed.stderr or removed.stdout
+    trash_name = json.loads(removed.stdout)["trash_name"]
+    assert not (tmp_path / "skills" / "example").exists()
+
+    restored = _run_manager(tmp_path, "restore", trash_name)
+    assert restored.returncode == 0, restored.stderr or restored.stdout
+    assert (tmp_path / "skills" / "example" / "SKILL.md").is_file()
+    assert not (tmp_path / "skills" / "example" / ".skill-manager-trash.json").exists()
+
+
+def test_manager_rejects_archive_traversal(tmp_path: Path) -> None:
+    archive = tmp_path / "unsafe.zip"
+    with zipfile.ZipFile(archive, "w") as bundle:
+        bundle.writestr("../SKILL.md", "not safe")
+
+    result = _run_manager(tmp_path, "inspect", str(archive))
+
+    assert result.returncode == 1
+    assert "unsafe archive path" in result.stdout
+    assert not (tmp_path.parent / "SKILL.md").exists()
+
+
+def test_manager_refuses_overwrite_without_force(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    source.mkdir()
+    (source / "SKILL.md").write_text(
+        "---\nname: stable\ndescription: First version.\n---\n\n# Stable\n",
+        encoding="utf-8",
+    )
+    first = _run_manager(tmp_path, "install", str(source))
+    assert first.returncode == 0, first.stderr or first.stdout
+
+    (source / "SKILL.md").write_text(
+        "---\nname: stable\ndescription: Second version.\n---\n\n# Stable\n",
+        encoding="utf-8",
+    )
+    refused = _run_manager(tmp_path, "install", str(source))
+    assert refused.returncode == 1
+    assert "ask before using --force" in refused.stdout
+    assert "First version" in (tmp_path / "skills" / "stable" / "SKILL.md").read_text()
+
+    replaced = _run_manager(tmp_path, "install", str(source), "--force")
+    assert replaced.returncode == 0, replaced.stderr or replaced.stdout
+    assert "Second version" in (tmp_path / "skills" / "stable" / "SKILL.md").read_text()
+
+
+def test_manager_refuses_to_replace_itself(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    source.mkdir()
+    (source / "SKILL.md").write_text(
+        "---\nname: skill-manager\ndescription: Untrusted replacement.\n---\n",
+        encoding="utf-8",
+    )
+
+    result = _run_manager(tmp_path, "install", str(source), "--force")
+
+    assert result.returncode == 1
+    assert "Octop-owned built-in" in result.stdout
+    assert not (tmp_path / "skills" / "skill-manager").exists()
+
+
+def test_manager_installs_namespaced_skillhub_page_url(tmp_path: Path) -> None:
+    fake_bin = tmp_path / "fake-bin"
+    fake_bin.mkdir()
+    log_path = tmp_path / "skillhub-args.json"
+    fake_skillhub = fake_bin / "skillhub"
+    fake_skillhub.write_text(
+        """#!/usr/bin/env python3
+import json
+import os
+import sys
+from pathlib import Path
+
+args = sys.argv[1:]
+Path(os.environ["FAKE_SKILLHUB_LOG"]).write_text(json.dumps(args), encoding="utf-8")
+slug = args[args.index("install") + 1]
+namespace = args[args.index("--namespace") + 1]
+root = Path(args[args.index("--dir") + 1]) / f"@{namespace}" / slug
+root.mkdir(parents=True)
+(root / "SKILL.md").write_text(
+    f"---\\nname: {slug}\\ndescription: Namespaced SkillHub test.\\n---\\n",
+    encoding="utf-8",
+)
+print(json.dumps({"installed": slug}))
+""",
+        encoding="utf-8",
+    )
+    fake_skillhub.chmod(0o755)
+    env = {
+        **os.environ,
+        "PATH": f"{fake_bin}{os.pathsep}{os.environ.get('PATH', '')}",
+        "FAKE_SKILLHUB_LOG": str(log_path),
+    }
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(_manager_script()),
+            "--workspace",
+            str(tmp_path),
+            "install",
+            "https://skillhub.cn/skills/user_741dc82b/dev-expert?from=skill-hunt",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    assert result.returncode == 0, result.stderr or result.stdout
+    assert (tmp_path / "skills/dev-expert/SKILL.md").is_file()
+    args = json.loads(log_path.read_text(encoding="utf-8"))
+    assert args[args.index("install") + 1] == "dev-expert"
+    assert args[args.index("--namespace") + 1] == "user_741dc82b"

--- a/tests/unit/agents/test_octop_builtin_skills.py
+++ b/tests/unit/agents/test_octop_builtin_skills.py
@@ -168,7 +168,7 @@ def test_manager_installs_namespaced_skillhub_page_url(tmp_path: Path) -> None:
     fake_bin = tmp_path / "fake-bin"
     fake_bin.mkdir()
     log_path = tmp_path / "skillhub-args.json"
-    fake_skillhub = fake_bin / "skillhub"
+    fake_skillhub = fake_bin / ("skillhub.py" if os.name == "nt" else "skillhub")
     fake_skillhub.write_text(
         """#!/usr/bin/env python3
 import json
@@ -190,7 +190,13 @@ print(json.dumps({"installed": slug}))
 """,
         encoding="utf-8",
     )
-    fake_skillhub.chmod(0o755)
+    if os.name == "nt":
+        (fake_bin / "skillhub.cmd").write_text(
+            f'@"{sys.executable}" "%~dp0skillhub.py" %*\n',
+            encoding="utf-8",
+        )
+    else:
+        fake_skillhub.chmod(0o755)
     env = {
         **os.environ,
         "PATH": f"{fake_bin}{os.pathsep}{os.environ.get('PATH', '')}",


### PR DESCRIPTION
## Summary

- seed an Octop-owned built-in `skill-manager` into every expert workspace without changing harness-agent
- support conversational install/import from uploaded files, raw `SKILL.md`, ZIP/TAR archives, Git/GitHub URLs, direct web URLs, and SkillHub pages/search
- support per-expert list, inspect, replace, soft-delete, and restore operations with staging, rollback, path traversal, symlink, size, and file-count protections
- render the exact Octop workspace path into the built-in skill and infer it from the deployed helper location, preventing agents from installing into a legacy `~/.harness-agent/workspace`

## Why

Users need to manage each expert instance's Skills freely through conversation. A real 小通助手 trace showed that a generic agent could confuse the current Octop expert workspace with a legacy harness-agent workspace. This change keeps ownership entirely in Octop and makes the destination deterministic.

## Validation

- develop pre-commit gate passed without bypass:
  - Ruff fix, lint, and format checks
  - mypy strict: 405 source files, no issues
  - pytest: 2110 passed, 43 skipped
  - dashboard production build
- targeted Skill Manager suite: 91 passed
- earlier full non-live suite: 1956 passed, 12 skipped, 31 deselected
- Skill quick validation passed
- real ZIP, GitHub, SkillHub, and LLM conversation end-to-end tests passed
