### PR TITLE
refactor: update BackupRestorePanel icon to CalendarClock

### DIFF
--- a/dashboard/src/pages/Settings/BackupRestore/index.tsx
+++ b/dashboard/src/pages/Settings/BackupRestore/index.tsx
@@ -19,6 +19,7 @@ import { message } from "@/utils/antdMessage";
 import type { ColumnsType } from "antd/es/table";
 import {
   Archive,
+  CalendarClock,
   Download,
   Plus,
   RefreshCw,
@@ -529,7 +530,7 @@ export default function BackupRestorePanel() {
       <Divider style={{ margin: "40px 0" }} />
 
       <TabPanelHeader
-        icon={<Archive size={22} />}
+        icon={<CalendarClock size={22} />}
         title={t("backup.autoTitle")}
         description={t("backup.autoDesc")}
       />


### PR DESCRIPTION
## Summary

- 将「自动备份」区块标题图标从 `Archive` 换成 `CalendarClock`，与上方手动备份列表区分，并更贴合“按计划调度”的语义。
- 仅改动 `dashboard/src/pages/Settings/BackupRestore/index.tsx`，无行为或 API 变更。

## Target branch

- [x] Base is **`develop`** (feature / fix — default)
- [ ] Base is **`main`** (`release/*` or `hotfix/*` only)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactor / chore
- [ ] Release / hotfix

## Test plan

- [ ] `make all` passes locally
- [ ] Added/updated tests
- [x] `cd dashboard && npx tsc --noEmit` passes
- [ ] 在 Settings → Backup / Restore 页面目视确认：手动备份区块仍为 `Archive`，自动备份区块为 `CalendarClock`

## Checklist

- [ ] Updated `CHANGELOG.md` (if user-facing)
- [ ] README / docs updated (if needed)
