### PR TITLE
fix(skills): 修复编辑技能后清空技能内其他文件与文件夹的问题

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 ### 修复
 
+- 技能：修复编辑已导入技能并保存后，技能内其余文件与文件夹（README.md、references/ 等）被整体清除的问题--内容编辑（仅 SKILL.md）现原地覆盖清单文件、保留全部同级文件；携带完整 `files` 载荷的更新仍整目录替换（与覆盖重装语义一致）
 - Harness usage 事件按稳定调用 ID 去重，避免流重放重复计费；上下文环保留路由模型的真实窗口上限，并将构成拆分明确显示为近似估算。
 
 - Admin 环境变量未进入正在运行的 Agent：本地 shell 默认不继承进程 env，Docker exec 也不传 env，工作区 `.env` 只落盘不注入。现本地 shell 每次 execute 继承当前进程环境（含 `~/.octop/env`）并 overlay 工作区 `.env`；Docker 热读全局文件 + 工作区 `.env` + 最小 PATH（不含完整宿主机环境）。保存 Admin 列表会从进程环境删除已去掉的键；仅搜索类 key 变化时后台 reload Agent。MCP stdio 只注入 SDK 安全子集 + 全局/连接器 env，不再灌入整份 `os.environ`。

--- a/src/octop/api/routers/skills.py
+++ b/src/octop/api/routers/skills.py
@@ -687,7 +687,13 @@ async def update_skill(
     user: Any = Depends(current_user),
     server: Any = Depends(get_server),
 ) -> dict[str, Any]:
-    """Overwrite an installed workspace skill via BackendWorkspace only."""
+    """Overwrite an installed workspace skill via BackendWorkspace only.
+
+    A ``content``-only body (the dashboard editor edits SKILL.md) rewrites just
+    the manifest in place - sibling files and directories are preserved. A
+    ``files`` payload replaces the whole skill directory, matching
+    create-with-overwrite / re-import semantics.
+    """
     ctx = await _ctx(agent_id, user=user, as_user=as_user, server=server)
     try:
         slug = validate_skill_slug(name)
@@ -709,8 +715,16 @@ async def update_skill(
     if meta_existing.get("removed"):
         raise OctopError(ErrorCode.NOT_FOUND, f"skill {slug!r} not found")
 
-    with contextlib.suppress(Exception):
-        await ctx.workspace.adelete(f"skills/{slug}")
+    # ``content``-only updates (the dashboard editor edits SKILL.md) must keep
+    # the skill's sibling files and directories (README.md, references/, ...)
+    # intact - deleting the whole directory here wiped imported ZIP skills down
+    # to a lone SKILL.md. A full ``files`` payload still replaces the directory
+    # wholesale, matching create-with-overwrite / re-import semantics. The
+    # truthiness check mirrors ``_files_from_skill_body`` so an empty ``files``
+    # list falls back to the content path on both sides.
+    if body.files:
+        with contextlib.suppress(Exception):
+            await ctx.workspace.adelete(f"skills/{slug}")
     await _write_skill_files(ctx.workspace, f"skills/{slug}", package.files)
     skill_md = next(
         (content for path, content in package.files if path == "SKILL.md"),

--- a/tests/integration/test_skills_api.py
+++ b/tests/integration/test_skills_api.py
@@ -323,6 +323,105 @@ async def test_put_updates_workspace_skill(env: Any) -> None:
     assert raw == UPDATED_SKILL
 
 
+async def test_put_content_only_keeps_sibling_files_and_dirs(env: Any) -> None:
+    """Editing SKILL.md via the dashboard must not wipe the skill's other files."""
+    c, srv, auth, aid = env
+    skill_md = "---\nname: zip-demo\ndescription: from zip\n---\n\n# Zip Demo\n"
+    r = await c.post(
+        f"/api/agents/{aid}/skills",
+        headers=auth,
+        json={
+            "name": "zip-demo",
+            "files": [
+                {"path": "SKILL.md", "content_base64": _b64(skill_md)},
+                {"path": "README.md", "content_base64": _b64("# readme")},
+                {"path": "references/", "content_base64": ""},
+                {"path": "references/doc.md", "content_base64": _b64("# doc")},
+            ],
+        },
+    )
+    assert r.status_code == 201, r.text
+
+    updated_md = "---\nname: zip-demo\ndescription: edited\n---\n\n# Edited\n"
+    r = await c.put(
+        f"/api/agents/{aid}/skills/zip-demo",
+        headers=auth,
+        json={"content": updated_md},
+    )
+    assert r.status_code == 200, r.text
+
+    agent = srv.app_runtime.agent_registry.get_agent(aid)
+    assert await agent.workspace.aread_text("skills/zip-demo/SKILL.md") == updated_md
+    assert await agent.workspace.aread_text("skills/zip-demo/README.md") == "# readme"
+    assert await agent.workspace.aread_text("skills/zip-demo/references/doc.md") == "# doc"
+
+
+async def test_put_files_payload_replaces_directory(env: Any) -> None:
+    """A full ``files`` payload on PUT replaces the skill directory wholesale."""
+    c, srv, auth, aid = env
+    skill_md = "---\nname: zip-demo\ndescription: from zip\n---\n\n# Zip Demo\n"
+    r = await c.post(
+        f"/api/agents/{aid}/skills",
+        headers=auth,
+        json={
+            "name": "zip-demo",
+            "files": [
+                {"path": "SKILL.md", "content_base64": _b64(skill_md)},
+                {"path": "stale.txt", "content_base64": _b64("old")},
+            ],
+        },
+    )
+    assert r.status_code == 201, r.text
+
+    updated_md = "---\nname: zip-demo\ndescription: replaced\n---\n\n# New\n"
+    r = await c.put(
+        f"/api/agents/{aid}/skills/zip-demo",
+        headers=auth,
+        json={
+            "files": [
+                {"path": "SKILL.md", "content_base64": _b64(updated_md)},
+                {"path": "fresh.txt", "content_base64": _b64("new")},
+            ],
+        },
+    )
+    assert r.status_code == 200, r.text
+
+    agent = srv.app_runtime.agent_registry.get_agent(aid)
+    assert await agent.workspace.aread_text("skills/zip-demo/SKILL.md") == updated_md
+    assert await agent.workspace.aread_text("skills/zip-demo/fresh.txt") == "new"
+    assert await agent.workspace.aread_text("skills/zip-demo/stale.txt") is None
+
+
+async def test_put_empty_files_list_falls_back_to_content_only(env: Any) -> None:
+    """``files: []`` + ``content`` must not wipe the directory (empty list = content path)."""
+    c, srv, auth, aid = env
+    skill_md = "---\nname: zip-demo\ndescription: from zip\n---\n\n# Zip Demo\n"
+    r = await c.post(
+        f"/api/agents/{aid}/skills",
+        headers=auth,
+        json={
+            "name": "zip-demo",
+            "files": [
+                {"path": "SKILL.md", "content_base64": _b64(skill_md)},
+                {"path": "notes.txt", "content_base64": _b64("keep me")},
+            ],
+        },
+    )
+    assert r.status_code == 201, r.text
+
+    updated_md = "---\nname: zip-demo\ndescription: edited\n---\n\n# Edited\n"
+    r = await c.put(
+        f"/api/agents/{aid}/skills/zip-demo",
+        headers=auth,
+        json={"content": updated_md, "files": []},
+    )
+    assert r.status_code == 200, r.text
+
+    agent = srv.app_runtime.agent_registry.get_agent(aid)
+    assert await agent.workspace.aread_text("skills/zip-demo/SKILL.md") == updated_md
+    assert await agent.workspace.aread_text("skills/zip-demo/notes.txt") == "keep me"
+
+
 async def test_put_rejects_missing_skill(env: Any) -> None:
     c, _srv, auth, aid = env
     r = await c.put(


### PR DESCRIPTION
PUT /agents/{aid}/skills/{name} 在写回请求载荷前会先删除整个 `skills/<slug>/` 目录。网页编辑器只提交 SKILL.md 的 `content`，因此在已导入（ZIP / SkillHub）的多文件技能上保存编辑时，README.md、references/、workflows/ 等所有同级文件与文件夹都会被清除，只留下一个 SKILL.md。

现在 `content`-only 更新改为原地覆盖清单文件；携带完整 `files` 载荷的更新仍整目录替换，与 create-with-overwrite / 重装语义一致（删除条件用真值判断，与 `_files_from_skill_body` 对齐，空 `files` 列表在两侧都落入 content 路径）。

## Summary

修复编辑已导入技能并保存后，技能目录内除 SKILL.md 外的所有文件与文件夹被整体清除的问题。

根因：`PUT /api/agents/{aid}/skills/{name}` 先 `adelete("skills/<slug>/")` 整目录删除、再写回请求携带的文件；而网页编辑器（`useSkills.updateSkill`）只提交 SKILL.md 内容，导致重写后仅剩 SKILL.md 一个文件。

修复方案：仅 `content` 的更新不再删除目录，只原地覆盖 `SKILL.md`，保留 README.md、references/、workflows/ 等全部同级文件；携带完整 `files` 载荷的更新保留原有整目录替换语义（与覆盖重装 / 重新导入一致）。删除条件改用真值判断，与 `_files_from_skill_body` 保持一致，避免 `files: []` + `content` 时误清空目录。

## Target branch

- [x] Base 是 **`develop`**（feature / fix — 默认）
- [ ] Base 是 **`main`**（仅 `release/*` 或 `hotfix/*`）

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / chore
- [ ] Release / hotfix

## Test plan

- 集成测试 `tests/integration/test_skills_api.py` 全文件 **32 passed**（新增 3 个用例）：
  - `test_put_content_only_keeps_sibling_files_and_dirs`：编辑后 README.md / references/doc.md 等保留
  - `test_put_files_payload_replaces_directory`：files 载荷仍整目录替换
  - `test_put_empty_files_list_falls_back_to_content_only`：空 files 列表边界不误清空
- 端到端验证：本地服务重导 zip → PUT content-only 保存 → 目录树完整、SKILL.md 已更新
- `ruff check` / `ruff format --check` / `mypy` 全部通过

- [ ] `make all` passes locally
- [x] Added/updated tests

## Checklist

- [x] 已更新 `CHANGELOG.md`（面向用户）
- [ ] README / 文档已更新（如需要）