### PR TITLE
fix(dashboard): hide cron session routing when using a fresh thread

### DIFF
--- a/dashboard/src/pages/Control/CronJobs/components/JobDrawer.tsx
+++ b/dashboard/src/pages/Control/CronJobs/components/JobDrawer.tsx
@@ -86,6 +86,7 @@ export function JobDrawer({
 }: JobDrawerProps) {
   const { t } = useTranslation();
   const scheduleMode = Form.useWatch("_scheduleMode", form);
+  const freshThread = Form.useWatch("fresh_thread", form);
 
   const [models, setModels] = useState<ModelPickerOption[]>([]);
   const [modelsLoading, setModelsLoading] = useState(false);
@@ -401,37 +402,47 @@ export function JobDrawer({
           valuePropName="checked"
           tooltip={t("cronJobs.form.freshThreadTooltip")}
         >
-          <Switch />
-        </Form.Item>
-
-        <SectionHeader
-          title={t("cronJobs.form.sectionRouting")}
-          description={t("cronJobs.form.sectionRoutingDesc")}
-        />
-
-        <Form.Item
-          name="session_key"
-          label={t("cronJobs.form.sessionKey")}
-          tooltip={t("cronJobs.form.sessionKeyTooltip")}
-          extra={
-            <Text type="secondary" style={{ fontSize: 12 }}>
-              {t("cronJobs.form.sessionKeyDefault")}
-            </Text>
-          }
-        >
-          <Select
-            allowClear
-            showSearch
-            loading={sessionsLoading}
-            placeholder={t("cronJobs.form.sessionKeyPlaceholder")}
-            options={sessionOptions}
-            filterOption={(input, option) =>
-              (option?.label?.toString() || "")
-                .toLowerCase()
-                .includes(input.toLowerCase())
-            }
+          <Switch
+            onChange={(checked) => {
+              if (checked) {
+                form.setFieldValue("session_key", undefined);
+              }
+            }}
           />
         </Form.Item>
+
+        {!freshThread && (
+          <>
+            <SectionHeader
+              title={t("cronJobs.form.sectionRouting")}
+              description={t("cronJobs.form.sectionRoutingDesc")}
+            />
+
+            <Form.Item
+              name="session_key"
+              label={t("cronJobs.form.sessionKey")}
+              tooltip={t("cronJobs.form.sessionKeyTooltip")}
+              extra={
+                <Text type="secondary" style={{ fontSize: 12 }}>
+                  {t("cronJobs.form.sessionKeyDefault")}
+                </Text>
+              }
+            >
+              <Select
+                allowClear
+                showSearch
+                loading={sessionsLoading}
+                placeholder={t("cronJobs.form.sessionKeyPlaceholder")}
+                options={sessionOptions}
+                filterOption={(input, option) =>
+                  (option?.label?.toString() || "")
+                    .toLowerCase()
+                    .includes(input.toLowerCase())
+                }
+              />
+            </Form.Item>
+          </>
+        )}
 
         <Form.Item>
           <div

--- a/dashboard/src/pages/Control/CronJobs/useCronJobs.ts
+++ b/dashboard/src/pages/Control/CronJobs/useCronJobs.ts
@@ -150,7 +150,7 @@ function toOctopCreateBody(values: CronJobFormValues) {
     trigger: resolveCronExpression(values),
     prompt: values.prompt.trim(),
     task_type: values.task_type,
-    session_key: values.session_key || null,
+    session_key: values.fresh_thread ? null : values.session_key || null,
     fresh_thread: Boolean(values.fresh_thread),
     model: defaultModelFromForm(values.model),
     mcp_servers: values.mcp_servers ?? [],


### PR DESCRIPTION
## Summary
- Cron JobDrawer hides session routing when **fresh thread** is on, clears `session_key`, and omits it from the create/update body.
- Split out of the schema v7 PR so it can merge independently.

## Test plan
- [ ] Open a cron job, enable 新会话: session picker disappears and save does not send a session_key
- [ ] Disable 新会话: picker returns; existing session_key can still be set


Made with [Cursor](https://cursor.com)