### PR TITLE
fix(dashboard): prevent CronJobs table overflow from long prompts

### DIFF
--- a/dashboard/src/pages/Control/CronJobs/components/columns.tsx
+++ b/dashboard/src/pages/Control/CronJobs/components/columns.tsx
@@ -152,11 +152,10 @@ export const createColumns = (
     {
       title: handlers.t("cronJobs.col.taskType"),
       key: "task_type",
-      width: 108,
       render: (_: unknown, record: CronJob) => {
         const taskType = record.task_type === "text" ? "text" : "agent";
         return (
-          <Tag style={{ fontSize: 11 }}>
+          <Tag style={{ fontSize: 11, whiteSpace: "nowrap" }}>
             {taskType === "text"
               ? handlers.t("cronJobs.form.taskTypeText")
               : handlers.t("cronJobs.form.taskTypeAgent")}

--- a/dashboard/src/pages/Control/CronJobs/index.module.less
+++ b/dashboard/src/pages/Control/CronJobs/index.module.less
@@ -55,7 +55,9 @@
 
 .promptCell {
   display: block;
-  max-width: 100%;
+  /* Table runs in `table-layout: auto` (scroll.x = max-content) so columns hug
+     their content — cap the prompt so a long instruction cannot stretch the row. */
+  max-width: 280px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/dashboard/src/pages/Control/CronJobs/index.tsx
+++ b/dashboard/src/pages/Control/CronJobs/index.tsx
@@ -354,7 +354,7 @@ function CronJobsPage() {
               dataSource={jobs}
               rowKey="id"
               size="middle"
-              scroll={{ x: 1100 }}
+              scroll={{ x: "max-content" }}
               pagination={{
                 pageSize: 10,
                 showSizeChanger: false,


### PR DESCRIPTION
## Summary

- Switch CronJobs table horizontal scroll to `max-content` so columns size to their content instead of a fixed `1100px` width.
- Cap the prompt cell at `280px` with ellipsis so a long instruction cannot stretch the row.
- Drop the fixed task-type column width and keep the type tag on one line with `whiteSpace: nowrap`.

Before:

<img width="1151" height="358" alt="Clipboard_Screenshot_1787107759" src="https://github.com/user-attachments/assets/138dc539-5f85-4aa0-a497-4f6b92bdc69d" />

After:

<img width="1066" height="355" alt="Clipboard_Screenshot_1787107922" src="https://github.com/user-attachments/assets/86cac897-769a-4adb-8b34-050c2f170412" />


## Target branch

- [x] Base is **`develop`** (feature / fix — default)
- [ ] Base is **`main`** (`release/*` or `hotfix/*` only)

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / chore
- [ ] Release / hotfix

## Test plan

<!-- How did you verify this? Include commands run (e.g. `make all`). -->

- Manual: open Control → Cron Jobs with a long prompt and confirm the prompt truncates and the table scrolls horizontally without overflow.
- [ ] `make all` passes locally
- [ ] Added/updated tests

## Checklist

- [ ] Updated `CHANGELOG.md` (if user-facing)
- [ ] README / docs updated (if needed)