### PR TITLE
fix: inject Admin env into running agents and sum turn token usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 
 ### 修复
 
+- Admin 环境变量未进入正在运行的 Agent：本地 shell 默认不继承进程 env，Docker exec 也不传 env，工作区 `.env` 只落盘不注入。现本地 shell 每次 execute 继承当前进程环境（含 `~/.octop/env`）并 overlay 工作区 `.env`；Docker 热读全局文件 + 工作区 `.env` + 最小 PATH（不含完整宿主机环境）。保存 Admin 列表会从进程环境删除已去掉的键；仅搜索类 key 变化时后台 reload Agent。MCP stdio 只注入 SDK 安全子集 + 全局/连接器 env，不再灌入整份 `os.environ`。
+- Token 用量账本每轮只记下最后一次模型调用，工具循环中前面若干次调用被丢弃，页面合计会远低于聊天里看到的用量；现按该轮全部 AI 调用的 `usage_metadata` 累加，以 `state_snapshot` 为权威终值（snapshot 之后的增量不再相加），畸形 usage 字段跳过以免打断对话
+- 工作区读写在 harness 后台重建窗口（DB 仍为 running）回退到 `workspace_for_agent`，避免误报 `AGENT_NOT_RUNNING`
 - 插件工具使用中文等非 ASCII 名称时 LLM 调用失败：主流 API 要求工具名匹配 `^[a-zA-Z0-9_-]{1,64}$`，现自动将非法名称转写为合法拼音名（`pypinyin` 缺失时退回下划线替换），冲突追加 `_2`/`_3` 后缀，并在工具描述前缀 `[原名: …]` 保留原名映射；`config_json.plugins` 配置键与插件内部仍使用原始名称，路由不受影响
 - 修复聊天页在"生成中"时于输入框持续打字导致消息列表上下轻微抖动的问题：输入框高度测量改为在离屏克隆节点上进行，不再瞬态改变页面布局
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -22,9 +22,27 @@ on first server start (or by `octop init` / `octop run`).
 ```
 
 `env` is dotenv format, applied before `config.json` is loaded
-(`OctopServer.start` → `apply_env_file`). Useful when process env is hard
-to set (e.g. Docker volume) without editing Compose. Dashboard
-**Environments** and some tools also read/write this file.
+(`OctopServer.start` → `apply_env_file`). Dashboard **Advanced → Environment
+variables** writes this file. Saving **replaces** the file and drops removed
+keys from the process environment (host/systemd keys that were never in the
+file are left alone). Every running agent inherits those keys:
+
+- **Local shell** — live process env (including this file) plus the agent's
+  workspace `.env` (workspace wins on the same key; `OCTOP_*` / `HOME` / `USER`
+  cannot be overridden from `.env`). Remote object-store workspaces are not
+  read here — `.env` must be on the host workspace path used for execute.
+- **Docker sandbox** — re-reads `~/.octop/env` on execute, plus workspace `.env`
+  and a minimal `PATH` (not the full host environment). Admin `PATH`/`HOME`
+  cannot override the container toolchain; workspace `.env` may set `PATH`.
+- **Web search tools** (Tavily, Brave, …) register at agent start from process
+  env. Changing those keys rebuilds agents in the background; other keys do not.
+  Put search API keys in the global file, not only in an agent's `.env`.
+- **MCP stdio** inherits the MCP SDK safe subset plus Admin keys (and the
+  connector's own `env`). Already-connected MCP servers keep their spawn env
+  until the agent is reloaded.
+
+Per-agent secrets belong in `{workspace}/.env` (also writable via the
+`write_env_file` tool). That file is excluded from published-expert snapshots.
 
 The root can be overridden with `OCTOP_HOME` (absolute path). Most
 sub-paths are exposed as properties on `PathLayout` in

--- a/src/octop/api/common/workspace.py
+++ b/src/octop/api/common/workspace.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any, cast
 from harness_agent.backends.workspace import BackendWorkspace
 
 from octop.api.common.agent import require_agent_owner_row, require_agent_row
+from octop.infra.errors import ErrorCode, OctopError
 
 if TYPE_CHECKING:
     from harness_agent import HarnessAgent
@@ -41,10 +42,51 @@ async def require_running_workspace(
     server: Any,
     owner_only: bool = False,
 ) -> BackendWorkspace:
-    """Auth-checked :class:`BackendWorkspace` for a running agent."""
+    """Auth-checked :class:`BackendWorkspace` for a running agent.
+
+    PATCH /agents triggers a background ``arebuild_agent`` that briefly
+    removes the live harness handle while the DB row still says ``running``.
+    Workspace file I/O does not need the compiled graph, so during that
+    window we fall back to :meth:`AgentManager.workspace_for_agent`.
+    Stopped / failed agents still raise — the fallback is only for the
+    rebuild gap, not a way to edit a stopped workspace through this helper.
+    """
     checker = require_agent_owner_row if owner_only else require_agent_row
-    checker(agent_id, user=user, as_user=as_user, server=server)
-    return require_running_agent(server, agent_id).workspace
+    row = checker(agent_id, user=user, as_user=as_user, server=server)
+    try:
+        return require_running_agent(server, agent_id).workspace
+    except OctopError as exc:
+        if exc.code is not ErrorCode.AGENT_NOT_RUNNING:
+            raise
+        state = str(getattr(row, "last_state", "") or "").strip().lower()
+        if state != "running":
+            raise
+        assert server.app_runtime is not None
+        fallback = server.app_runtime.agent_registry.workspace_for_agent(agent_id)
+        if fallback is None:
+            raise
+        return cast("BackendWorkspace", fallback)
+
+
+async def require_agent_workspace(
+    agent_id: str,
+    *,
+    user: Any,
+    server: Any,
+    owner_only: bool = False,
+) -> BackendWorkspace:
+    """Auth-checked workspace even when the agent is stopped.
+
+    Used for display files (e.g. expert avatar) that must work from the
+    experts list without requiring a running harness handle.
+    """
+    checker = require_agent_owner_row if owner_only else require_agent_row
+    checker(agent_id, user=user, as_user=None, server=server)
+    assert server.app_runtime is not None
+    workspace = server.app_runtime.agent_registry.workspace_for_agent(agent_id)
+    if workspace is None:
+        raise OctopError(ErrorCode.AGENT_NOT_FOUND, f"agent {agent_id!r} not found")
+    return cast("BackendWorkspace", workspace)
 
 
 def workspace_api_path(raw: str) -> str:

--- a/src/octop/api/routers/envs.py
+++ b/src/octop/api/routers/envs.py
@@ -1,7 +1,9 @@
-"""Environment variables API — backed by ``~/.octop/env``."""
+"""Environment variables API — backed by ``~/.octop/env`` (inherited by all agents)."""
 
 from __future__ import annotations
 
+import asyncio
+import logging
 import os
 import re
 from typing import Any
@@ -11,19 +13,45 @@ from fastapi import APIRouter, Body, Depends
 from octop.api.deps import get_server, require_permission
 from octop.infra.errors import ErrorCode, OctopError
 from octop.infra.utils.env_file import (
-    apply_env_file,
+    apply_env_file_replace,
     env_file_path,
     list_env_items,
     load_env_file,
     save_env_file,
+    search_env_changed,
 )
 
 router = APIRouter(prefix="/envs", tags=["envs"])
+logger = logging.getLogger(__name__)
 
 _KEY_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 
-@router.get("")
+def _after_env_sync(server: Any, previous: dict[str, str], new: dict[str, str]) -> None:
+    """Drop MCP tool cache; rebuild agents only when search-tool keys change."""
+    runtime = getattr(server, "app_runtime", None)
+    registry = getattr(runtime, "agent_registry", None) if runtime is not None else None
+    if registry is None:
+        return
+    invalidate = getattr(registry, "invalidate_mcp_tool_cache", None)
+    if callable(invalidate):
+        invalidate()
+    if not search_env_changed(previous, new):
+        return
+    reload_all = getattr(registry, "reload_all", None)
+    if not callable(reload_all):
+        return
+
+    async def _reload() -> None:
+        try:
+            await reload_all()
+        except Exception:
+            logger.exception("background agent reload after search env change failed")
+
+    asyncio.create_task(_reload(), name="reload-agents-search-env")
+
+
+@router.get("", summary="List global environment variables")
 async def list_envs(
     _: Any = Depends(require_permission("envs")),
     server: Any = Depends(get_server),
@@ -32,7 +60,16 @@ async def list_envs(
     return list_env_items(path)
 
 
-@router.put("")
+@router.put(
+    "",
+    summary="Replace global environment variables",
+    description=(
+        "Overwrite ~/.octop/env and align the Octop process environment "
+        "(including deleting keys removed from the list). Running shells and "
+        "Docker sandboxes pick up keys without a full agent reload. Agents are "
+        "rebuilt in the background only when web-search keys change."
+    ),
+)
 async def batch_save_envs(
     body: dict[str, str] = Body(...),
     _: Any = Depends(require_permission("envs")),
@@ -47,12 +84,18 @@ async def batch_save_envs(
             raise OctopError(ErrorCode.SLASH_BAD_ARGS, f"invalid env key: {k!r}")
         cleaned[k] = str(value)
     path = env_file_path(server.paths.root)
+    previous = load_env_file(path)
     save_env_file(path, cleaned)
-    apply_env_file(path)
+    apply_env_file_replace(path, previous=previous)
+    _after_env_sync(server, previous, cleaned)
     return list_env_items(path)
 
 
-@router.delete("/{key}")
+@router.delete(
+    "/{key}",
+    summary="Delete one global environment variable",
+    description="Remove a key from ~/.octop/env and the process environment.",
+)
 async def delete_env(
     key: str,
     _: Any = Depends(require_permission("envs")),
@@ -62,9 +105,11 @@ async def delete_env(
     if not _KEY_RE.match(k):
         raise OctopError(ErrorCode.SLASH_BAD_ARGS, f"invalid env key: {k!r}")
     path = env_file_path(server.paths.root)
-    values = load_env_file(path)
+    previous = load_env_file(path)
+    values = dict(previous)
     values.pop(k, None)
     save_env_file(path, values)
-    apply_env_file(path)
+    apply_env_file_replace(path, previous=previous)
     os.environ.pop(k, None)
+    _after_env_sync(server, previous, values)
     return list_env_items(path)

--- a/src/octop/infra/agents/manager.py
+++ b/src/octop/infra/agents/manager.py
@@ -29,7 +29,10 @@ from octop.infra.agents.runtime_limits import (
     resolve_context_max_tokens as config_context_max_tokens,
 )
 from octop.infra.agents.security import SecuritySettingsStore, ToolGuardRulesStore
-from octop.infra.backend.docker_spec import enrich_docker_backend_spec
+from octop.infra.backend.docker_spec import (
+    enrich_docker_backend_spec,
+    inject_docker_global_environment,
+)
 from octop.infra.backend.resolver import (
     default_agent_backend_spec,
     resolve_agent_backend_spec,
@@ -1004,7 +1007,14 @@ class AgentManager:
             cached = self._mcp_tool_cache.get(cache_key)
             if cached is not None:
                 return cached
-            raw = await aload_mcp_tools({server_name: spec})
+            from octop.infra.utils.env_file import (  # noqa: PLC0415
+                env_file_path,
+                load_env_file,
+                overlay_stdio_spec_env,
+            )
+
+            load_spec = overlay_stdio_spec_env(spec, load_env_file(env_file_path(self.paths.root)))
+            raw = await aload_mcp_tools({server_name: load_spec})
             server_lock = await self._server_lock(user_id, server_name)
             wrapped = wrap_tools_for_shared_use(raw, server_lock)
             self._mcp_tool_cache[cache_key] = wrapped
@@ -1737,11 +1747,14 @@ class AgentManager:
         """Inject Octop docker defaults (prefix / agent_id / username) without overwrite."""
         if not isinstance(backend, dict) or backend.get("type") != "docker":
             return backend
-        return enrich_docker_backend_spec(
+        from octop.infra.utils.env_file import env_file_path  # noqa: PLC0415
+
+        enriched = enrich_docker_backend_spec(
             backend,
             agent_id=row.agent_id,
             username=self._owner_username(row),
         )
+        return inject_docker_global_environment(enriched, env_file_path(self.paths.root))
 
     def _backend_workspace_for_row(self, row: AgentRow) -> Any:
         """Resolve :class:`BackendWorkspace` for *row* without a running harness agent."""

--- a/src/octop/infra/backend/docker_spec.py
+++ b/src/octop/infra/backend/docker_spec.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any
 
 DEFAULT_SANDBOX_PREFIX = "octop_sandbox"
@@ -16,6 +17,8 @@ _DOCKER_PASSTHROUGH_KEYS = (
     "auto_remove",
     "workspace_path",
     "volumes",
+    "environment",
+    "environment_file",
     "agent_id",
     "container_name",
     "sandbox_scope",
@@ -72,4 +75,17 @@ def enrich_docker_backend_spec(
         out.setdefault("agent_id", agent_id)
     elif scope == "user" and username and not out.get("username"):
         out["username"] = username
+    return out
+
+
+def inject_docker_global_environment(
+    spec: dict[str, Any],
+    env_file: str | Path | None,
+) -> dict[str, Any]:
+    """Point a docker spec at Admin ``~/.octop/env`` (re-read on each execute)."""
+    if str(spec.get("type") or "").lower() != "docker":
+        return spec
+    out = dict(spec)
+    if env_file is not None:
+        out["environment_file"] = str(env_file)
     return out

--- a/src/octop/infra/gateway/process/usage_record.py
+++ b/src/octop/infra/gateway/process/usage_record.py
@@ -6,9 +6,131 @@ import contextlib
 from dataclasses import dataclass, field
 from typing import Any
 
+_USER_ROLES = frozenset({"human", "user"})
+_AI_ROLES = frozenset({"ai", "assistant"})
+
+
+def _msg_role(msg: Any) -> str:
+    if isinstance(msg, dict):
+        return str(msg.get("role") or msg.get("type") or "").lower()
+    raw = getattr(msg, "type", None)
+    if raw:
+        return str(raw).lower()
+    name = type(msg).__name__.lower()
+    if "human" in name:
+        return "human"
+    if "ai" in name:
+        return "ai"
+    return ""
+
+
+def _is_user(msg: Any) -> bool:
+    return _msg_role(msg) in _USER_ROLES
+
+
+def _is_ai(msg: Any) -> bool:
+    return _msg_role(msg) in _AI_ROLES
+
+
+def _msg_usage(msg: Any) -> dict[str, Any] | None:
+    usage = getattr(msg, "usage_metadata", None)
+    if usage is None and isinstance(msg, dict):
+        usage = msg.get("usage_metadata")
+    if isinstance(usage, dict) and usage:
+        return usage
+    return None
+
+
+def _msg_model(msg: Any) -> str:
+    rm = getattr(msg, "response_metadata", None)
+    if rm is None and isinstance(msg, dict):
+        rm = msg.get("response_metadata")
+    if isinstance(rm, dict):
+        return str(rm.get("model_name") or rm.get("model") or "")
+    return ""
+
+
+def _chunk_messages(chunk: dict[str, Any]) -> list[Any]:
+    data = chunk.get("data")
+    if isinstance(data, dict):
+        raw = data.get("messages")
+        return list(raw) if isinstance(raw, list) else []
+    if isinstance(data, list):
+        return data
+    return []
+
+
+def _token_int(value: Any) -> int:
+    """Parse a token count; malformed values must not raise."""
+    if isinstance(value, bool) or value is None:
+        return 0
+    try:
+        n = int(value)
+    except (TypeError, ValueError):
+        return 0
+    return n if n > 0 else 0
+
+
+def _usage_io(usage: dict[str, Any]) -> tuple[int, int]:
+    input_tokens = _token_int(usage.get("input_tokens")) or _token_int(usage.get("prompt_tokens"))
+    output_tokens = _token_int(usage.get("output_tokens")) or _token_int(
+        usage.get("completion_tokens")
+    )
+    return input_tokens, output_tokens
+
+
+def turn_usage_from_messages(messages: list[Any]) -> dict[str, Any] | None:
+    """Sum ``usage_metadata`` on AI messages after the last user message.
+
+    Agent turns make multiple LLM calls (plan → tools → final reply). Each
+    AIMessage carries *that call's* tokens; the ledger must record the sum,
+    not the last call alone.
+    """
+    last_user = -1
+    for i, msg in enumerate(messages):
+        if _is_user(msg):
+            last_user = i
+
+    input_tokens = 0
+    output_tokens = 0
+    model = ""
+    saw = False
+    for msg in messages[last_user + 1 :]:
+        if not _is_ai(msg):
+            continue
+        usage = _msg_usage(msg)
+        if usage is None:
+            continue
+        inp, out = _usage_io(usage)
+        if inp == 0 and out == 0:
+            continue
+        saw = True
+        input_tokens += inp
+        output_tokens += out
+        name = _msg_model(msg)
+        if name:
+            model = name
+    if not saw:
+        return None
+    payload: dict[str, Any] = {
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+        "total_tokens": input_tokens + output_tokens,
+    }
+    if model:
+        payload["model"] = model
+    return payload
+
 
 def extract_usage_from_chunk(chunk: dict[str, Any]) -> dict[str, Any] | None:
-    """Best-effort extraction of usage_metadata from a streaming chunk."""
+    """Best-effort extraction of usage_metadata from a streaming chunk.
+
+    ``state_snapshot`` carries the full thread; usage is the current turn
+    total (every AI call after the last user message). ``state_update``
+    usually carries only new messages — an AI-only list is that call's
+    tokens, while a list that includes a user message is treated as a
+    turn total.
+    """
     if not isinstance(chunk, dict):
         return None
 
@@ -19,40 +141,57 @@ def extract_usage_from_chunk(chunk: dict[str, Any]) -> dict[str, Any] | None:
     if chunk.get("type") not in ("state_snapshot", "state_update"):
         return None
 
-    data = chunk.get("data") or {}
-    messages: list[Any] = []
-    if isinstance(data, dict):
-        messages = list(data.get("messages") or [])
+    messages = _chunk_messages(chunk)
+    if not messages:
+        return None
+    return turn_usage_from_messages(messages)
 
-    for msg in reversed(messages):
-        usage = getattr(msg, "usage_metadata", None)
-        if usage is None and isinstance(msg, dict):
-            usage = msg.get("usage_metadata")
-        if isinstance(usage, dict) and usage:
-            model = ""
-            response_metadata = getattr(msg, "response_metadata", None)
-            if isinstance(response_metadata, dict):
-                model = str(
-                    response_metadata.get("model_name") or response_metadata.get("model") or ""
-                )
-            elif isinstance(msg, dict):
-                rm = msg.get("response_metadata") or {}
-                if isinstance(rm, dict):
-                    model = str(rm.get("model_name") or rm.get("model") or "")
-            return {**usage, "model": model}
-    return None
+
+def _add_usage(base: dict[str, Any] | None, found: dict[str, Any]) -> dict[str, Any]:
+    if base is None:
+        return dict(found)
+    input_tokens = _token_int(base.get("input_tokens")) + _token_int(found.get("input_tokens"))
+    output_tokens = _token_int(base.get("output_tokens")) + _token_int(found.get("output_tokens"))
+    model = str(found.get("model") or base.get("model") or "")
+    return {
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+        "total_tokens": input_tokens + output_tokens,
+        "model": model,
+    }
 
 
 @dataclass
 class UsageTracker:
-    """Collect the latest usage payload seen while iterating a harness stream."""
+    """Collect token usage for one harness stream (one chat turn).
+
+    ``state_snapshot`` is authoritative: each snapshot replaces the total
+    with the full-turn sum. ``state_update`` is only accumulated until the
+    first snapshot, so a replayed AI message after a snapshot cannot
+    double-count.
+    """
 
     usage: dict[str, Any] | None = field(default=None, init=False)
+    _seen_snapshot: bool = field(default=False, init=False)
 
     def observe(self, chunk: dict[str, Any]) -> None:
         found = extract_usage_from_chunk(chunk)
-        if found:
+        if not found or not isinstance(chunk, dict):
+            return
+        if isinstance(chunk.get("usage"), dict):
             self.usage = found
+            return
+        if chunk.get("type") == "state_snapshot":
+            self.usage = found
+            self._seen_snapshot = True
+            return
+        if self._seen_snapshot:
+            return
+        messages = _chunk_messages(chunk)
+        if any(_is_user(m) for m in messages):
+            self.usage = found
+            return
+        self.usage = _add_usage(self.usage, found)
 
 
 def record_turn_usage(
@@ -66,12 +205,13 @@ def record_turn_usage(
 ) -> None:
     """Append one usage row. Best-effort — malformed payloads must not break chat."""
     with contextlib.suppress(Exception):
+        inp, out = _usage_io(usage)
         usage_repo.record(
             agent_id=agent_id,
             user_id=user_id,
             thread_id=thread_id,
             model=str(usage.get("model") or ""),
-            input_tokens=int(usage.get("input_tokens") or usage.get("prompt_tokens") or 0),
-            output_tokens=int(usage.get("output_tokens") or usage.get("completion_tokens") or 0),
+            input_tokens=inp,
+            output_tokens=out,
             source=source,
         )

--- a/src/octop/infra/utils/env_file.py
+++ b/src/octop/infra/utils/env_file.py
@@ -4,9 +4,32 @@ from __future__ import annotations
 
 import os
 import re
+from collections.abc import Mapping
 from pathlib import Path
+from typing import Any
 
 _KEY_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_PROTECTED_EXACT = frozenset(
+    {
+        "HOME",
+        "USER",
+        "USERNAME",
+        "LOGNAME",
+        "SHELL",
+        "PWD",
+    }
+)
+
+# Web-search tools register at agent construction from these keys.
+SEARCH_ENV_KEYS = frozenset(
+    {
+        "TAVILY_API_KEY",
+        "BRAVE_API_KEY",
+        "GOOGLE_API_KEY",
+        "GOOGLE_CSE_ID",
+        "MOONSHOT_API_KEY",
+    }
+)
 
 
 def env_file_path(root: Path) -> Path:
@@ -67,6 +90,38 @@ def apply_env_file(path: Path) -> dict[str, str]:
     for key, value in values.items():
         os.environ[key] = value
     return values
+
+
+def apply_env_file_replace(path: Path, *, previous: Mapping[str, str]) -> dict[str, str]:
+    """Apply the file to ``os.environ`` and drop keys that left the file."""
+    values = load_env_file(path)
+    for key in previous:
+        if key not in values:
+            os.environ.pop(key, None)
+    for key, value in values.items():
+        os.environ[key] = value
+    return values
+
+
+def search_env_changed(previous: Mapping[str, str], new: Mapping[str, str]) -> bool:
+    return any(previous.get(key, "") != new.get(key, "") for key in SEARCH_ENV_KEYS)
+
+
+def _is_protected_env_key(key: str) -> bool:
+    return key in _PROTECTED_EXACT or key.startswith("OCTOP_")
+
+
+def overlay_stdio_spec_env(spec: dict[str, Any], global_env: Mapping[str, str]) -> dict[str, Any]:
+    """Fold Admin env into an MCP stdio spec (spec env wins; skip protected keys)."""
+    if str(spec.get("transport") or "").lower() != "stdio":
+        return spec
+    raw_env = spec.get("env")
+    existing: dict[str, Any] = raw_env if isinstance(raw_env, dict) else {}
+    merged = {str(k): str(v) for k, v in global_env.items() if not _is_protected_env_key(str(k))}
+    merged.update({str(k): str(v) for k, v in existing.items()})
+    out = dict(spec)
+    out["env"] = merged
+    return out
 
 
 def list_env_items(path: Path) -> list[dict[str, str]]:

--- a/tests/integration/test_envs_api.py
+++ b/tests/integration/test_envs_api.py
@@ -25,6 +25,19 @@ async def test_envs_crud_cycle(env: Any) -> None:
     assert {row["key"] for row in r.json()} == {"TAVILY_API_KEY"}
 
 
+async def test_envs_put_unsets_removed_process_keys(env: Any) -> None:
+    import os
+
+    c, _srv, auth = env
+    r = await c.put("/api/envs", headers=auth, json={"GONE": "1", "KEEP": "2"})
+    assert r.status_code == 200
+    assert os.environ.get("GONE") == "1"
+    r = await c.put("/api/envs", headers=auth, json={"KEEP": "2"})
+    assert r.status_code == 200
+    assert "GONE" not in os.environ
+    assert os.environ.get("KEEP") == "2"
+
+
 async def test_envs_non_admin_forbidden(env: Any) -> None:
     c, _srv, admin_auth = env
     await c.post(

--- a/tests/integration/test_usage_api.py
+++ b/tests/integration/test_usage_api.py
@@ -207,6 +207,33 @@ def test_extract_usage_from_state_snapshot_dict_message() -> None:
     assert out["model"] == "openai:gpt-4o-mini"
 
 
+def test_extract_usage_from_state_snapshot_sums_turn_calls() -> None:
+    from octop.api.routers.chat.turn import extract_usage_from_chunk as _extract_usage_from_chunk
+
+    chunk = {
+        "type": "state_snapshot",
+        "data": {
+            "messages": [
+                {"role": "user", "content": "hi"},
+                {
+                    "role": "assistant",
+                    "usage_metadata": {"input_tokens": 100, "output_tokens": 10},
+                },
+                {
+                    "role": "assistant",
+                    "usage_metadata": {"input_tokens": 200, "output_tokens": 20},
+                    "response_metadata": {"model_name": "openai:gpt-4o-mini"},
+                },
+            ],
+        },
+    }
+    out = _extract_usage_from_chunk(chunk)
+    assert out is not None
+    assert out["input_tokens"] == 300
+    assert out["output_tokens"] == 30
+    assert out["model"] == "openai:gpt-4o-mini"
+
+
 def test_extract_usage_returns_none_when_absent() -> None:
     from octop.api.routers.chat.turn import extract_usage_from_chunk as _extract_usage_from_chunk
 

--- a/tests/unit/agents/test_mcp_tool_cache.py
+++ b/tests/unit/agents/test_mcp_tool_cache.py
@@ -82,6 +82,7 @@ async def test_get_or_load_caches_and_reuses() -> None:
     mgr._mcp_tool_cache = {}
     mgr._mcp_tool_cache_locks = {}
     mgr._mcp_tool_cache_guard = asyncio.Lock()
+    mgr._paths = MagicMock(root=MagicMock())
 
     fake = MagicMock()
     fake.name = "s_tool1"
@@ -110,6 +111,7 @@ async def test_get_or_load_misses_on_fingerprint_change() -> None:
     mgr._mcp_tool_cache = {}
     mgr._mcp_tool_cache_locks = {}
     mgr._mcp_tool_cache_guard = asyncio.Lock()
+    mgr._paths = MagicMock(root=MagicMock())
 
     def _tool(name: str) -> MagicMock:
         t = MagicMock()
@@ -144,6 +146,7 @@ async def test_prepare_chat_mcp_injects_custom_from_cache() -> None:
     mgr._mcp_tool_cache = {}
     mgr._mcp_tool_cache_locks = {}
     mgr._mcp_tool_cache_guard = asyncio.Lock()
+    mgr._paths = MagicMock(root=MagicMock())
 
     tool = MagicMock()
     tool.name = "deepwiki_ask"

--- a/tests/unit/api/test_require_running_workspace.py
+++ b/tests/unit/api/test_require_running_workspace.py
@@ -1,0 +1,98 @@
+"""Workspace I/O should survive a harness rebuild window."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from octop.api.common.workspace import require_running_workspace
+from octop.infra.errors import ErrorCode, OctopError
+
+
+def _server(
+    *, row: object, get_agent: object, workspace_for_agent: object = None
+) -> SimpleNamespace:
+    registry = MagicMock()
+    registry.get_row.return_value = row
+    registry.get_agent.side_effect = get_agent
+    registry.workspace_for_agent.return_value = workspace_for_agent
+    return SimpleNamespace(app_runtime=SimpleNamespace(agent_registry=registry))
+
+
+@pytest.mark.asyncio
+async def test_require_running_workspace_uses_live_handle() -> None:
+    live_ws = object()
+    row = SimpleNamespace(agent_id="A1", user_id=1, is_shared=0, enabled=True, last_state="running")
+    user = SimpleNamespace(id=1, is_admin=False)
+    agent = SimpleNamespace(workspace=live_ws)
+    server = _server(row=row, get_agent=lambda _aid: agent)
+
+    ws = await require_running_workspace("A1", user=user, as_user=None, server=server)
+    assert ws is live_ws
+    server.app_runtime.agent_registry.workspace_for_agent.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_require_running_workspace_falls_back_during_rebuild() -> None:
+    fallback_ws = object()
+    row = SimpleNamespace(agent_id="A1", user_id=1, is_shared=0, enabled=True, last_state="running")
+    user = SimpleNamespace(id=1, is_admin=False)
+    server = _server(
+        row=row,
+        get_agent=OctopError(ErrorCode.AGENT_NOT_RUNNING, "agent 'A1' not running"),
+        workspace_for_agent=fallback_ws,
+    )
+
+    ws = await require_running_workspace("A1", user=user, as_user=None, server=server)
+    assert ws is fallback_ws
+    server.app_runtime.agent_registry.workspace_for_agent.assert_called_once_with("A1")
+
+
+@pytest.mark.asyncio
+async def test_require_running_workspace_still_raises_when_stopped() -> None:
+    row = SimpleNamespace(agent_id="A1", user_id=1, is_shared=0, enabled=True, last_state="stopped")
+    user = SimpleNamespace(id=1, is_admin=False)
+    server = _server(
+        row=row,
+        get_agent=OctopError(ErrorCode.AGENT_NOT_RUNNING, "agent 'A1' not running"),
+        workspace_for_agent=object(),
+    )
+
+    with pytest.raises(OctopError) as ei:
+        await require_running_workspace("A1", user=user, as_user=None, server=server)
+    assert ei.value.code is ErrorCode.AGENT_NOT_RUNNING
+    server.app_runtime.agent_registry.workspace_for_agent.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_require_running_workspace_reraises_when_fallback_missing() -> None:
+    row = SimpleNamespace(agent_id="A1", user_id=1, is_shared=0, enabled=True, last_state="running")
+    user = SimpleNamespace(id=1, is_admin=False)
+    server = _server(
+        row=row,
+        get_agent=OctopError(ErrorCode.AGENT_NOT_RUNNING, "agent 'A1' not running"),
+        workspace_for_agent=None,
+    )
+
+    with pytest.raises(OctopError) as ei:
+        await require_running_workspace("A1", user=user, as_user=None, server=server)
+    assert ei.value.code is ErrorCode.AGENT_NOT_RUNNING
+    server.app_runtime.agent_registry.workspace_for_agent.assert_called_once_with("A1")
+
+
+@pytest.mark.asyncio
+async def test_require_running_workspace_does_not_mask_failed_agent() -> None:
+    row = SimpleNamespace(agent_id="A1", user_id=1, is_shared=0, enabled=True, last_state="failed")
+    user = SimpleNamespace(id=1, is_admin=False)
+    server = _server(
+        row=row,
+        get_agent=OctopError(ErrorCode.AGENT_FAILED, "agent 'A1' failed to start"),
+        workspace_for_agent=object(),
+    )
+
+    with pytest.raises(OctopError) as ei:
+        await require_running_workspace("A1", user=user, as_user=None, server=server)
+    assert ei.value.code is ErrorCode.AGENT_FAILED
+    server.app_runtime.agent_registry.workspace_for_agent.assert_not_called()

--- a/tests/unit/gateway/test_usage_record.py
+++ b/tests/unit/gateway/test_usage_record.py
@@ -1,0 +1,174 @@
+"""Turn-level token usage extraction (multi-call agent loops)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from octop.infra.gateway.process.usage_record import (
+    UsageTracker,
+    extract_usage_from_chunk,
+    turn_usage_from_messages,
+)
+
+
+def _ai(
+    input_tokens: int,
+    output_tokens: int,
+    *,
+    model: str = "openai:gpt-4o-mini",
+) -> dict[str, object]:
+    return {
+        "role": "assistant",
+        "content": "ok",
+        "usage_metadata": {
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+        },
+        "response_metadata": {"model_name": model},
+    }
+
+
+def test_turn_usage_sums_all_ai_calls_after_last_user() -> None:
+    messages = [
+        {"role": "user", "content": "first"},
+        _ai(10, 2),
+        {"role": "user", "content": "second"},
+        _ai(100, 20),
+        {"role": "tool", "content": "result"},
+        _ai(200, 30, model="openai:gpt-4o"),
+    ]
+    out = turn_usage_from_messages(messages)
+    assert out is not None
+    assert out["input_tokens"] == 300
+    assert out["output_tokens"] == 50
+    assert out["total_tokens"] == 350
+    assert out["model"] == "openai:gpt-4o"
+
+
+def test_turn_usage_from_langchain_style_objects() -> None:
+    messages = [
+        SimpleNamespace(type="human", content="hi"),
+        SimpleNamespace(
+            type="ai",
+            usage_metadata={"input_tokens": 7, "output_tokens": 3},
+            response_metadata={"model": "m1"},
+        ),
+        SimpleNamespace(
+            type="ai",
+            usage_metadata={"prompt_tokens": 8, "completion_tokens": 4},
+            response_metadata={"model_name": "m2"},
+        ),
+    ]
+    out = turn_usage_from_messages(messages)
+    assert out == {
+        "input_tokens": 15,
+        "output_tokens": 7,
+        "total_tokens": 22,
+        "model": "m2",
+    }
+
+
+def test_turn_usage_skips_malformed_token_fields() -> None:
+    messages = [
+        {"role": "user", "content": "hi"},
+        {
+            "role": "assistant",
+            "usage_metadata": {"input_tokens": {"cache": 9}, "output_tokens": "nope"},
+        },
+        _ai(12, 3),
+    ]
+    out = turn_usage_from_messages(messages)
+    assert out is not None
+    assert out["input_tokens"] == 12
+    assert out["output_tokens"] == 3
+
+
+def test_extract_snapshot_sums_current_turn_not_last_call() -> None:
+    chunk = {
+        "type": "state_snapshot",
+        "data": {
+            "messages": [
+                {"role": "user", "content": "hi"},
+                _ai(1_000, 50),
+                _ai(20_000, 80),
+            ],
+        },
+    }
+    out = extract_usage_from_chunk(chunk)
+    assert out is not None
+    assert out["input_tokens"] == 21_000
+    assert out["output_tokens"] == 130
+
+
+def test_tracker_snapshot_is_authoritative_over_later_updates() -> None:
+    tracker = UsageTracker()
+    tracker.observe(
+        {
+            "type": "state_snapshot",
+            "data": {
+                "messages": [
+                    {"role": "user", "content": "hi"},
+                    _ai(100, 10),
+                ],
+            },
+        }
+    )
+    # Same (or extra) AI replayed as an incremental update must not add.
+    tracker.observe({"type": "state_update", "data": {"messages": [_ai(100, 10)]}})
+    tracker.observe({"type": "state_update", "data": {"messages": [_ai(200, 20)]}})
+    assert tracker.usage is not None
+    assert tracker.usage["input_tokens"] == 100
+    assert tracker.usage["output_tokens"] == 10
+
+    tracker.observe(
+        {
+            "type": "state_snapshot",
+            "data": {
+                "messages": [
+                    {"role": "user", "content": "hi"},
+                    _ai(100, 10),
+                    _ai(200, 20),
+                ],
+            },
+        }
+    )
+    assert tracker.usage["input_tokens"] == 300
+    assert tracker.usage["output_tokens"] == 30
+
+
+def test_tracker_updates_accumulate_until_first_snapshot() -> None:
+    tracker = UsageTracker()
+    tracker.observe({"type": "state_update", "data": {"messages": [_ai(10, 1)]}})
+    tracker.observe({"type": "state_update", "data": {"messages": [_ai(20, 2)]}})
+    assert tracker.usage is not None
+    assert tracker.usage["input_tokens"] == 30
+    assert tracker.usage["output_tokens"] == 3
+
+    tracker.observe(
+        {
+            "type": "state_snapshot",
+            "data": {
+                "messages": [
+                    {"role": "user", "content": "hi"},
+                    _ai(10, 1),
+                    _ai(20, 2),
+                ],
+            },
+        }
+    )
+    assert tracker.usage["input_tokens"] == 30
+    assert tracker.usage["output_tokens"] == 3
+
+
+def test_tracker_history_shaped_update_does_not_double_count() -> None:
+    tracker = UsageTracker()
+    messages = [
+        {"role": "user", "content": "hi"},
+        _ai(100, 10),
+        _ai(200, 20),
+    ]
+    tracker.observe({"type": "state_snapshot", "data": {"messages": messages}})
+    tracker.observe({"type": "state_update", "data": {"messages": messages}})
+    assert tracker.usage is not None
+    assert tracker.usage["input_tokens"] == 300
+    assert tracker.usage["output_tokens"] == 30

--- a/tests/unit/test_env_file.py
+++ b/tests/unit/test_env_file.py
@@ -6,10 +6,12 @@ from pathlib import Path
 
 from octop.infra.utils.env_file import (
     apply_env_file,
+    apply_env_file_replace,
     format_env_file,
     load_env_file,
     parse_env_text,
     save_env_file,
+    search_env_changed,
 )
 
 
@@ -33,3 +35,36 @@ def test_save_and_load(tmp_path: Path, monkeypatch) -> None:
     import os
 
     assert os.environ["API_KEY"] == "secret"
+
+
+def test_apply_env_file_replace_unsets_removed_keys(tmp_path: Path, monkeypatch) -> None:
+    import os
+
+    path = tmp_path / "env"
+    save_env_file(path, {"KEEP": "1", "GONE": "2"})
+    monkeypatch.setenv("GONE", "2")
+    monkeypatch.setenv("KEEP", "1")
+    monkeypatch.setenv("UNRELATED", "host")
+    save_env_file(path, {"KEEP": "1"})
+    apply_env_file_replace(path, previous={"KEEP": "1", "GONE": "2"})
+    assert os.environ["KEEP"] == "1"
+    assert "GONE" not in os.environ
+    assert os.environ["UNRELATED"] == "host"
+
+
+def test_overlay_stdio_spec_env_skips_protected() -> None:
+    from octop.infra.utils.env_file import overlay_stdio_spec_env
+
+    spec = overlay_stdio_spec_env(
+        {"transport": "stdio", "command": "npx", "env": {"SPEC": "1"}},
+        {"TAVILY_API_KEY": "tvly", "OCTOP_HOME": "/nope", "HOME": "/hack"},
+    )
+    assert spec["env"]["TAVILY_API_KEY"] == "tvly"
+    assert spec["env"]["SPEC"] == "1"
+    assert "OCTOP_HOME" not in spec["env"]
+    assert "HOME" not in spec["env"]
+
+
+def test_search_env_changed_detects_tavily() -> None:
+    assert search_env_changed({}, {"TAVILY_API_KEY": "x"}) is True
+    assert search_env_changed({"FOO": "1"}, {"FOO": "2"}) is False

--- a/tests/unit/test_storage_spec.py
+++ b/tests/unit/test_storage_spec.py
@@ -148,6 +148,19 @@ def test_enrich_docker_backend_spec_defaults() -> None:
     assert "agent_id" not in fixed or fixed.get("agent_id") == "ZE6GR2"
 
 
+def test_inject_docker_global_environment_sets_file() -> None:
+    from octop.infra.backend.docker_spec import inject_docker_global_environment
+
+    spec = inject_docker_global_environment(
+        {"type": "docker", "environment": {"FOO": "from-spec"}},
+        "/data/octop/env",
+    )
+    assert spec["environment_file"] == "/data/octop/env"
+    assert spec["environment"] == {"FOO": "from-spec"}
+    local = inject_docker_global_environment({"type": "local_shell"}, "/data/octop/env")
+    assert "environment_file" not in local
+
+
 def test_collect_named_storage_backend_refs() -> None:
     assert collect_named_storage_backend_refs({"type": "named", "name": "my-cos"}) == {"my-cos"}
     assert collect_named_storage_backend_refs(


### PR DESCRIPTION
## Summary
- Running local shells and Docker sandboxes inherit Admin `~/.octop/env` (workspace `.env` overlays). Saving the env list unsets removed process keys; search-tool keys trigger a background agent reload. MCP stdio no longer gets the full host environment.
- Token usage for a turn sums every model call, using `state_snapshot` as the authoritative total.
- Workspace file I/O falls back to `workspace_for_agent` during the harness rebuild window so the API does not report `AGENT_NOT_RUNNING` while the DB still says running.

## Test plan
- [ ] Save / delete keys in Advanced → Environment variables; confirm process env and a subsequent shell/Docker execute see them without a full restart
- [ ] Change a search API key and confirm agents reload in the background
- [ ] Send a multi-tool chat turn and confirm usage totals match the sum of model calls
- [ ] Edit a workspace file while an agent PATCH rebuild is in flight


Made with [Cursor](https://cursor.com)