### PR TITLE
feat(chat): add delete action to dock file list rows

### DIFF
--- a/dashboard/src/locales/en.json
+++ b/dashboard/src/locales/en.json
@@ -1056,6 +1056,8 @@
     "dockFileListCount": "{{count}} files",
     "dockFileListHint": "This list only shows files produced during execution. They are not guaranteed to be kept, and the model may delete them after processing finishes.",
     "dockFileMaybeDeleted": "This file may have been a temporary artifact during processing and has already been deleted.",
+    "dockFileDelete": "Delete file",
+    "dockFileDeleteConfirm": "Delete this file? This cannot be undone.",
     "remoteBrowserTitle": "Remote Browser",
     "dockTerminalTitle": "Terminal",
     "loadEarlierMessages": "Load earlier messages"

--- a/dashboard/src/locales/zh.json
+++ b/dashboard/src/locales/zh.json
@@ -1055,6 +1055,8 @@
     "dockFileListCount": "{{count}} 个文件",
     "dockFileListHint": "当前仅列出执行过程中生成的文件，不代表最终一定存储，可能在处理结束后被大模型删除。",
     "dockFileMaybeDeleted": "该文件可能为处理过程中的临时文件，当前已经被删除。",
+    "dockFileDelete": "删除文件",
+    "dockFileDeleteConfirm": "确定删除该文件吗？删除后不可恢复。",
     "remoteBrowserTitle": "远程浏览器",
     "dockTerminalTitle": "终端",
     "loadEarlierMessages": "加载更早的消息"

--- a/dashboard/src/pages/Chat/chatBrowserPanel.partial.less
+++ b/dashboard/src/pages/Chat/chatBrowserPanel.partial.less
@@ -392,12 +392,20 @@
   white-space: nowrap;
 }
 
-.dockFileTreeDownload {
+.dockFileTreeActions {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+  margin-left: auto;
+}
+
+.dockFileTreeDownload,
+.dockFileTreeDelete {
   display: inline-flex;
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
-  margin-left: auto;
   width: 28px;
   height: 28px;
   padding: 0;
@@ -434,15 +442,28 @@
   }
 }
 
-/* Desktop: hide download until row hover / keyboard focus. */
+.dockFileTreeDelete:hover:not(:disabled) {
+  color: var(--fn-color-danger);
+  border-color: color-mix(in srgb, var(--fn-color-danger) 35%, transparent);
+  background: color-mix(
+    in srgb,
+    var(--fn-color-danger) 8%,
+    var(--fn-bg-primary)
+  );
+}
+
+/* Desktop: hide actions until row hover / keyboard focus. */
 @media (hover: hover) and (pointer: fine) {
-  .dockFileTreeDownload {
+  .dockFileTreeDownload,
+  .dockFileTreeDelete {
     opacity: 0;
     pointer-events: none;
   }
 
   .dockFileTreeFile:hover .dockFileTreeDownload,
-  .dockFileTreeFile:focus-within .dockFileTreeDownload {
+  .dockFileTreeFile:focus-within .dockFileTreeDownload,
+  .dockFileTreeFile:hover .dockFileTreeDelete,
+  .dockFileTreeFile:focus-within .dockFileTreeDelete {
     opacity: 1;
     pointer-events: auto;
   }

--- a/dashboard/src/pages/Chat/components/ChatDockFileList.tsx
+++ b/dashboard/src/pages/Chat/components/ChatDockFileList.tsx
@@ -1,13 +1,15 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Empty, Tooltip } from "antd";
-import { ChevronDown, ChevronRight, Download, Info } from "lucide-react";
+import { Empty, Popconfirm, Tooltip } from "antd";
+import { ChevronDown, ChevronRight, Download, Info, Trash2 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { message } from "@/utils/antdMessage";
 import { requestBlob } from "../../../api/request";
+import { workspaceApi } from "../../../api/modules/workspace";
 import { isNotFoundApiError } from "../../../utils/apiError";
 import { fileTreeIcon } from "../../../utils/fileTreeIcon";
 import {
   buildDockPathTree,
+  canonicalizeDockFilePath,
   collectDockFolderPaths,
   dedupeDockFilePaths,
   dockFileBasename,
@@ -21,6 +23,8 @@ interface ChatDockFileListProps {
   agentId: string;
   filePaths: string[];
   onOpenFile: (path: string) => void;
+  /** Called after a file is deleted so its viewer tab can be closed. */
+  onCloseFile?: (path: string) => void;
 }
 
 function FolderRow({
@@ -64,17 +68,23 @@ function FileRow({
   node,
   depth,
   downloading,
+  deleting,
   onOpen,
   onDownload,
+  onDelete,
   downloadLabel,
 }: {
   node: DockPathTreeNode;
   depth: number;
   downloading: boolean;
+  deleting: boolean;
   onOpen: () => void;
   onDownload: () => void;
+  onDelete: () => void;
   downloadLabel: string;
 }) {
+  const { t } = useTranslation();
+  const deleteLabel = t("chat.dockFileDelete", "删除文件");
   return (
     <div
       className={styles.dockFileTreeFile}
@@ -93,20 +103,45 @@ function FileRow({
           {dockFileBasename(node.path)}
         </span>
       </button>
-      <Tooltip title={downloadLabel}>
-        <button
-          type="button"
-          className={styles.dockFileTreeDownload}
-          onClick={(e) => {
-            e.stopPropagation();
-            onDownload();
-          }}
-          disabled={downloading}
-          aria-label={downloadLabel}
-        >
-          <Download size={15} strokeWidth={2} />
-        </button>
-      </Tooltip>
+      <div className={styles.dockFileTreeActions}>
+        <Tooltip title={deleteLabel}>
+          <Popconfirm
+            title={t(
+              "chat.dockFileDeleteConfirm",
+              "确定删除该文件吗？删除后不可恢复。",
+            )}
+            okText={t("common.delete", "删除")}
+            cancelText={t("common.cancel", "取消")}
+            okButtonProps={{ danger: true }}
+            onConfirm={() => onDelete()}
+            disabled={downloading || deleting}
+          >
+            <button
+              type="button"
+              className={styles.dockFileTreeDelete}
+              onClick={(e) => e.stopPropagation()}
+              disabled={downloading || deleting}
+              aria-label={deleteLabel}
+            >
+              <Trash2 size={15} strokeWidth={2} />
+            </button>
+          </Popconfirm>
+        </Tooltip>
+        <Tooltip title={downloadLabel}>
+          <button
+            type="button"
+            className={styles.dockFileTreeDownload}
+            onClick={(e) => {
+              e.stopPropagation();
+              onDownload();
+            }}
+            disabled={downloading || deleting}
+            aria-label={downloadLabel}
+          >
+            <Download size={15} strokeWidth={2} />
+          </button>
+        </Tooltip>
+      </div>
     </div>
   );
 }
@@ -117,8 +152,10 @@ function TreeNodes({
   expanded,
   toggle,
   downloading,
+  deleting,
   onOpenFile,
   onDownload,
+  onDelete,
   downloadLabel,
 }: {
   nodes: DockPathTreeNode[];
@@ -126,8 +163,10 @@ function TreeNodes({
   expanded: Set<string>;
   toggle: (path: string) => void;
   downloading: string | null;
+  deleting: string | null;
   onOpenFile: (path: string) => void;
   onDownload: (path: string) => void;
+  onDelete: (path: string) => void;
   downloadLabel: string;
 }) {
   return (
@@ -150,8 +189,10 @@ function TreeNodes({
                   expanded={expanded}
                   toggle={toggle}
                   downloading={downloading}
+                  deleting={deleting}
                   onOpenFile={onOpenFile}
                   onDownload={onDownload}
+                  onDelete={onDelete}
                   downloadLabel={downloadLabel}
                 />
               ) : null}
@@ -164,8 +205,10 @@ function TreeNodes({
             node={node}
             depth={depth}
             downloading={downloading === node.path}
+            deleting={deleting === node.path}
             onOpen={() => onOpenFile(node.path)}
             onDownload={() => onDownload(node.path)}
+            onDelete={() => onDelete(node.path)}
             downloadLabel={downloadLabel}
           />
         );
@@ -181,11 +224,17 @@ export default function ChatDockFileList({
   agentId,
   filePaths,
   onOpenFile,
+  onCloseFile,
 }: ChatDockFileListProps) {
   const { t } = useTranslation();
+  // Deleted files stay in message-derived filePaths; hide them by canonical key.
+  const [deletedKeys, setDeletedKeys] = useState<Set<string>>(() => new Set());
   const paths = useMemo(
-    () => dedupeDockFilePaths(filePaths, agentId),
-    [filePaths, agentId],
+    () =>
+      dedupeDockFilePaths(filePaths, agentId).filter(
+        (p) => !deletedKeys.has(canonicalizeDockFilePath(p, agentId)),
+      ),
+    [filePaths, agentId, deletedKeys],
   );
   const tree = useMemo(
     () => buildDockPathTree(paths, agentId),
@@ -193,6 +242,7 @@ export default function ChatDockFileList({
   );
   const [expanded, setExpanded] = useState<Set<string>>(() => new Set());
   const [downloading, setDownloading] = useState<string | null>(null);
+  const [deleting, setDeleting] = useState<string | null>(null);
   const seenFoldersRef = useRef<Set<string>>(new Set());
 
   // Expand newly appeared folders only; keep user collapse state.
@@ -256,6 +306,56 @@ export default function ChatDockFileList({
     [agentId, t],
   );
 
+  /** Hide a path from the list (by canonical key) and close its viewer tab. */
+  const hideDeletedPath = useCallback(
+    (path: string) => {
+      const key = canonicalizeDockFilePath(path, agentId);
+      if (key) {
+        setDeletedKeys((prev) => {
+          if (prev.has(key)) return prev;
+          const next = new Set(prev);
+          next.add(key);
+          return next;
+        });
+      }
+      onCloseFile?.(path);
+    },
+    [agentId, onCloseFile],
+  );
+
+  const handleDelete = useCallback(
+    async (path: string) => {
+      if (!agentId || !path) return;
+      setDeleting(path);
+      try {
+        await workspaceApi.deleteWorkspaceFile(
+          agentId,
+          toDockWorkspaceApiPath(path, agentId),
+        );
+        message.success(t("workspace.deleteSuccess", "已删除"));
+        hideDeletedPath(path);
+      } catch (err: unknown) {
+        if (isNotFoundApiError(err)) {
+          message.warning(
+            t(
+              "chat.dockFileMaybeDeleted",
+              "该文件可能为处理过程中的临时文件，当前已经被删除。",
+            ),
+          );
+          hideDeletedPath(path);
+          return;
+        }
+        message.error(
+          (err instanceof Error ? err.message : String(err)) ||
+            t("workspace.deleteFailed", "删除失败"),
+        );
+      } finally {
+        setDeleting(null);
+      }
+    },
+    [agentId, hideDeletedPath, t],
+  );
+
   const listHint = (
     <div className={styles.dockFileListHint} role="note">
       <Info
@@ -309,8 +409,10 @@ export default function ChatDockFileList({
             expanded={expanded}
             toggle={toggle}
             downloading={downloading}
+            deleting={deleting}
             onOpenFile={onOpenFile}
             onDownload={(p) => void handleDownload(p)}
+            onDelete={(p) => void handleDelete(p)}
             downloadLabel={downloadLabel}
           />
         </div>

--- a/dashboard/src/pages/Chat/components/ChatDockPanel.tsx
+++ b/dashboard/src/pages/Chat/components/ChatDockPanel.tsx
@@ -25,7 +25,7 @@ import ChatDockPanelShell from "../../../components/BrowserWorkspace/ChatDockPan
 import type { DisplayEnvironment } from "../../../api/types/browser";
 import { resolveBrowserProfile } from "../../../utils/browserProfile";
 import type { DockTab, DockTabId } from "../hooks/useChatDockPanel";
-import { dockFileBasename } from "../utils/dockFilePath";
+import { dockFileBasename, dockFileTabId } from "../utils/dockFilePath";
 import styles from "../index.module.less";
 import ChatDockFileList from "./ChatDockFileList";
 import FilePanelContent from "./FilePanelContent";
@@ -127,6 +127,14 @@ const ChatDockPanel: React.FC<ChatDockPanelProps> = ({
   const handleBrowserRefreshReady = useCallback((refresh: () => void) => {
     browserRefreshRef.current = refresh;
   }, []);
+
+  /** Close the viewer tab of a deleted file (canonical key matches tab id). */
+  const handleCloseFile = useCallback(
+    (path: string) => {
+      onCloseTab(dockFileTabId(path, agentId));
+    },
+    [agentId, onCloseTab],
+  );
 
   const getFileActionsHandler = useCallback((path: string) => {
     const existing = fileActionsHandlersRef.current[path];
@@ -254,6 +262,7 @@ const ChatDockPanel: React.FC<ChatDockPanelProps> = ({
               agentId={agentId}
               filePaths={filePaths}
               onOpenFile={onOpenFile}
+              onCloseFile={handleCloseFile}
             />
           </div>
         )}


### PR DESCRIPTION
Each file row in the chat dock "modified files" panel now has a delete button (Trash2 icon, danger hover) to the left of the download button, with a Popconfirm guard since deletion is irreversible.

- Calls the existing DELETE /agents/{id}/workspace/file endpoint
- Deleted paths are hidden via a canonical-key set (the list itself is message-derived and would otherwise keep showing them)
- The file's open viewer tab is closed after deletion (same tab id function as openFileAt, so no mismatch)
- 404 during delete treats the file as already gone and hides the row
- Button styles shared with the download button; hover-reveal behavior extended to both actions

## Summary
在专家聊天「已修改文件」面板的每行文件上，下载按钮左侧新增删除按钮（Trash2 图标、危险色 hover），点击弹 Popconfirm 二次确认后调用既有 DELETE /workspace/file 接口真实删除文件
删除后文件从列表消失（通过 canonical-key 集合过滤）、自动关闭该文件打开的查看器标签页；404 视为已删除并提示
改动 5 个前端文件：[ChatDockFileList.tsx](vscode-webview://0fivrrinp690rj4q45slqhnbkhjkk4g890kfqo0ppll8mu1lee23/dashboard/src/pages/Chat/components/ChatDockFileList.tsx)、[ChatDockPanel.tsx](vscode-webview://0fivrrinp690rj4q45slqhnbkhjkk4g890kfqo0ppll8mu1lee23/dashboard/src/pages/Chat/components/ChatDockPanel.tsx)、[chatBrowserPanel.partial.less](vscode-webview://0fivrrinp690rj4q45slqhnbkhjkk4g890kfqo0ppll8mu1lee23/dashboard/src/pages/Chat/chatBrowserPanel.partial.less)、中英文 locale
<!-- What does this PR change and why? -->
<img width="780" height="450" alt="image" src="https://github.com/user-attachments/assets/fb385d41-f5dc-4a68-9d15-e595a5ef2b6f" />

## Target branch

- [x] Base is **`develop`** (feature / fix — default)
- [ ] Base is **`main`** (`release/*` or `hotfix/*` only)

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / chore
- [ ] Release / hotfix

## Test plan

<!-- How did you verify this? Include commands run (e.g. `make all`). -->

- [x] `make all` passes locally
- [ ] Added/updated tests

## Checklist

- [ ] Updated `CHANGELOG.md` (if user-facing)
- [ ] README / docs updated (if needed)
