### PR TITLE
fix(dashboard): move update progress/result prompts above release notes

### DIFF
--- a/dashboard/src/pages/Settings/AdvancedSettings/UpdateConfig.tsx
+++ b/dashboard/src/pages/Settings/AdvancedSettings/UpdateConfig.tsx
@@ -366,20 +366,6 @@ export default function UpdateConfig() {
             )}
           </div>
 
-          {status?.has_update && status.release_notes && (
-            <Collapse
-              className={styles.releaseNotes}
-              defaultActiveKey={["changelog"]}
-              items={[
-                {
-                  key: "changelog",
-                  label: t("advancedSettings.update.releaseNotes"),
-                  children: <Markdown content={status.release_notes} />,
-                },
-              ]}
-            />
-          )}
-
           {progress && (
             <div className={styles.progressSection}>
               {progress.status === "running" && (
@@ -454,6 +440,20 @@ export default function UpdateConfig() {
                 </div>
               )}
             </div>
+          )}
+
+          {status?.has_update && status.release_notes && (
+            <Collapse
+              className={styles.releaseNotes}
+              defaultActiveKey={["changelog"]}
+              items={[
+                {
+                  key: "changelog",
+                  label: t("advancedSettings.update.releaseNotes"),
+                  children: <Markdown content={status.release_notes} />,
+                },
+              ]}
+            />
           )}
         </section>
 


### PR DESCRIPTION

## Summary

The upgrade progress bar and the "upgrade complete / restart required" prompts rendered below the (default-expanded) release notes collapse, pushing them out of the viewport with no visible cue — easy to miss.

Reorder the panel: progress / result prompts now render directly under the action buttons (check / restart / upgrade), above the release notes. No logic changes; the two blocks are independent (both use margin-top).

升级进度条和“升级完成/需要重启”提示在（默认展开的）版本说明下方渲染，随后折叠，将它们推出窗口且没有任何可见提示——很容易被忽略。

重新排序面板：进度/结果提示现在直接渲染在操作按钮（检查/重启/升级）下方、版本说明上方。无逻辑更改；这两个区块相互独立（均使用 margin-top）。

## Target branch

- [ ] Base is **`develop`** (feature / fix — default)
- [ ] Base is **`main`** (`release/*` or `hotfix/*` only)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / chore
- [ ] Release / hotfix

## Test plan

<!-- How did you verify this? Include commands run (e.g. `make all`). -->

- [ ] `make all` passes locally
- [ ] Added/updated tests

## Checklist

- [ ] Updated `CHANGELOG.md` (if user-facing)
- [ ] README / docs updated (if needed)
