### PR TITLE
fix(cli): force utf-8 stdio so octop init does not crash on GBK consoles

### DIFF
--- a/src/octop/cli/main.py
+++ b/src/octop/cli/main.py
@@ -3,11 +3,39 @@
 from __future__ import annotations
 
 import importlib
-from typing import ClassVar
+import sys
+from typing import Any, ClassVar
 
 import click
 
 from octop.cli.registry import COMMANDS
+
+
+def _ensure_utf8_stdio(
+    streams: tuple[Any, ...] | None = None,
+) -> None:
+    """Force UTF-8 output so emoji (✅/❌/QR art) can never crash the CLI.
+
+    On Windows the ANSI code page is often GBK (cp936); Python then encodes
+    piped/redirected stdout and stderr with it, so any non-GBK character
+    (e.g. the success checkmark printed by ``octop init``) raises
+    ``UnicodeEncodeError`` and kills the process after the work was already
+    done. Output is re-encoded to UTF-8 (``errors="replace"`` as a last
+    resort) instead.
+
+    ``streams`` is overridable for tests; the CLI entry uses ``sys.stdout``
+    and ``sys.stderr``.
+    """
+    for stream in (sys.stdout, sys.stderr) if streams is None else streams:
+        if stream is None:
+            continue
+        encoding = getattr(stream, "encoding", None) or ""
+        if encoding.lower().replace("_", "-") == "utf-8":
+            continue
+        try:
+            stream.reconfigure(encoding="utf-8", errors="replace")
+        except (AttributeError, ValueError, OSError, UnicodeError):
+            continue
 
 
 def _get_version() -> str:
@@ -91,6 +119,7 @@ def cli(
     json_out: bool,
 ) -> None:
     """Octop command-line interface."""
+    _ensure_utf8_stdio()
     ctx.ensure_object(dict)
     ctx.obj["as_user"] = as_user
     ctx.obj["agent_id"] = agent_id

--- a/tests/unit/cli/test_main_encoding.py
+++ b/tests/unit/cli/test_main_encoding.py
@@ -1,0 +1,66 @@
+"""CLI stdio encoding guard — emoji output must not crash on legacy code pages.
+
+Reported on Chinese Windows (GBK / cp936): ``octop init`` bootstraps the
+database and then raises ``UnicodeEncodeError`` while printing its ``✅``
+success message, because piped/redirected stdout is encoded with the ANSI
+code page. The CLI entry point now re-encodes stdout/stderr to UTF-8.
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from octop.cli.main import _ensure_utf8_stdio
+
+
+def test_ensure_utf8_stdio_reconfigures_gbk_streams() -> None:
+    out = io.TextIOWrapper(io.BytesIO(), encoding="gbk")
+    err = io.TextIOWrapper(io.BytesIO(), encoding="gbk")
+    _ensure_utf8_stdio(streams=(out, err))
+    assert out.encoding.lower() == "utf-8"
+    assert err.encoding.lower() == "utf-8"
+    # U+2705 (✅) is not representable in GBK; must encode without raising.
+    out.write("\u2705 Octop bootstrapped")
+    out.flush()
+
+
+def test_ensure_utf8_stdio_leaves_utf8_streams_alone() -> None:
+    out = io.TextIOWrapper(io.BytesIO(), encoding="utf-8")
+    _ensure_utf8_stdio(streams=(out, None))
+    assert out.encoding.lower() == "utf-8"
+
+
+def test_init_completes_with_gbk_stdout(tmp_path: Path) -> None:
+    """``octop init`` still bootstraps when stdout is forced to GBK. The crash
+    previously happened at the final success message, after the DB and admin
+    user were already created."""
+    home = tmp_path / "octop-home"
+    env = dict(os.environ)
+    env["OCTOP_HOME"] = str(home)
+    env["PYTHONIOENCODING"] = "gbk"
+    env.pop("PYTHONUTF8", None)
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "octop.cli.main",
+            "init",
+            "--yes",
+            "--admin-username",
+            "alice",
+            "--admin-password",
+            "Wonderland1",
+        ],
+        env=env,
+        capture_output=True,
+        check=False,
+        timeout=120,
+    )
+    assert proc.returncode == 0, proc.stdout.decode("utf-8", "replace") + proc.stderr.decode(
+        "utf-8", "replace"
+    )
+    assert (home / "octop.db").is_file()


### PR DESCRIPTION
## Problem

On Chinese Windows (GBK / cp936) the ANSI code page is used to encode
piped/redirected CLI stdout. `octop init` prints a success message
containing `✅` (U+2705), which is not representable in GBK, so the process
crashes with `UnicodeEncodeError: 'gbk' codec can't encode character '\u2705'`
**after** the database and admin user were already created. The same bug
class also affects other CLI emoji output (`stub` `❌`, terminal QR art `▀`).

## Solution

Re-encode `sys.stdout`/`sys.stderr` to UTF-8 at the CLI entry point
(`octop/cli/main.py`) whenever the current stream encoding is not UTF-8.
The guard covers the whole bug class (init, stub, QR art, future emoji)
with one small, dependency-free helper; `errors="replace"` is the last
resort so a stream write can never take the process down.

## Testing

- New `tests/unit/cli/test_main_encoding.py` (3 tests):
  - the guard reconfigures GBK streams to UTF-8 and can encode `✅`;
  - UTF-8 streams are left untouched;
  - end-to-end `octop init` under `PYTHONIOENCODING=gbk` exits 0 and
    creates the database (exact reproduction of the reported crash).
- `pytest -m "not live"` passes locally: 2156 passed; the 12 failures are
  pre-existing Windows/db-migration environment issues reproduced on the
  untouched `develop` baseline, unchanged by this patch.
- `ruff check`, `ruff format --check`, and `mypy --strict src/octop` are
  clean.