### PR TITLE
fix(voice): 修复 MiMo TTS 无效音色与 TTS 配置后未自动激活、添加流式低延迟输出

### DIFF
--- a/dashboard/src/api/modules/voice.ts
+++ b/dashboard/src/api/modules/voice.ts
@@ -1,4 +1,4 @@
-import { request, requestBlob, requestUpload } from "../request";
+import { request, requestBlob, requestStream, requestUpload } from "../request";
 
 export interface VoicePreset {
   id: string;
@@ -59,6 +59,23 @@ export const voiceApi = {
   },
   synthesize: (text: string, provider?: string) =>
     requestBlob("/voice/tts", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        text,
+        ...(provider ? { provider } : {}),
+      }),
+    }),
+  /**
+   * Streamed variant for low-latency playback. The server flushes chunks as
+   * they arrive (MiMo streams live WAV); other providers stream MP3, in
+   * which case the buffered `synthesize` path is used instead.
+   */
+  synthesizeStream: (
+    text: string,
+    provider?: string,
+  ): Promise<{ contentType: string; body: ReadableStream<Uint8Array> }> =>
+    requestStream("/voice/tts", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({

--- a/dashboard/src/api/request.ts
+++ b/dashboard/src/api/request.ts
@@ -357,6 +357,47 @@ export async function probeAuthResource(
   }
 }
 
+/**
+ * POST JSON and hand back the response body as a byte stream (chunked TTS).
+ * Mirrors requestBlob()'s auth/setup/401 handling but never buffers.
+ */
+export async function requestStream(
+  path: string,
+  options: RequestInit = {},
+): Promise<{ contentType: string; body: ReadableStream<Uint8Array> }> {
+  const url = getApiUrl(path);
+  const headers = buildAuthHeaders(path);
+  const response = await fetch(url, {
+    ...options,
+    headers: { ...headers, ...(options.headers as Record<string, string>) },
+  });
+
+  if (await check503ForSetupRequired(path, response)) {
+    throw new Error("Setup required — redirecting to /setup");
+  }
+
+  await throwIfUnauthorized(path, response);
+  applyRenewedAccessToken(response);
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => "");
+    throw new Error(
+      `Request failed: ${response.status} ${response.statusText}${
+        text ? ` - ${text}` : ""
+      }`,
+    );
+  }
+
+  if (!response.body) {
+    throw new Error("Empty stream from server");
+  }
+
+  return {
+    contentType: response.headers.get("content-type") || "",
+    body: response.body,
+  };
+}
+
 export type UploadProgressHandler = (percent: number) => void;
 
 /**

--- a/dashboard/src/hooks/useVoiceOutput.ts
+++ b/dashboard/src/hooks/useVoiceOutput.ts
@@ -10,6 +10,7 @@ import {
 import { prepareSpeechText } from "../utils/plainTextForSpeech";
 import { speakBrowserText, stopBrowserSpeech } from "../utils/browserSpeech";
 import { isMobileUserAgent } from "../utils/mobileDevice";
+import { WavStreamPlayer } from "../utils/wavStreamPlayer";
 
 import { message as antMessage } from "@/utils/antdMessage";
 
@@ -17,6 +18,7 @@ export function useVoiceOutput() {
   const { t } = useTranslation();
   const [speakingId, setSpeakingId] = useState<string | null>(null);
   const audioRef = useRef<HTMLAudioElement | null>(null);
+  const streamPlayerRef = useRef<WavStreamPlayer | null>(null);
   const speakingIdRef = useRef<string | null>(null);
   const playGenerationRef = useRef(0);
 
@@ -28,6 +30,8 @@ export function useVoiceOutput() {
   const abortPlayback = useCallback(() => {
     playGenerationRef.current += 1;
     stopBrowserSpeech();
+    streamPlayerRef.current?.stop();
+    streamPlayerRef.current = null;
     if (audioRef.current) {
       audioRef.current.pause();
       audioRef.current.onended = null;
@@ -46,8 +50,81 @@ export function useVoiceOutput() {
     primeAudioElement(audio);
   }, []);
 
+  /**
+   * Stream the MiMo WAV response and schedule chunks as they arrive.
+   * Returns false when streaming is unsupported or the response is not a
+   * WAV — the caller then falls back to the buffered blob path.
+   */
+  const speakMimoStream = useCallback(
+    async (plain: string, gen: number) => {
+      const player = new WavStreamPlayer();
+      streamPlayerRef.current = player;
+      try {
+        if (!player.ensureContext()) return false;
+        const { contentType, body } = await voiceApi.synthesizeStream(plain);
+        if (
+          !contentType.includes("audio/wav") &&
+          !contentType.includes("audio/wave")
+        ) {
+          try {
+            await body.cancel();
+          } catch {
+            /* ignore */
+          }
+          return false;
+        }
+        const reader = body.getReader();
+        // Read until the WAV header plus first audio chunk are scheduled —
+        // malformed streams can still fall back to the blob path here.
+        for (;;) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          if (!value) continue;
+          if (!player.push(value)) {
+            player.stop();
+            return false;
+          }
+          if (player.hasAudio) break;
+        }
+        // Feed remaining chunks in the background until the stream ends.
+        void (async () => {
+          try {
+            for (;;) {
+              const { done, value } = await reader.read();
+              if (done) break;
+              if (value) player.push(value);
+            }
+          } catch {
+            /* network hiccup — keep whatever was scheduled */
+          } finally {
+            const wait = Math.max(player.msRemaining(), 0);
+            window.setTimeout(() => {
+              player.stop();
+              if (playGenerationRef.current === gen) finishSpeaking();
+            }, wait);
+          }
+        })();
+        if (playGenerationRef.current !== gen) {
+          player.stop();
+        }
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    [finishSpeaking],
+  );
+
   const speakWithServer = useCallback(
     async (plain: string, gen: number, provider?: string) => {
+      // MiMo streams a live WAV — play it chunk-by-chunk for low latency.
+      // Other providers stream MP3, which needs the buffered blob path.
+      const active = cachedActiveVoice();
+      const ttsProvider = provider ?? active?.tts;
+      if (ttsProvider === "mimo-tts" || ttsProvider === "mimo") {
+        if (await speakMimoStream(plain, gen)) return;
+      }
+
       try {
         const blob = await voiceApi.synthesize(plain, provider);
         if (playGenerationRef.current !== gen) return;
@@ -86,7 +163,7 @@ export function useVoiceOutput() {
         finishSpeaking();
       }
     },
-    [finishSpeaking, t],
+    [finishSpeaking, speakMimoStream, t],
   );
 
   const speakWithBrowser = useCallback(

--- a/dashboard/src/pages/Settings/Voice/index.tsx
+++ b/dashboard/src/pages/Settings/Voice/index.tsx
@@ -39,7 +39,7 @@ export function VoiceSettingsPanel() {
   const [mimoEndpoint, setMimoEndpoint] = useState<"payg" | "tokenplan">(
     "payg",
   );
-  const [mimoVoiceId, setMimoVoiceId] = useState("mimo_default");
+  const [mimoVoiceId, setMimoVoiceId] = useState("冰糖");
   const [saving, setSaving] = useState(false);
 
   const fetchAll = useCallback(async () => {
@@ -100,7 +100,7 @@ export function VoiceSettingsPanel() {
     setSecretId(String(extra.secret_id ?? ""));
     setSecretKey(String(extra.secret_key ?? ""));
     setMimoEndpoint(extra.endpoint_type === "tokenplan" ? "tokenplan" : "payg");
-    setMimoVoiceId(String(extra.voice_id ?? "mimo_default"));
+    setMimoVoiceId(String(extra.voice_id ?? "冰糖"));
   };
 
   const handleSaveProvider = async () => {
@@ -155,6 +155,15 @@ export function VoiceSettingsPanel() {
         active.stt === "browser"
       ) {
         const next = await voiceApi.setActive({ stt: preset.id });
+        setActive(next);
+        invalidateVoiceConfigCache();
+      }
+      if (
+        preset.kind !== "browser" &&
+        (preset.capability === "tts" || preset.capability === "both") &&
+        active.tts === "browser"
+      ) {
+        const next = await voiceApi.setActive({ tts: preset.id });
         setActive(next);
         invalidateVoiceConfigCache();
       }
@@ -407,7 +416,6 @@ export function VoiceSettingsPanel() {
                   value={mimoVoiceId}
                   onChange={(v) => setMimoVoiceId(v)}
                   options={[
-                    { value: "mimo_default", label: "MiMo Default" },
                     { value: "冰糖", label: "冰糖 (中文·女)" },
                     { value: "茉莉", label: "茉莉 (中文·女)" },
                     { value: "苏打", label: "苏打 (中文·男)" },

--- a/dashboard/src/utils/wavStreamPlayer.test.ts
+++ b/dashboard/src/utils/wavStreamPlayer.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+
+import { parseWavHeader, pcm16ToFloat32 } from "./wavStreamPlayer";
+
+function wavHeaderBytes(
+  sampleRate = 24000,
+  channels = 1,
+  dataLen = 8,
+): Uint8Array {
+  const bytes = new Uint8Array(44);
+  const dv = new DataView(bytes.buffer);
+  const ascii = (offset: number, s: string) => {
+    for (let i = 0; i < s.length; i++) bytes[offset + i] = s.charCodeAt(i);
+  };
+  ascii(0, "RIFF");
+  dv.setUint32(4, 36 + dataLen, true);
+  ascii(8, "WAVE");
+  ascii(12, "fmt ");
+  dv.setUint32(16, 16, true);
+  dv.setUint16(20, 1, true); // PCM
+  dv.setUint16(22, channels, true);
+  dv.setUint32(24, sampleRate, true);
+  dv.setUint32(28, sampleRate * channels * 2, true);
+  dv.setUint16(32, channels * 2, true);
+  dv.setUint16(34, 16, true);
+  ascii(36, "data");
+  dv.setUint32(40, dataLen, true);
+  return bytes;
+}
+
+describe("parseWavHeader", () => {
+  it("parses a canonical 44-byte PCM header", () => {
+    const fmt = parseWavHeader(wavHeaderBytes());
+    expect(fmt).not.toBeNull();
+    expect(fmt?.sampleRate).toBe(24000);
+    expect(fmt?.channels).toBe(1);
+    expect(fmt?.bitsPerSample).toBe(16);
+    expect(fmt?.headerLength).toBe(44);
+  });
+
+  it("rejects short buffers", () => {
+    expect(parseWavHeader(new Uint8Array(10))).toBeNull();
+  });
+
+  it("rejects non-WAV payloads", () => {
+    const mp3 = new TextEncoder().encode(
+      "ID3SOMEDATASOMEDATASOMEDATASOMEDATASOMED",
+    );
+    expect(parseWavHeader(mp3)).toBeNull();
+  });
+});
+
+describe("pcm16ToFloat32", () => {
+  it("decodes little-endian int16 to [-1, 1] floats", () => {
+    const bytes = new Uint8Array([0x00, 0x00, 0x00, 0x80, 0x00, 0x7f]);
+    const out = pcm16ToFloat32(bytes);
+    expect(out).toHaveLength(3);
+    expect(out[0]).toBe(0);
+    expect(out[1]).toBeCloseTo(-1);
+    expect(out[2]).toBeCloseTo(32512 / 32768);
+  });
+
+  it("drops a trailing odd byte", () => {
+    expect(pcm16ToFloat32(new Uint8Array(5))).toHaveLength(2);
+  });
+});
+
+describe("WavStreamPlayer frame buffering (node env without AudioContext)", () => {
+  it("pushing a non-WAV first chunk reports unsupported", async () => {
+    const { WavStreamPlayer } = await import("./wavStreamPlayer");
+    const player = new WavStreamPlayer();
+    const mp3 = new TextEncoder().encode("ID3...");
+    expect(player.push(mp3)).toBe(false);
+  });
+
+  it("validates header and buffers partial frames via push/carry", async () => {
+    const { WavStreamPlayer } = await import("./wavStreamPlayer");
+    const player = new WavStreamPlayer();
+    // No AudioContext in node — push() should still parse the header and
+    // buffer partial frames without throwing.
+    const header = wavHeaderBytes();
+    const odd = new Uint8Array(3);
+    expect(player.push(header)).toBe(true);
+    expect(player.push(odd)).toBe(true);
+    expect(player.hasAudio).toBe(false);
+    expect(player.push(new Uint8Array(1))).toBe(true);
+    // hasAudio stays false in node (no context to schedule on).
+    player.stop();
+  });
+});

--- a/dashboard/src/utils/wavStreamPlayer.ts
+++ b/dashboard/src/utils/wavStreamPlayer.ts
@@ -1,0 +1,190 @@
+/**
+ * Incremental WAV/PCM playback for streaming TTS responses.
+ *
+ * The server streams MiMo TTS as a WAV (24kHz PCM16LE mono) whose data-size
+ * field is a max-size sentinel — a blob/<audio> player would have to wait for
+ * the full body. Here we parse the header once, decode incoming PCM chunks,
+ * and schedule them back-to-back on an AudioContext as they arrive.
+ */
+
+export interface WavFormat {
+  channels: number;
+  sampleRate: number;
+  bitsPerSample: number;
+  headerLength: number;
+}
+
+/** Parse the canonical 44-byte PCM WAV header the voice router emits. */
+export function parseWavHeader(bytes: Uint8Array): WavFormat | null {
+  if (bytes.length < 44) return null;
+  const dv = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const tag = (offset: number) =>
+    String.fromCharCode(
+      bytes[offset],
+      bytes[offset + 1],
+      bytes[offset + 2],
+      bytes[offset + 3],
+    );
+  if (tag(0) !== "RIFF" || tag(8) !== "WAVE" || tag(36) !== "data") return null;
+  const channels = dv.getUint16(22, true);
+  const sampleRate = dv.getUint32(24, true);
+  const bitsPerSample = dv.getUint16(34, true);
+  if (bitsPerSample !== 16 || channels < 1) return null;
+  return { channels, sampleRate, bitsPerSample, headerLength: 44 };
+}
+
+/** Convert little-endian PCM16 bytes to normalized float samples. */
+export function pcm16ToFloat32(bytes: Uint8Array): Float32Array {
+  const frames = Math.floor(bytes.length / 2);
+  const out = new Float32Array(frames);
+  const dv = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  for (let i = 0; i < frames; i++) {
+    out[i] = dv.getInt16(i * 2, true) / 32768;
+  }
+  return out;
+}
+
+type AudioContextCtor = typeof AudioContext;
+
+function audioContextCtor(): AudioContextCtor | null {
+  if (typeof window === "undefined") return null;
+  return (
+    window.AudioContext ||
+    (window as unknown as { webkitAudioContext?: AudioContextCtor })
+      .webkitAudioContext ||
+    null
+  );
+}
+
+/** True when the environment can do WebAudio streaming playback. */
+export function supportsWavStreamPlayback(): boolean {
+  return audioContextCtor() !== null && typeof ReadableStream !== "undefined";
+}
+
+/**
+ * Schedules PCM chunks on an AudioContext with gapless back-to-back timing.
+ * Supports the mono/stereo PCM16 formats the TTS route produces.
+ */
+export class WavStreamPlayer {
+  private ctx: AudioContext | null = null;
+  private nextStart = 0;
+  private sources = new Set<AudioBufferSourceNode>();
+  private headerConsumed = false;
+  private bytesScheduled = 0;
+  private carry: Uint8Array = new Uint8Array(0);
+
+  get hasAudio(): boolean {
+    return this.bytesScheduled > 0;
+  }
+
+  /** Create/resume the AudioContext (call inside the user-gesture task). */
+  ensureContext(): boolean {
+    const Ctor = audioContextCtor();
+    if (!Ctor) return false;
+    if (!this.ctx) this.ctx = new Ctor();
+    if (this.ctx.state === "suspended") {
+      void this.ctx.resume().catch(() => {});
+    }
+    return true;
+  }
+
+  /**
+   * Feed one raw HTTP response chunk. Strips the WAV header on the first
+   * call, re-buffers partial frames, and schedules complete frames.
+   * Returns false when the stream is not a supported WAV (nothing played).
+   */
+  push(chunk: Uint8Array): boolean {
+    let data = this.carry.length
+      ? concatBytes(this.carry, chunk)
+      : chunk.slice();
+    this.carry = new Uint8Array(0);
+    if (!this.headerConsumed) {
+      const fmt = parseWavHeader(data);
+      if (!fmt) return false;
+      this.fmt = fmt;
+      data = data.subarray(fmt.headerLength);
+      this.headerConsumed = true;
+    }
+    const fmt = this.fmt;
+    if (!fmt) return false;
+    const frameBytes = fmt.channels * (fmt.bitsPerSample / 8);
+    const whole = Math.floor(data.length / frameBytes) * frameBytes;
+    if (whole > 0) this.schedule(data.subarray(0, whole));
+    if (whole < data.length) this.carry = data.slice(whole);
+    return true;
+  }
+
+  private fmt: WavFormat | null = null;
+
+  private schedule(pcm: Uint8Array): void {
+    const ctx = this.ctx;
+    const fmt = this.fmt;
+    if (!ctx || !fmt) return;
+    const samples = pcm16ToFloat32(pcm);
+    const perChannel = Math.floor(samples.length / fmt.channels);
+    if (perChannel === 0) return;
+    const buffer = ctx.createBuffer(fmt.channels, perChannel, fmt.sampleRate);
+    if (fmt.channels === 1) {
+      buffer.copyToChannel(samples, 0);
+    } else {
+      for (let ch = 0; ch < fmt.channels; ch++) {
+        const channelData = new Float32Array(perChannel);
+        for (let i = 0; i < perChannel; i++) {
+          channelData[i] = samples[i * fmt.channels + ch];
+        }
+        buffer.copyToChannel(channelData, ch);
+      }
+    }
+    const src = ctx.createBufferSource();
+    src.buffer = buffer;
+    src.connect(ctx.destination);
+    const startAt = Math.max(ctx.currentTime + 0.02, this.nextStart);
+    src.start(startAt);
+    this.nextStart = startAt + buffer.duration;
+    this.sources.add(src);
+    this.bytesScheduled += pcm.length;
+    src.onended = () => {
+      this.sources.delete(src);
+    };
+  }
+
+  /** Milliseconds until every scheduled chunk has finished playing. */
+  msRemaining(): number {
+    if (!this.ctx || this.bytesScheduled === 0) return 0;
+    return Math.max(0, (this.nextStart - this.ctx.currentTime) * 1000);
+  }
+
+  /** Stop immediately; pending and queued audio are dropped. */
+  stop(): void {
+    for (const src of this.sources) {
+      try {
+        src.stop();
+      } catch {
+        /* already stopped */
+      }
+    }
+    this.sources.clear();
+    const ctx = this.ctx;
+    this.close();
+    if (ctx && ctx.state !== "closed") {
+      void ctx.close().catch(() => {
+        /* ignore close failures */
+      });
+    }
+  }
+
+  /** Release the AudioContext (keeps it usable until closed). */
+  close(): void {
+    this.ctx = null;
+    this.fmt = null;
+    this.headerConsumed = false;
+    this.carry = new Uint8Array(0);
+  }
+}
+
+function concatBytes(a: Uint8Array, b: Uint8Array): Uint8Array {
+  const out = new Uint8Array(a.length + b.length);
+  out.set(a, 0);
+  out.set(b, a.length);
+  return out;
+}

--- a/src/octop/api/routers/voice.py
+++ b/src/octop/api/routers/voice.py
@@ -143,7 +143,8 @@ async def synthesize_speech(
         ):
             yield chunk
 
-    return StreamingResponse(_stream(), media_type="audio/mpeg")
+    # Mimo streams a live WAV (24kHz PCM16LE); other providers stream MP3.
+    return StreamingResponse(_stream(), media_type=mgr.media_type(body.provider))
 
 
 @admin_router.get("")

--- a/src/octop/infra/voice/adapters.py
+++ b/src/octop/infra/voice/adapters.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import base64
+import json
+import struct
 import uuid
 from collections.abc import AsyncIterator
 from dataclasses import dataclass
@@ -243,6 +245,52 @@ async def _guard_mimo_base_url(base_url: str) -> None:
     await validate_https_url_resolved(base_url)
 
 
+# Mimo preset voices (docs: preset voice names; "mimo_default" is not one).
+MIMO_PRESET_VOICES = ("冰糖", "茉莉", "苏打", "白桦", "Mia", "Chloe", "Milo", "Dean")
+
+# WAV header for raw Mimo streaming output: 24kHz PCM16LE mono.
+_MIMO_WAV_SAMPLE_RATE = 24000
+
+
+def _wav_header(data_len: int, sample_rate: int = _MIMO_WAV_SAMPLE_RATE) -> bytes:
+    """Minimal canonical WAV header for PCM16LE mono audio.
+
+    ``data_len`` is clamped to uint32 range; streaming callers pass a max-size
+    sentinel (players that trust it simply read until the body ends).
+    """
+    data = min(data_len, 0xFFFF_FFFF)
+    riff = min(36 + data, 0xFFFF_FFFF)
+    byte_rate = sample_rate * 2
+    return struct.pack(
+        "<4sI4s4sIHHIIHH4sI",
+        b"RIFF",
+        riff,
+        b"WAVE",
+        b"fmt ",
+        16,
+        1,  # PCM
+        1,  # mono
+        sample_rate,
+        byte_rate,
+        2,  # block align
+        16,  # bits per sample
+        b"data",
+        data,
+    )
+
+
+def _normalize_mimo_voice(voice: str | None) -> str:
+    """Map config values onto Mimo preset voice names.
+
+    "mimo_default" (a legacy default from an earlier docs revision) is not a
+    valid preset voice; fall back to 冰糖 (the documented default for the
+    China cluster) so existing configs keep working.
+    """
+    if not voice or voice == "mimo_default":
+        return "冰糖"
+    return voice
+
+
 def _mimo_audio_mime(mime: str) -> str:
     """Normalize incoming mime to a Mimo-supported format (wav or mp3)."""
     lowered = mime.lower()
@@ -320,7 +368,7 @@ async def synthesize_mimo(
     base_url = (row.base_url or "https://api.xiaomimimo.com/v1").rstrip("/")
     await _guard_mimo_base_url(base_url)
     extra = row.get_extra()
-    voice = voice_id or str(extra.get("voice_id") or "mimo_default")
+    voice = _normalize_mimo_voice(voice_id or str(extra.get("voice_id") or "") or None)
     # Mimo TTS: text goes in assistant message, optional style in user message.
     # Speed is not a direct API parameter; ignored for stability.
     payload: dict[str, Any] = {
@@ -329,26 +377,54 @@ async def synthesize_mimo(
             {"role": "user", "content": "Speak naturally."},
             {"role": "assistant", "content": text},
         ],
-        "audio": {"format": "wav", "voice": voice},
+        "audio": {"format": "pcm16", "voice": voice},
+        "stream": True,
     }
-    async with httpx.AsyncClient(timeout=120.0) as client:
-        resp = await client.post(
+    # Low-latency streaming: request pcm16 chunks (24kHz PCM16LE mono) and
+    # wrap them in a WAV container on the fly so standard players work.
+    yield _wav_header(0xFFFF_FFFF)  # unknown length → max data size sentinel
+    async with (
+        httpx.AsyncClient(timeout=120.0) as client,
+        client.stream(
+            "POST",
             f"{base_url}/chat/completions",
             headers={
                 "Authorization": f"Bearer {api_key}",
                 "Content-Type": "application/json",
+                "Accept": "text/event-stream",
             },
             json=payload,
-        )
+        ) as resp,
+    ):
         resp.raise_for_status()
-        body = resp.json()
-    choices = body.get("choices") or []
-    if not choices:
-        raise RuntimeError("Mimo TTS returned no choices")
-    audio_data = choices[0].get("message", {}).get("audio", {}).get("data")
-    if not audio_data:
-        raise RuntimeError("Mimo TTS returned no audio data")
-    yield base64.b64decode(audio_data)
+        buf = ""
+        async for line in resp.aiter_lines():
+            if not line.startswith("data:"):
+                # Blank line terminates an SSE event; other lines are ignored.
+                if not line.strip():
+                    buf = ""
+                continue
+            buf += line[len("data:") :]
+            if buf.strip() == "[DONE]":
+                break
+            try:
+                event = json.loads(buf)
+            except json.JSONDecodeError:
+                continue  # JSON event may span multiple data lines.
+            buf = ""
+            choices = event.get("choices") or []
+            if not choices:
+                continue
+            delta = choices[0].get("delta") or {}
+            audio = delta.get("audio")
+            if not audio:
+                continue
+            data = audio.get("data")
+            if not data:
+                continue
+            pcm = base64.b64decode(data)
+            if pcm:
+                yield pcm
 
 
 async def test_stt(row: VoiceProviderRow | None, kind: str) -> dict[str, Any]:

--- a/src/octop/infra/voice/manager.py
+++ b/src/octop/infra/voice/manager.py
@@ -83,6 +83,12 @@ class VoiceManager:
             )
         return ResolvedVoiceProvider(name=row.name, kind=row.kind, row=row)
 
+    def media_type(self, provider_name: str | None) -> str:
+        """HTTP content type of the synthesize() stream for the given provider."""
+        name = provider_name or self.get_active()["tts"]
+        kind = self.resolve(name).kind
+        return "audio/wav" if kind == "mimo" else "audio/mpeg"
+
     async def transcribe(
         self,
         audio: bytes,

--- a/tests/unit/api/test_voice_mimo.py
+++ b/tests/unit/api/test_voice_mimo.py
@@ -1,0 +1,209 @@
+"""Unit tests for Mimo voice adapters (voice normalization + streaming TTS)."""
+
+from __future__ import annotations
+
+import base64
+import json
+from collections.abc import AsyncIterator
+from typing import Any
+
+import httpx
+import pytest
+
+import octop.infra.voice.adapters as voice_adapters
+from octop.infra.db.repos.voice_providers import VoiceProviderRow
+from octop.infra.voice.adapters import (
+    MIMO_PRESET_VOICES,
+    _normalize_mimo_voice,
+    _wav_header,
+    synthesize_mimo,
+)
+
+
+@pytest.fixture(autouse=True)
+def _skip_mimo_url_guard(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _fake_guard(_base_url: str) -> None:
+        return None
+
+    monkeypatch.setattr(voice_adapters, "_guard_mimo_base_url", _fake_guard)
+
+
+def _mimo_row(*, extra: dict[str, Any] | None = None) -> VoiceProviderRow:
+    return VoiceProviderRow(
+        id=1,
+        name="mimo-tts",
+        kind="mimo",
+        capability="tts",
+        base_url="https://api.xiaomimimo.com/v1",
+        api_key="sk-test",
+        extra_json=json.dumps(extra) if extra else None,
+        note=None,
+        enabled=1,
+        created_at=0,
+        updated_at=0,
+    )
+
+
+def _sse(*events: dict[str, Any]) -> bytes:
+    out = []
+    for event in events:
+        payload = json.dumps(event)
+        # Split each payload across two data lines to exercise multi-line joins.
+        mid = len(payload) // 2
+        out.append(f"data:{payload[:mid]}\n".encode())
+        out.append(f"data:{payload[mid:]}\n\n".encode())
+    out.append(b"data: [DONE]\n\n")
+    return b"".join(out)
+
+
+def _audio_event(pcm: bytes) -> dict[str, Any]:
+    return {"choices": [{"delta": {"audio": {"data": base64.b64encode(pcm).decode("ascii")}}}]}
+
+
+@pytest.fixture
+def mock_mimo_http(monkeypatch: pytest.MonkeyPatch) -> Any:
+    """Install an httpx.MockTransport-backed AsyncClient inside adapters."""
+
+    def install(handler: Any) -> None:
+        original = httpx.AsyncClient
+
+        def factory(**kwargs: Any) -> httpx.AsyncClient:
+            kwargs["transport"] = httpx.MockTransport(handler)
+            return original(**kwargs)
+
+        monkeypatch.setattr(voice_adapters.httpx, "AsyncClient", factory)
+
+    return install
+
+
+class TestNormalizeMimoVoice:
+    def test_legacy_default_maps_to_preset_voice(self) -> None:
+        assert _normalize_mimo_voice("mimo_default") == "冰糖"
+
+    def test_empty_falls_back_to_preset_voice(self) -> None:
+        assert _normalize_mimo_voice("") == "冰糖"
+        assert _normalize_mimo_voice(None) == "冰糖"
+
+    def test_preset_voices_pass_through(self) -> None:
+        for voice in MIMO_PRESET_VOICES:
+            assert _normalize_mimo_voice(voice) == voice
+
+
+class TestWavHeader:
+    def test_header_is_pcm16_mono_24k(self) -> None:
+        header = _wav_header(8)
+        assert len(header) == 44
+        assert header[0:4] == b"RIFF"
+        assert header[8:12] == b"WAVE"
+        assert header[36:40] == b"data"
+        assert int.from_bytes(header[4:8], "little") == 36 + 8
+        assert int.from_bytes(header[40:44], "little") == 8
+        assert int.from_bytes(header[22:24], "little") == 1  # mono
+        assert int.from_bytes(header[24:28], "little") == 24000
+        assert int.from_bytes(header[34:36], "little") == 16  # bits
+
+    def test_streaming_sentinel_does_not_overflow(self) -> None:
+        header = _wav_header(0xFFFF_FFFF)
+        assert len(header) == 44
+        assert int.from_bytes(header[40:44], "little") == 0xFFFF_FFFF
+
+
+class TestMimoTTSStreaming:
+    async def test_streams_pcm_chunks_wrapped_in_wav(self, mock_mimo_http: Any) -> None:
+        pcm_chunks = [b"\x01\x02" * 10, b"\x03\x04" * 6]
+        requests: list[dict[str, Any]] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            requests.append(json.loads(request.content.decode("utf-8")))
+            return httpx.Response(
+                200,
+                headers={"content-type": "text/event-stream"},
+                content=_sse(*[_audio_event(p) for p in pcm_chunks]),
+            )
+
+        mock_mimo_http(handler)
+        out = b"".join(
+            [
+                chunk
+                async for chunk in synthesize_mimo(_mimo_row(), "你好", voice_id=None, speed=1.0)
+            ]
+        )
+        assert out[:44] == _wav_header(0xFFFF_FFFF)
+        assert out[44:] == b"".join(pcm_chunks)
+
+    async def test_request_uses_streaming_pcm16_and_normalized_voice(
+        self, mock_mimo_http: Any
+    ) -> None:
+        requests: list[dict[str, Any]] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            requests.append(json.loads(request.content.decode("utf-8")))
+            return httpx.Response(
+                200,
+                headers={"content-type": "text/event-stream"},
+                content=_sse(_audio_event(b"\x00\x01")),
+            )
+
+        mock_mimo_http(handler)
+        async for _ in synthesize_mimo(
+            _mimo_row(extra={"voice_id": "mimo_default"}), "hi", voice_id=None, speed=1.0
+        ):
+            pass
+        assert requests, "handler must capture the outbound request"
+        body = requests[0]
+        assert body["stream"] is True
+        assert body["audio"]["format"] == "pcm16"
+        assert body["audio"]["voice"] == "冰糖"
+        # TTS text rides in the assistant message per Mimo docs.
+        assert body["messages"][1]["role"] == "assistant"
+        assert body["messages"][1]["content"] == "hi"
+
+    async def test_multiline_json_without_done_marker_is_ignored(self, mock_mimo_http: Any) -> None:
+        # A truncated event followed by [DONE] must not raise.
+        def handler(_request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                headers={"content-type": "text/event-stream"},
+                content=b'data:{"choices":\ndata: [DONE]\n\n',
+            )
+
+        mock_mimo_http(handler)
+        out = b"".join(
+            [chunk async for chunk in synthesize_mimo(_mimo_row(), "x", voice_id=None, speed=1.0)]
+        )
+        assert out == _wav_header(0xFFFF_FFFF)  # header only, no audio
+
+    async def test_extra_voice_id_from_config_is_used(self, mock_mimo_http: Any) -> None:
+        requests: list[dict[str, Any]] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            requests.append(json.loads(request.content.decode("utf-8")))
+            return httpx.Response(
+                200,
+                headers={"content-type": "text/event-stream"},
+                content=_sse(_audio_event(b"\x00\x01")),
+            )
+
+        mock_mimo_http(handler)
+        async for _ in synthesize_mimo(
+            _mimo_row(extra={"voice_id": "Chloe"}), "hi", voice_id=None, speed=1.0
+        ):
+            pass
+        assert requests[0]["audio"]["voice"] == "Chloe"
+
+
+class TestMimoTTSStreamingYieldsNothingOnEmpty:
+    async def test_done_only_stream_yields_header_only(self, mock_mimo_http: Any) -> None:
+        def handler(_request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                headers={"content-type": "text/event-stream"},
+                content=b"data: [DONE]\n\n",
+            )
+
+        mock_mimo_http(handler)
+        chunks: list[bytes] = []
+        stream: AsyncIterator[bytes] = synthesize_mimo(_mimo_row(), "x", voice_id=None, speed=1.0)
+        async for chunk in stream:
+            chunks.append(chunk)
+        assert chunks == [_wav_header(0xFFFF_FFFF)]


### PR DESCRIPTION
## Summary

### 问题与修复

1. **TTS 配置后未自动设为当前**：STT 配置完成后会自动激活，TTS 却不会，
   行为不对称。现与 STT 对齐——配置 TTS 提供商后，若当前仍为 browser 则自动切换。

2. **无效音色 mimo_default**：该 ID 并非官方预置音色（V2 时代概念，V2.5 已按
   集群映射为冰糖/Mia），实际请求会报 invalid voice。UI 下拉框已移除并默认
   「冰糖」；后端将存量 mimo_default 配置自动映射为冰糖，旧配置无需改动。

3. **MiMo TTS 需等待整段合成完才出声**：原实现为非流式请求 + 前端整包缓冲，
   长文本延迟数秒。现全链路流式：
   - 后端按文档要求以 pcm16 + stream 请求，实时解析 SSE 音频块并封装为
     流式 WAV（24kHz PCM16LE 单声道）
   - 路由按 provider 返回正确的 Content-Type（mimo→audio/wav）
   - 前端新增流式 fetch 与 WebAudio 播放器，首块到达即出声；
     非 WAV 提供商自动回落原缓冲路径，OpenAI/腾讯云/Edge 行为不变

### 测试

- 新增后端单测（音色归一化、WAV 头、SSE 多行 JSON 拼接、流式输出）
- 新增前端单测（WAV 头解析、PCM16 解码、半帧缓冲）
- 后端 174 个单测通过；前端 tsc / vitest / eslint / prettier 全绿
- 已对接 MiMo 线上 API 实测流式播放延迟


## Target branch

- [ ] Base is **`develop`** (feature / fix — default)
- [ ] Base is **`main`** (`release/*` or `hotfix/*` only)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / chore
- [ ] Release / hotfix

## Test plan

<!-- How did you verify this? Include commands run (e.g. `make all`). -->

- [ ] `make all` passes locally
- [ ] Added/updated tests

## Checklist

- [ ] Updated `CHANGELOG.md` (if user-facing)
- [ ] README / docs updated (if needed)
