### PR TITLE
fix(chat): strip media-offload placeholder text from image history

### DIFF
--- a/src/octop/api/routers/chat/serialize.py
+++ b/src/octop/api/routers/chat/serialize.py
@@ -11,16 +11,33 @@ from pathlib import Path
 from typing import Any
 
 from octop.api.common.agent_workspace import resolve_agent_workspace_dir
+from octop.i18n.domains.attachment import attachment_empty_image
 from octop.infra.gateway.process.message_keys import (
     COMPOSER_CTX_KEY,
     INBOUND_ATTACHMENTS_KEY,
 )
 from octop.infra.utils.llm_text import strip_thinking as _strip_thinking
+from octop.infra.utils.locale import normalize_locale
 
 logger = logging.getLogger(__name__)
 
 _THINKING_CAPTURE_RE = re.compile(
     r"<think>([\s\S]*?)</think>\s*",
+    re.IGNORECASE,
+)
+
+# Matches the lightweight placeholder that ``MediaOffloadMiddleware`` writes
+# into LangGraph state for already-offloaded inline images / audio. Format
+# (see harness_agent.middleware.media_offload._placeholder_text_block):
+#   [<btype> offloaded: sha=<short_sha> path=<path> size=<n>B mime=<m>;
+#   use read_file to retrieve bytes]
+# We strip these on history serialization because the original bytes are
+# still available via ``inbound_attachments`` and the dashboard renders the
+# thumbnail from there — leaving the placeholder visible made the chat show
+# a "[image offloaded: sha=… path=…]" line under every user image after the
+# second turn (when the middleware first re-encountered the block).
+_OFFLOAD_PLACEHOLDER_RE = re.compile(
+    r"^\s*\[\s*(?:image|audio)\s+offloaded\s*:",
     re.IGNORECASE,
 )
 
@@ -33,6 +50,73 @@ HISTORY_MAX_LIMIT = 200
 
 def _clamp_history_limit(limit: int) -> int:
     return max(1, min(limit, HISTORY_MAX_LIMIT))
+
+
+def _is_offload_placeholder_block(block: Any) -> bool:
+    """True when *block* is a ``MediaOffloadMiddleware`` placeholder.
+
+    The middleware rewrites an inline image/audio block into a single text
+    block of the form ``[image offloaded: sha=… path=… size=…B mime=…; use
+    read_file to retrieve bytes]`` on every turn after the first one. We
+    must not surface that text in the dashboard: the original attachment
+    is still available via ``inbound_attachments`` and the UI renders the
+    image from there. Showing the placeholder underneath is a UX bug.
+    """
+    if not isinstance(block, dict):
+        return False
+    if str(block.get("type") or "").lower() != "text":
+        return False
+    text = str(block.get("text") or "")
+    return bool(_OFFLOAD_PLACEHOLDER_RE.match(text))
+
+
+def _user_message_has_image_attachment(additional_kwargs: Any) -> bool:
+    """True if the persisted ``INBOUND_ATTACHMENTS_KEY`` carries any image."""
+    if not isinstance(additional_kwargs, dict):
+        return False
+    raw = additional_kwargs.get(INBOUND_ATTACHMENTS_KEY)
+    if not isinstance(raw, list):
+        return False
+    for item in raw:
+        if not isinstance(item, dict):
+            continue
+        kind = str(item.get("kind") or "").lower()
+        media_type = str(item.get("media_type") or item.get("mediaType") or "")
+        if kind == "image" or media_type.lower().startswith("image/"):
+            return True
+    return False
+
+
+def _strip_image_only_text_blocks(
+    blocks: list[dict[str, Any]],
+    *,
+    locale: str,
+) -> list[dict[str, Any]]:
+    """Drop placeholders + the LLM-facing "User sent an image." sentinel.
+
+    Only safe when the original image is also being delivered to the
+    dashboard via ``inbound_attachments``; if not, removing the text
+    would make a pure-image turn look empty in the UI.
+    """
+    empty_image = attachment_empty_image(normalize_locale(locale)).strip()
+    out: list[dict[str, Any]] = []
+    for block in blocks:
+        if _is_offload_placeholder_block(block):
+            continue
+        if (
+            empty_image
+            and isinstance(block, dict)
+            and str(block.get("type") or "").lower() == "text"
+            and str(block.get("text") or "").strip() == empty_image
+        ):
+            continue
+        out.append(block)
+    return out
+
+
+def _user_locale(user: Any) -> str:
+    raw = getattr(user, "locale", None) if user is not None else None
+    return normalize_locale(str(raw) if raw else None)
 
 
 def _slice_message_page(
@@ -112,7 +196,7 @@ async def _load_thread_messages(
             offset,
         )
         for m in raw_messages:
-            entry = _serialize_history_message(m)
+            entry = _serialize_history_message(m, user=user)
             if entry is not None:
                 out.append(entry)
     except Exception:
@@ -474,7 +558,7 @@ def _split_string_thinking(text: str) -> list[dict[str, Any]]:
     return blocks
 
 
-def _serialize_history_message(msg: Any) -> dict[str, Any] | None:
+def _serialize_history_message(msg: Any, *, user: Any = None) -> dict[str, Any] | None:
     """Project a LangGraph checkpoint message into dashboard history shape."""
     role = _message_role(msg)
     if role in ("system", ""):
@@ -512,7 +596,19 @@ def _serialize_history_message(msg: Any) -> dict[str, Any] | None:
     if role == "assistant":
         blocks.extend(_tool_use_blocks(_msg_attr(msg, "tool_calls")))
 
-    if not blocks:
+    raw_att = (
+        additional_kwargs.get(INBOUND_ATTACHMENTS_KEY)
+        if isinstance(additional_kwargs, dict)
+        else None
+    )
+    has_user_attachments = isinstance(raw_att, list) and bool(raw_att)
+    if role == "user" and _user_message_has_image_attachment(additional_kwargs):
+        # The original image is being delivered through inbound_attachments;
+        # the image/audio offload placeholders and the LLM-only "User sent
+        # an image." sentinel are redundant noise on the dashboard.
+        blocks = _strip_image_only_text_blocks(blocks, locale=_user_locale(user))
+
+    if not blocks and not (role == "user" and has_user_attachments):
         return None
 
     entry = {"role": role, "content": blocks}
@@ -524,8 +620,7 @@ def _serialize_history_message(msg: Any) -> dict[str, Any] | None:
         raw_ctx = additional_kwargs.get(COMPOSER_CTX_KEY)
         if isinstance(raw_ctx, dict) and raw_ctx:
             entry["composer_context"] = raw_ctx
-        raw_att = additional_kwargs.get(INBOUND_ATTACHMENTS_KEY)
-        if isinstance(raw_att, list) and raw_att:
+        if has_user_attachments:
             entry["inbound_attachments"] = raw_att
     ts_ms = _extract_message_timestamp_ms(msg)
     if ts_ms is not None:

--- a/tests/unit/api/test_chat_polish.py
+++ b/tests/unit/api/test_chat_polish.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
@@ -10,8 +11,10 @@ from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 
 from octop.api.routers.chat.serialize import (
     _entry_matches_thread,
+    _is_offload_placeholder_block,
     _merge_adjacent_messages,
     _serialize_history_message,
+    _strip_image_only_text_blocks,
     _strip_thinking,
     _ts_to_ms,
 )
@@ -179,6 +182,191 @@ def test_serialize_history_message_includes_checkpoint_timestamp_for_tool() -> N
 
 def test_ts_to_ms_converts_seconds() -> None:
     assert _ts_to_ms(1_700_000_000.5) == 1_700_000_000_500
+
+
+# ---------------------------------------------------------------------------
+# Image-offload placeholder filtering on history serialization
+# ---------------------------------------------------------------------------
+
+
+_PLACEHOLDER_TEXT = (
+    "[image offloaded: sha=06bdd82d592a "
+    "path=C:\\Users\\me\\.octop\\agents\\DMQ318\\.media-cache/"
+    "06bdd82d592a5cd6371ccdb2ed49d347a4ffb0fca4b80ea57e991f51522e178e.png "
+    "size=173004B mime=image/png; use read_file to retrieve bytes]"
+)
+
+
+def test_is_offload_placeholder_block_matches_image_format() -> None:
+    assert _is_offload_placeholder_block({"type": "text", "text": _PLACEHOLDER_TEXT})
+    # Same shape, but a 12-char short sha and trailing "]".
+    assert _is_offload_placeholder_block(
+        {
+            "type": "text",
+            "text": "  [audio offloaded: sha=abcdef012345 path=/x.y size=1B mime=audio/mpeg; use read_file to retrieve bytes]  ",
+        }
+    )
+
+
+def test_is_offload_placeholder_block_rejects_unrelated_text() -> None:
+    assert not _is_offload_placeholder_block({"type": "text", "text": "hello"})
+    assert not _is_offload_placeholder_block(
+        {"type": "text", "text": "[image] some other bracket text"}
+    )
+    # Image block (not text) is not a placeholder.
+    assert not _is_offload_placeholder_block(
+        {"type": "image_url", "image_url": {"url": "data:..."}}
+    )
+    assert not _is_offload_placeholder_block("not a dict")
+
+
+def test_serialize_history_message_drops_image_offload_placeholder_for_image_user() -> None:
+    msg = HumanMessage(
+        content=[
+            {"type": "text", "text": "用户发送了图片。"},
+            {"type": "text", "text": _PLACEHOLDER_TEXT},
+        ],
+        additional_kwargs={
+            "octop_inbound_attachments": [
+                {
+                    "filename": "image.png",
+                    "media_type": "image/png",
+                    "kind": "image",
+                    "workspace_path": "inbound/123_image.png",
+                }
+            ],
+        },
+    )
+    user = SimpleNamespace(locale="zh")
+    entry = _serialize_history_message(msg, user=user)
+    assert entry is not None
+    # Both the localized "User sent an image." sentinel and the offload
+    # placeholder must be stripped — only the image (rendered from
+    # inbound_attachments) is meaningful on the dashboard.
+    assert entry["content"] == []
+    # Attachments are still propagated for the frontend to render the image.
+    assert entry["inbound_attachments"][0]["workspace_path"] == "inbound/123_image.png"
+
+
+def test_serialize_history_message_keeps_user_caption_alongside_image_placeholder() -> None:
+    msg = HumanMessage(
+        content=[
+            {"type": "text", "text": "请帮我看看这张图"},
+            {"type": "text", "text": _PLACEHOLDER_TEXT},
+        ],
+        additional_kwargs={
+            "octop_inbound_attachments": [
+                {
+                    "filename": "image.png",
+                    "media_type": "image/png",
+                    "kind": "image",
+                    "workspace_path": "inbound/123_image.png",
+                }
+            ],
+        },
+    )
+    user = SimpleNamespace(locale="zh")
+    entry = _serialize_history_message(msg, user=user)
+    assert entry is not None
+    # Only the offload placeholder is dropped; the user-written caption
+    # is preserved verbatim so the dashboard still shows it.
+    assert entry["content"] == [{"type": "text", "text": "请帮我看看这张图"}]
+
+
+def test_serialize_history_message_keeps_placeholder_when_no_image_attachment() -> None:
+    """Without inbound_attachments, the placeholder is the only sign of media."""
+    msg = HumanMessage(
+        content=[{"type": "text", "text": _PLACEHOLDER_TEXT}],
+    )
+    # No additional_kwargs → no inbound_attachments → no filtering.
+    entry = _serialize_history_message(msg, user=SimpleNamespace(locale="en"))
+    assert entry is not None
+    assert entry["content"] == [{"type": "text", "text": _PLACEHOLDER_TEXT}]
+
+
+def test_serialize_history_message_drops_placeholder_for_en_locale() -> None:
+    msg = HumanMessage(
+        content=[
+            {"type": "text", "text": "User sent an image."},
+            {"type": "text", "text": _PLACEHOLDER_TEXT},
+        ],
+        additional_kwargs={
+            "octop_inbound_attachments": [
+                {
+                    "filename": "image.png",
+                    "media_type": "image/png",
+                    "kind": "image",
+                    "workspace_path": "inbound/123_image.png",
+                }
+            ],
+        },
+    )
+    entry = _serialize_history_message(msg, user=SimpleNamespace(locale="en"))
+    assert entry is not None
+    assert entry["content"] == []
+
+
+def test_strip_image_only_text_blocks_without_user_skips_zh_default() -> None:
+    """Locale falls back to ``zh`` when no user is supplied."""
+    msg = HumanMessage(
+        content=[
+            {"type": "text", "text": "用户发送了图片。"},
+            {"type": "text", "text": _PLACEHOLDER_TEXT},
+        ],
+        additional_kwargs={
+            "octop_inbound_attachments": [
+                {
+                    "filename": "image.png",
+                    "media_type": "image/png",
+                    "kind": "image",
+                    "workspace_path": "inbound/x.png",
+                }
+            ],
+        },
+    )
+    # Pass no user — caller signature is ``user=None`` default.
+    entry = _serialize_history_message(msg)
+    assert entry is not None
+    assert entry["content"] == []
+
+
+def test_strip_image_only_text_blocks_keeps_voice_caption() -> None:
+    """A non-image attachment must not trigger placeholder stripping."""
+    msg = HumanMessage(
+        content=[
+            {"type": "text", "text": "请听这段录音"},
+            {"type": "text", "text": _PLACEHOLDER_TEXT},  # NOT real, but tests shape
+        ],
+        additional_kwargs={
+            "octop_inbound_attachments": [
+                {
+                    "filename": "voice.m4a",
+                    "media_type": "audio/mp4",
+                    "kind": "file",
+                    "workspace_path": "inbound/voice.m4a",
+                }
+            ],
+        },
+    )
+    entry = _serialize_history_message(msg, user=SimpleNamespace(locale="zh"))
+    assert entry is not None
+    # The audio file is rendered from inbound_attachments, not as a
+    # placeholder text block, so the on-disk placeholder is the only
+    # signal — leave it alone.
+    assert entry["content"] == [
+        {"type": "text", "text": "请听这段录音"},
+        {"type": "text", "text": _PLACEHOLDER_TEXT},
+    ]
+
+
+def test_strip_image_only_text_blocks_directly() -> None:
+    blocks = [
+        {"type": "text", "text": "用户发送了图片。"},
+        {"type": "text", "text": _PLACEHOLDER_TEXT},
+        {"type": "text", "text": "你好"},
+    ]
+    out = _strip_image_only_text_blocks(blocks, locale="zh")
+    assert out == [{"type": "text", "text": "你好"}]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

修复聊天记录里用户图片下方多出内部占位文本的 bug。

用户发送较大（>4KiB）的 inline 图片后，harness 的 `MediaOffloadMiddleware`（`harness_agent/middleware/media_offload.py`，非 octop 源码）会把图片字节 offload 到工作区 `.media-cache/<sha>.<ext>`，并从第二轮起把对应 inline 块替换成一段占位文本：

`[image offloaded: sha=… path=… size=…B mime=…; use read_file to retrieve bytes]`

这段文本是写给 LLM 看的（提示模型用 `read_file` 取回字节），会经 state 合并写回 LangGraph checkpoint。用户切出聊天再切回后，历史接口 `GET /threads/{tid}/history` 从 checkpoint 原样读出并序列化 → 前端在图片下方渲染出这段内部文本，属于 UX 缺陷。

**修复**（`src/octop/api/routers/chat/serialize.py`）：
- 新增 `_is_offload_placeholder_block`，用正则 `^\s*\[(?:image|audio)\s+offloaded\s*:` 识别占位块；
- `_serialize_history_message(msg, *, user=None)`：当消息 role=user 且 `additional_kwargs` 里带图片 `inbound_attachments`（键 `octop_inbound_attachments`）时，用 `_strip_image_only_text_blocks` 过滤掉占位文本和仅给 LLM 看的本地化哨兵文本（`attachment_empty_image`：`用户发送了图片。` / `User sent an image.`），用户自己写的 caption 原样保留；
- 关键边界：过滤后 blocks 为空但消息**带 inbound_attachments 时不能 return None**——否则前端连图片都看不到。entry 保留空 content，前端从 `inbound_attachments`（workspace_path → agentAttachmentAccessUrl → ChatAttachment）渲染原图；
- 调用方 `_load_thread_messages` 把 `user` 传入（locale 用于匹配本地化哨兵文本，`User.locale` 默认 `zh`）；
- 新增 8 个单测，覆盖占位块匹配/过滤、caption 保留、无附件时保留占位文本、en locale、无 user 默认 zh、非图片附件不触发过滤、`_strip_image_only_text_blocks` 直接调用等边界。

## Target branch

- [x] Base is **`develop`** (feature / fix — default)
- [ ] Base is **`main`** (`release/*` or `hotfix/*` only)

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / chore
- [ ] Release / hotfix

## Test plan
1. `pytest tests/unit/api/test_chat_polish.py` 全绿（含新增 8 例占位文本过滤用例）。
2. 手工复现：在聊天里发一张 >4KiB 的图片 → 正常对话几轮 → 切出再切回 → 图片正常渲染，下方不再出现 `[image offloaded: sha=…]` 占位文本。
3. 带 caption 场景：图片附带文字说明时，过滤后只保留用户文字，占位文本被移除。
4. 纯图片消息：只发图不带文字，切回后图片依然显示（content 为空但 entry 不丢，由 inbound_attachments 渲染）。
5. 非图片附件：语音 / 文件等非图片附件历史内容不受影响，原样保留。
6. 兼容性：无 `inbound_attachments` 的旧历史消息序列化行为不变，占位文本不会被误删。

<!-- How did you verify this? Include commands run (e.g. `make all`). -->

- [ ] `make all` passes locally
- [x] Added/updated tests

## Checklist

- [ ] Updated `CHANGELOG.md` (if user-facing)
- [ ] README / docs updated (if needed)