### PR TITLE
fix(dashboard): polish invite flow, boot splash, and chat dock

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -31,6 +31,109 @@
     <link rel="manifest" href="/manifest.json" />
     <title>Octop</title>
     <!--
+      First-paint boot splash: visible before JS chunks parse. React.createRoot
+      replaces #root contents on mount, so this disappears automatically.
+    -->
+    <style>
+      html,
+      body {
+        height: 100%;
+        margin: 0;
+        background: #f7f8fa;
+      }
+      #root {
+        min-height: 100%;
+        min-height: 100dvh;
+      }
+      #octop-boot {
+        /* fixed + inset: always viewport-centered before app CSS sets #root height */
+        position: fixed;
+        inset: 0;
+        z-index: 2147483646;
+        box-sizing: border-box;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 20px;
+        padding: 24px;
+        margin: 0;
+        background: #f7f8fa;
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI",
+          "Noto Sans SC", sans-serif;
+        color: #8b8fa3;
+      }
+      @media (prefers-color-scheme: dark) {
+        html,
+        body {
+          background: #12141c;
+        }
+        #octop-boot {
+          background: #12141c;
+          color: rgba(255, 255, 255, 0.55);
+        }
+      }
+      #octop-boot-mark {
+        position: relative;
+        width: 88px;
+        height: 88px;
+        flex: none;
+      }
+      #octop-boot-ring {
+        box-sizing: border-box;
+        position: absolute;
+        inset: 0;
+        border-radius: 50%;
+        border: 3px solid rgba(232, 93, 117, 0.18);
+        border-top-color: #e85d75;
+        animation: octop-boot-spin 0.85s linear infinite;
+      }
+      @media (prefers-color-scheme: dark) {
+        #octop-boot-ring {
+          border-color: rgba(240, 139, 154, 0.22);
+          border-top-color: #f08b9a;
+        }
+      }
+      #octop-boot-logo {
+        position: absolute;
+        inset: 14px;
+        width: 60px;
+        height: 60px;
+        border-radius: 14px;
+        object-fit: contain;
+        display: block;
+        animation: octop-boot-breathe 1.6s ease-in-out infinite;
+      }
+      #octop-boot-text {
+        font-size: 14px;
+        font-weight: 500;
+        letter-spacing: 0.04em;
+        user-select: none;
+      }
+      @keyframes octop-boot-spin {
+        to {
+          transform: rotate(360deg);
+        }
+      }
+      @keyframes octop-boot-breathe {
+        0%,
+        100% {
+          transform: scale(1);
+          opacity: 1;
+        }
+        50% {
+          transform: scale(0.94);
+          opacity: 0.88;
+        }
+      }
+      @media (prefers-reduced-motion: reduce) {
+        #octop-boot-ring,
+        #octop-boot-logo {
+          animation: none;
+        }
+      }
+    </style>
+    <!--
       Classic script (not type=module) so it runs even when hashed chunks 404.
       Shares octop:chunk-reload with reloadOnStaleChunk.ts.
     -->
@@ -90,7 +193,35 @@
     </script>
   </head>
   <body>
-    <div id="root"></div>
+    <div id="root">
+      <div id="octop-boot" role="status" aria-live="polite">
+        <div id="octop-boot-mark" aria-hidden="true">
+          <div id="octop-boot-ring"></div>
+          <img
+            id="octop-boot-logo"
+            src="/logo.svg"
+            alt=""
+            width="60"
+            height="60"
+          />
+        </div>
+        <div id="octop-boot-text">Loading…</div>
+      </div>
+    </div>
+    <script>
+      (function () {
+        var el = document.getElementById("octop-boot-text");
+        if (!el) return;
+        try {
+          var lang = (
+            navigator.language ||
+            navigator.userLanguage ||
+            ""
+          ).toLowerCase();
+          if (lang.indexOf("zh") === 0) el.textContent = "加载中…";
+        } catch (e) {}
+      })();
+    </script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/dashboard/src/api/modules/invites.ts
+++ b/dashboard/src/api/modules/invites.ts
@@ -47,7 +47,7 @@ export interface InviteRedeemResponse {
 /** Prefer the browser origin so copied links match how admins reach the UI. */
 export function localInviteUrl(code: string): string {
   const origin = typeof window !== "undefined" ? window.location.origin : "";
-  return `${origin}/?invite=${encodeURIComponent(code)}`;
+  return `${origin}/invite?code=${encodeURIComponent(code)}`;
 }
 
 export const invitesApi = {

--- a/dashboard/src/components/AuthGuard.tsx
+++ b/dashboard/src/components/AuthGuard.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { useNavigate, useSearchParams } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import { Spin } from "antd";
 import { getAuthToken } from "../api/request";
 import { authApi, type OctopUser } from "../api/modules/auth";
@@ -8,16 +8,6 @@ import { CurrentUserProvider } from "../hooks/useCurrentUser";
 
 interface AuthGuardProps {
   children: React.ReactNode;
-}
-
-function inviteRedirectTarget(searchParams: URLSearchParams): string | null {
-  const invite = (
-    searchParams.get("invite") ||
-    searchParams.get("code") ||
-    ""
-  ).trim();
-  if (!invite) return null;
-  return `/invite?code=${encodeURIComponent(invite)}`;
 }
 
 /**
@@ -32,11 +22,10 @@ function inviteRedirectTarget(searchParams: URLSearchParams): string | null {
  *
  * When unauthenticated we must NOT render children: MainLayout / AgentProvider
  * would fire authenticated APIs, trip the 401 interceptor, and race the
- * invite redirect back to ``/login``.
+ * navigate back to ``/login``.
  */
 export default function AuthGuard({ children }: AuthGuardProps) {
   const navigate = useNavigate();
-  const [searchParams] = useSearchParams();
   const hadToken = Boolean(getAuthToken());
   const [checking, setChecking] = useState(!hadToken);
   const [authed, setAuthed] = useState(hadToken);
@@ -62,8 +51,7 @@ export default function AuthGuard({ children }: AuthGuardProps) {
             setAuthed(false);
             // Stay on the spinner until navigation away completes — do not
             // flip ``checking`` off or children would mount and 401→/login.
-            const inviteTo = inviteRedirectTarget(searchParams);
-            navigate(inviteTo ?? "/login", { replace: true });
+            navigate("/login", { replace: true });
           }
           return;
         }
@@ -99,7 +87,7 @@ export default function AuthGuard({ children }: AuthGuardProps) {
     return () => {
       cancelled = true;
     };
-  }, [navigate, searchParams]);
+  }, [navigate]);
 
   if (checking || !authed) {
     return (

--- a/dashboard/src/pages/Chat/chatBrowserPanel.partial.less
+++ b/dashboard/src/pages/Chat/chatBrowserPanel.partial.less
@@ -95,10 +95,6 @@
   .chat-floating-circle-btn();
 }
 
-.phoneFloatBtn {
-  .chat-floating-circle-btn();
-}
-
 .filePanelBody {
   flex: 1;
   min-height: 0;

--- a/dashboard/src/pages/Chat/components/ChatDockPanel.tsx
+++ b/dashboard/src/pages/Chat/components/ChatDockPanel.tsx
@@ -14,7 +14,6 @@ import {
   FolderOpen,
   Globe,
   RefreshCw,
-  Smartphone,
   Terminal,
   X,
 } from "lucide-react";
@@ -32,7 +31,6 @@ import ChatDockFileList from "./ChatDockFileList";
 import FilePanelContent from "./FilePanelContent";
 
 const TerminalPage = lazy(() => import("../../Control/Terminal"));
-const RemoteAndroidPage = lazy(() => import("../../Control/RemoteAndroid"));
 
 interface ChatDockPanelProps {
   mode: PanelMode;
@@ -56,7 +54,7 @@ interface ChatDockPanelProps {
 }
 
 /**
- * Tabbed dock shell: file list + per-file viewers + browser + terminal + phone.
+ * Tabbed dock shell: file list + per-file viewers + browser + terminal.
  * Bodies stay mounted after first open so streams / editors survive tab switches.
  */
 const ChatDockPanel: React.FC<ChatDockPanelProps> = ({
@@ -81,9 +79,6 @@ const ChatDockPanel: React.FC<ChatDockPanelProps> = ({
   const [terminalMounted, setTerminalMounted] = useState(
     openTabs.some((tab) => tab.kind === "terminal"),
   );
-  const [phoneMounted, setPhoneMounted] = useState(
-    openTabs.some((tab) => tab.kind === "phone"),
-  );
   const [mountedFilePaths, setMountedFilePaths] = useState<string[]>(() =>
     openTabs.filter((tab) => tab.kind === "file").map((tab) => tab.path),
   );
@@ -98,10 +93,8 @@ const ChatDockPanel: React.FC<ChatDockPanelProps> = ({
   useEffect(() => {
     const hasBrowser = openTabs.some((tab) => tab.kind === "browser");
     const hasTerminal = openTabs.some((tab) => tab.kind === "terminal");
-    const hasPhone = openTabs.some((tab) => tab.kind === "phone");
     setBrowserMounted(hasBrowser);
     setTerminalMounted(hasTerminal);
-    setPhoneMounted(hasPhone);
     const openFilePaths = new Set(
       openTabs.filter((tab) => tab.kind === "file").map((tab) => tab.path),
     );
@@ -158,7 +151,6 @@ const ChatDockPanel: React.FC<ChatDockPanelProps> = ({
   const activeTab =
     openTabs.find((tab) => tab.id === activeTabId) ?? openTabs[0] ?? null;
   const terminalVisible = surfaceVisible && activeTab?.kind === "terminal";
-  const phoneVisible = surfaceVisible && activeTab?.kind === "phone";
 
   const tabBar = (
     <div className={styles.dockTabBar} role="tablist">
@@ -179,11 +171,6 @@ const ChatDockPanel: React.FC<ChatDockPanelProps> = ({
             <>
               <Terminal size={16} strokeWidth={2} aria-hidden />
               <span>{t("chat.dockTerminalTitle", "终端")}</span>
-            </>
-          ) : tab.kind === "phone" ? (
-            <>
-              <Smartphone size={16} strokeWidth={2} aria-hidden />
-              <span>{t("chat.dockPhoneTitle", "远程手机")}</span>
             </>
           ) : (
             <>
@@ -322,24 +309,6 @@ const ChatDockPanel: React.FC<ChatDockPanelProps> = ({
               }
             >
               <TerminalPage embedded isVisible={terminalVisible} />
-            </Suspense>
-          </div>
-        )}
-
-        {phoneMounted && (
-          <div
-            className={styles.dockTabBody}
-            style={{ display: phoneVisible ? "flex" : "none" }}
-            aria-hidden={!phoneVisible}
-          >
-            <Suspense
-              fallback={
-                <div className={styles.dockTerminalLoading}>
-                  <Spin size="small" />
-                </div>
-              }
-            >
-              <RemoteAndroidPage embedded />
             </Suspense>
           </div>
         )}

--- a/dashboard/src/pages/Chat/hooks/useChatDockPanel.test.ts
+++ b/dashboard/src/pages/Chat/hooks/useChatDockPanel.test.ts
@@ -61,21 +61,6 @@ describe("useChatDockPanel tabs", () => {
     expect(result.current.openTabs.map((t) => t.id)).toEqual(["terminal"]);
   });
 
-  it("togglePhonePanel opens phone tab then closes dock when active", () => {
-    const { result } = renderHook(() => useChatDockPanel(false));
-    act(() => {
-      result.current.togglePhonePanel();
-    });
-    expect(result.current.dockOpen).toBe(true);
-    expect(result.current.activeTabId).toBe("phone");
-    expect(result.current.openTabs.map((t) => t.id)).toEqual(["phone"]);
-    act(() => {
-      result.current.togglePhonePanel();
-    });
-    expect(result.current.dockOpen).toBe(false);
-    expect(result.current.openTabs.map((t) => t.id)).toEqual(["phone"]);
-  });
-
   it("reopening terminal does not add another dock tab", () => {
     const { result } = renderHook(() => useChatDockPanel(false));
     act(() => {

--- a/dashboard/src/pages/Chat/hooks/useChatDockPanel.ts
+++ b/dashboard/src/pages/Chat/hooks/useChatDockPanel.ts
@@ -20,7 +20,6 @@ export type DockTab =
   | { id: "files"; kind: "files" }
   | { id: "browser"; kind: "browser" }
   | { id: "terminal"; kind: "terminal" }
-  | { id: "phone"; kind: "phone" }
   | { id: string; kind: "file"; path: string };
 
 export type DockTabId = DockTab["id"];
@@ -88,7 +87,7 @@ function fallbackActiveId(
 }
 
 /**
- * Shared chat dock with tabbed file list / file viewers / browser / terminal / phone.
+ * Shared chat dock with tabbed file list / file viewers / browser / terminal.
  */
 export function useChatDockPanel(isMobile: boolean, agentId?: string | null) {
   const [dockOpen, setDockOpen] = useState(false);
@@ -175,18 +174,9 @@ export function useChatDockPanel(isMobile: boolean, agentId?: string | null) {
     openDock();
   }, [openDock]);
 
-  const openPhoneTab = useCallback(() => {
-    setOpenTabs((prev) => {
-      if (prev.some((t) => t.id === "phone")) return prev;
-      return [...prev, { id: "phone", kind: "phone" }];
-    });
-    setActiveTabId("phone");
-    openDock();
-  }, [openDock]);
-
-  /** Toggle dock open/closed around a dedicated tab (browser / terminal / phone). */
+  /** Toggle dock open/closed around a dedicated tab (browser / terminal). */
   const toggleDockTab = useCallback(
-    (tab: Extract<DockTab, { kind: "browser" | "terminal" | "phone" }>) => {
+    (tab: Extract<DockTab, { kind: "browser" | "terminal" }>) => {
       setDockOpen((prevOpen) => {
         if (prevOpen && activeTabId === tab.id) {
           return false;
@@ -211,10 +201,6 @@ export function useChatDockPanel(isMobile: boolean, agentId?: string | null) {
 
   const toggleTerminalPanel = useCallback(() => {
     toggleDockTab({ id: "terminal", kind: "terminal" });
-  }, [toggleDockTab]);
-
-  const togglePhonePanel = useCallback(() => {
-    toggleDockTab({ id: "phone", kind: "phone" });
   }, [toggleDockTab]);
 
   const closeTab = useCallback((id: DockTabId) => {
@@ -277,8 +263,6 @@ export function useChatDockPanel(isMobile: boolean, agentId?: string | null) {
     toggleBrowserPanel,
     openTerminalTab,
     toggleTerminalPanel,
-    openPhoneTab,
-    togglePhonePanel,
     closeTab,
     setActiveTab,
   };

--- a/dashboard/src/pages/Chat/index.tsx
+++ b/dashboard/src/pages/Chat/index.tsx
@@ -7,7 +7,6 @@ import {
   GraduationCap,
   Globe,
   FilePen,
-  Smartphone,
   Terminal,
   FolderOpen,
 } from "lucide-react";
@@ -16,7 +15,6 @@ import { message as antMessage } from "@/utils/antdMessage";
 
 import { useIsMobile } from "../../hooks/useIsMobile";
 import { useCurrentUser } from "../../hooks/useCurrentUser";
-import { useServerCapabilities } from "../../hooks/useServerCapabilities";
 import { userCan } from "../../utils/permissions";
 import { useChat } from "./hooks/useChat";
 import { useSessions, fetchAndSyncSessionArtifacts } from "./hooks/useSessions";
@@ -89,9 +87,6 @@ function ChatPageInner() {
   const { layoutMode } = useLayoutMode();
   const isMinimalLayout = layoutMode === "minimal";
   const canTerminal = userCan(user, "terminal");
-  const canMobile = userCan(user, "mobile");
-  const { mobileEnabled } = useServerCapabilities();
-  const showPhoneDock = canMobile && mobileEnabled;
   const chatHistoryRail = useChatHistoryRail();
   const [selectedTargetAgents, setSelectedTargetAgents] = useState<string[]>(
     [],
@@ -311,7 +306,6 @@ function ChatPageInner() {
     openBrowserTab,
     toggleBrowserPanel,
     toggleTerminalPanel,
-    togglePhonePanel,
     closeTab: closeDockTab,
     setActiveTab: setDockActiveTab,
   } = useChatDockPanel(isMobile, resolvedAgentId);
@@ -1100,24 +1094,6 @@ function ChatPageInner() {
                     </button>
                   </span>
                 </Tooltip>
-                {showPhoneDock && (
-                  <Tooltip
-                    title={t("chat.openPhone", "打开远程手机")}
-                    mouseEnterDelay={0.35}
-                    placement="left"
-                  >
-                    <span className={styles.chatFloatBtnWrap}>
-                      <button
-                        type="button"
-                        className={styles.phoneFloatBtn}
-                        onClick={togglePhonePanel}
-                        aria-label={t("chat.openPhone", "打开远程手机")}
-                      >
-                        <Smartphone size={20} strokeWidth={2.1} />
-                      </button>
-                    </span>
-                  </Tooltip>
-                )}
               </div>
             )}
 

--- a/dashboard/src/pages/Invite/index.tsx
+++ b/dashboard/src/pages/Invite/index.tsx
@@ -39,11 +39,7 @@ export default function InvitePage() {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const initialCode = useMemo(() => {
-    return (
-      searchParams.get("code") ||
-      searchParams.get("invite") ||
-      ""
-    ).trim();
+    return (searchParams.get("code") || "").trim();
   }, [searchParams]);
 
   const [step, setStep] = useState<StepKey>(0);
@@ -138,199 +134,204 @@ export default function InvitePage() {
 
   return (
     <div className={styles.inviteShell}>
-      <div
-        className={[styles.inviteCard, isDark ? styles.inviteCardDark : ""]
-          .filter(Boolean)
-          .join(" ")}
-      >
-        <div className={styles.inviteHeader}>
-          <Title level={3} className={styles.inviteTitle}>
-            {t("invite.title")}
-          </Title>
-          <Segmented
-            className={styles.inviteLang}
-            size="small"
-            value={currentLang}
-            options={[
-              { label: t("account.langZh"), value: "zh" },
-              { label: t("account.langEn"), value: "en" },
-            ]}
-            onChange={handleLanguageChange}
-          />
-        </div>
-        <Text type="secondary" className={styles.inviteSubtitle}>
-          {t("invite.subtitle")}
-        </Text>
-
-        <Steps
-          size="small"
-          current={step}
-          className={styles.inviteSteps}
-          items={[
-            { title: t("invite.stepCode"), icon: <KeyRound size={14} /> },
-            { title: t("invite.stepAccount"), icon: <UserPlus size={14} /> },
-            { title: t("invite.stepDone"), icon: <CheckCircle2 size={14} /> },
-          ]}
-        />
-
-        {step === 0 ? (
-          <div>
-            <Text style={{ display: "block", marginBottom: 8 }}>
-              {t("invite.codeLabel")}
-            </Text>
-            <Input
-              size="large"
-              prefix={<KeyRound size={16} />}
-              value={code}
-              onChange={(e) => setCode(e.target.value)}
-              onPressEnter={() => void onValidate()}
-              placeholder={t("invite.codePlaceholder")}
-              style={{ marginBottom: 16 }}
-            />
-            <Button
-              type="primary"
-              size="large"
-              block
-              loading={validating}
-              onClick={() => void onValidate()}
-            >
-              {t("invite.continue")}
-            </Button>
-            <Button
-              type="link"
-              block
-              style={{ marginTop: 8 }}
-              onClick={() => navigate("/login", { replace: true })}
-            >
-              {t("invite.backToLogin")}
-            </Button>
-          </div>
-        ) : null}
-
-        {step === 1 ? (
-          <Form
-            form={form}
-            layout="vertical"
-            requiredMark={false}
-            onFinish={(v) => void onCreate(v)}
-          >
-            <Form.Item
-              name="username"
-              label={t("invite.username")}
-              rules={[
-                { required: true, message: t("invite.usernameRequired") },
-              ]}
-            >
-              <Input
-                size="large"
-                prefix={<User size={16} />}
-                autoComplete="username"
-              />
-            </Form.Item>
-            <Form.Item
-              name="email"
-              label={t("invite.email")}
-              rules={[{ type: "email", message: t("invite.emailInvalid") }]}
-            >
-              <Input
-                size="large"
-                prefix={<Mail size={16} />}
-                type="email"
-                autoComplete="email"
-              />
-            </Form.Item>
-            <Form.Item name="display_name" label={t("invite.displayName")}>
-              <Input
-                size="large"
-                prefix={<IdCard size={16} />}
-                autoComplete="nickname"
-              />
-            </Form.Item>
-            <Form.Item
-              name="password"
-              label={t("invite.password")}
-              extra={t("invite.passwordHint")}
-              rules={[
-                { required: true, message: t("invite.passwordRequired") },
-                {
-                  validator(_, value: string) {
-                    if (!value) return Promise.resolve();
-                    const issue = passwordPolicyIssue(value);
-                    if (issue) {
-                      return Promise.reject(
-                        new Error(passwordPolicyMessage(issue)),
-                      );
-                    }
-                    return Promise.resolve();
-                  },
-                },
-              ]}
-            >
-              <Input.Password
-                size="large"
-                prefix={<Lock size={16} />}
-                autoComplete="new-password"
-              />
-            </Form.Item>
-            <Form.Item
-              name="confirm"
-              label={t("invite.passwordConfirm")}
-              dependencies={["password"]}
-              rules={[
-                {
-                  required: true,
-                  message: t("invite.passwordConfirmRequired"),
-                },
-                ({ getFieldValue }) => ({
-                  validator(_, value) {
-                    if (!value || getFieldValue("password") === value) {
-                      return Promise.resolve();
-                    }
-                    return Promise.reject(
-                      new Error(t("invite.passwordMismatch")),
-                    );
-                  },
-                }),
-              ]}
-            >
-              <Input.Password
-                size="large"
-                prefix={<Lock size={16} />}
-                autoComplete="new-password"
-              />
-            </Form.Item>
-            <Button
-              type="primary"
-              size="large"
-              htmlType="submit"
-              block
-              loading={submitting}
-            >
-              {t("invite.createAccount")}
-            </Button>
-            <Button
-              type="link"
-              block
-              style={{ marginTop: 8 }}
-              onClick={() => setStep(0)}
-            >
-              {t("invite.back")}
-            </Button>
-          </Form>
-        ) : null}
-
-        {step === 2 ? (
-          <div className={styles.inviteSuccess}>
-            <CheckCircle2
-              size={40}
-              style={{ color: "var(--fn-success, #52c41a)", marginBottom: 12 }}
-            />
-            <Title level={4} style={{ marginBottom: 8 }}>
-              {t("invite.successTitle")}
+      <div className={styles.inviteShellInner}>
+        <div
+          className={[styles.inviteCard, isDark ? styles.inviteCardDark : ""]
+            .filter(Boolean)
+            .join(" ")}
+        >
+          <div className={styles.inviteHeader}>
+            <Title level={3} className={styles.inviteTitle}>
+              {t("invite.title")}
             </Title>
-            <Text type="secondary">{t("invite.successHint")}</Text>
+            <Segmented
+              className={styles.inviteLang}
+              size="small"
+              value={currentLang}
+              options={[
+                { label: t("account.langZh"), value: "zh" },
+                { label: t("account.langEn"), value: "en" },
+              ]}
+              onChange={handleLanguageChange}
+            />
           </div>
-        ) : null}
+          <Text type="secondary" className={styles.inviteSubtitle}>
+            {t("invite.subtitle")}
+          </Text>
+
+          <Steps
+            size="small"
+            current={step}
+            className={styles.inviteSteps}
+            items={[
+              { title: t("invite.stepCode"), icon: <KeyRound size={14} /> },
+              { title: t("invite.stepAccount"), icon: <UserPlus size={14} /> },
+              { title: t("invite.stepDone"), icon: <CheckCircle2 size={14} /> },
+            ]}
+          />
+
+          {step === 0 ? (
+            <div>
+              <Text style={{ display: "block", marginBottom: 8 }}>
+                {t("invite.codeLabel")}
+              </Text>
+              <Input
+                size="large"
+                prefix={<KeyRound size={16} />}
+                value={code}
+                onChange={(e) => setCode(e.target.value)}
+                onPressEnter={() => void onValidate()}
+                placeholder={t("invite.codePlaceholder")}
+                style={{ marginBottom: 16 }}
+              />
+              <Button
+                type="primary"
+                size="large"
+                block
+                loading={validating}
+                onClick={() => void onValidate()}
+              >
+                {t("invite.continue")}
+              </Button>
+              <Button
+                type="link"
+                block
+                style={{ marginTop: 8 }}
+                onClick={() => navigate("/login", { replace: true })}
+              >
+                {t("invite.backToLogin")}
+              </Button>
+            </div>
+          ) : null}
+
+          {step === 1 ? (
+            <Form
+              form={form}
+              layout="vertical"
+              requiredMark={false}
+              onFinish={(v) => void onCreate(v)}
+            >
+              <Form.Item
+                name="username"
+                label={t("invite.username")}
+                rules={[
+                  { required: true, message: t("invite.usernameRequired") },
+                ]}
+              >
+                <Input
+                  size="large"
+                  prefix={<User size={16} />}
+                  autoComplete="username"
+                />
+              </Form.Item>
+              <Form.Item
+                name="email"
+                label={t("invite.email")}
+                rules={[{ type: "email", message: t("invite.emailInvalid") }]}
+              >
+                <Input
+                  size="large"
+                  prefix={<Mail size={16} />}
+                  type="email"
+                  autoComplete="email"
+                />
+              </Form.Item>
+              <Form.Item name="display_name" label={t("invite.displayName")}>
+                <Input
+                  size="large"
+                  prefix={<IdCard size={16} />}
+                  autoComplete="nickname"
+                />
+              </Form.Item>
+              <Form.Item
+                name="password"
+                label={t("invite.password")}
+                extra={t("invite.passwordHint")}
+                rules={[
+                  { required: true, message: t("invite.passwordRequired") },
+                  {
+                    validator(_, value: string) {
+                      if (!value) return Promise.resolve();
+                      const issue = passwordPolicyIssue(value);
+                      if (issue) {
+                        return Promise.reject(
+                          new Error(passwordPolicyMessage(issue)),
+                        );
+                      }
+                      return Promise.resolve();
+                    },
+                  },
+                ]}
+              >
+                <Input.Password
+                  size="large"
+                  prefix={<Lock size={16} />}
+                  autoComplete="new-password"
+                />
+              </Form.Item>
+              <Form.Item
+                name="confirm"
+                label={t("invite.passwordConfirm")}
+                dependencies={["password"]}
+                rules={[
+                  {
+                    required: true,
+                    message: t("invite.passwordConfirmRequired"),
+                  },
+                  ({ getFieldValue }) => ({
+                    validator(_, value) {
+                      if (!value || getFieldValue("password") === value) {
+                        return Promise.resolve();
+                      }
+                      return Promise.reject(
+                        new Error(t("invite.passwordMismatch")),
+                      );
+                    },
+                  }),
+                ]}
+              >
+                <Input.Password
+                  size="large"
+                  prefix={<Lock size={16} />}
+                  autoComplete="new-password"
+                />
+              </Form.Item>
+              <Button
+                type="primary"
+                size="large"
+                htmlType="submit"
+                block
+                loading={submitting}
+              >
+                {t("invite.createAccount")}
+              </Button>
+              <Button
+                type="link"
+                block
+                style={{ marginTop: 8 }}
+                onClick={() => setStep(0)}
+              >
+                {t("invite.back")}
+              </Button>
+            </Form>
+          ) : null}
+
+          {step === 2 ? (
+            <div className={styles.inviteSuccess}>
+              <CheckCircle2
+                size={40}
+                style={{
+                  color: "var(--fn-success, #52c41a)",
+                  marginBottom: 12,
+                }}
+              />
+              <Title level={4} style={{ marginBottom: 8 }}>
+                {t("invite.successTitle")}
+              </Title>
+              <Text type="secondary">{t("invite.successHint")}</Text>
+            </div>
+          ) : null}
+        </div>
       </div>
     </div>
   );

--- a/dashboard/src/pages/Invite/invite.module.less
+++ b/dashboard/src/pages/Invite/invite.module.less
@@ -1,12 +1,24 @@
+/* #root / body are overflow:hidden — pin a viewport scrollport so the invite
+   form can center when short and scroll when tall (mobile register step). */
 .inviteShell {
-  box-sizing: border-box;
-  min-height: 100dvh;
-  display: flex;
-  justify-content: center;
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  overflow-x: hidden;
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
+  overscroll-behavior: contain;
   background: var(--fn-bg-layout);
   transition: background var(--fn-transition);
+}
+
+.inviteShellInner {
+  box-sizing: border-box;
+  min-height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
   padding: 24px 16px;
   padding-top: max(24px, env(safe-area-inset-top));
   padding-bottom: max(24px, env(safe-area-inset-bottom));
@@ -18,7 +30,7 @@
   box-sizing: border-box;
   width: 100%;
   max-width: 420px;
-  margin-block: auto;
+  flex: 0 0 auto;
   padding: 40px 32px 36px;
   border-radius: 16px;
   background: var(--fn-bg-elevated, #fff);
@@ -64,17 +76,15 @@
 }
 
 @media (max-width: 480px) {
-  .inviteShell {
+  .inviteShellInner {
     padding: 12px;
     padding-top: max(12px, env(safe-area-inset-top));
     padding-bottom: max(12px, env(safe-area-inset-bottom));
     padding-left: max(12px, env(safe-area-inset-left));
     padding-right: max(12px, env(safe-area-inset-right));
-    align-items: stretch;
   }
 
   .inviteCard {
-    margin-block: 0;
     max-width: none;
     padding: 24px 16px 20px;
     border-radius: 12px;

--- a/dashboard/src/pages/Login/index.tsx
+++ b/dashboard/src/pages/Login/index.tsx
@@ -31,24 +31,6 @@ export default function LoginPage() {
     void applyGuestLocale();
   }, []);
 
-  // Invite links that bounced onto /login (e.g. race before AuthGuard fix)
-  // should continue the invite wizard instead of the password form.
-  useEffect(() => {
-    const invite = (
-      searchParams.get("invite") ||
-      searchParams.get("code") ||
-      ""
-    ).trim();
-    if (!invite) return;
-    // OIDC error uses ``code`` as an error key — don't hijack that.
-    if (searchParams.get("oidc_error")) return;
-    if (searchParams.has("code") && !searchParams.has("invite")) {
-      // Bare ``?code=`` on /login is ambiguous; only trust ``invite``.
-      return;
-    }
-    navigate(`/invite?code=${encodeURIComponent(invite)}`, { replace: true });
-  }, [navigate, searchParams]);
-
   useEffect(() => {
     let cancelled = false;
     authApi

--- a/dashboard/src/pages/Setup/steps/AdminStep.tsx
+++ b/dashboard/src/pages/Setup/steps/AdminStep.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { Form, Input, Button, Alert, Typography, Space } from "antd";
-import { User, Lock, IdCard } from "lucide-react";
+import { User, Lock, IdCard, Mail } from "lucide-react";
 import { useTranslation } from "react-i18next";
 
 import { wizardApi, wizardSession } from "../wizardClient";
@@ -169,7 +169,11 @@ export default function AdminStep({ createdCreds, onBack, onCreated }: Props) {
             },
           ]}
         >
-          <Input type="email" autoComplete="email" />
+          <Input
+            type="email"
+            autoComplete="email"
+            prefix={<Mail size={16} />}
+          />
         </Form.Item>
 
         <Form.Item

--- a/src/octop/infra/users/invites.py
+++ b/src/octop/infra/users/invites.py
@@ -55,8 +55,8 @@ def generate_invite_code() -> str:
 
 
 def invite_path(code: str) -> str:
-    """Canonical share path (SPA root query), matching common invite links."""
-    return f"/?invite={code}"
+    """Canonical share path for invite redemption UI."""
+    return f"/invite?code={code}"
 
 
 def build_invite_url(base_url: str, code: str) -> str:

--- a/tests/integration/test_invites_api.py
+++ b/tests/integration/test_invites_api.py
@@ -16,7 +16,7 @@ async def test_invite_create_list_redeem_and_one_time(env) -> None:
     assert invite["status"] == "pending"
     assert invite["note"] == "for bob"
     assert invite["code"]
-    assert invite["invite_path"].startswith("/?invite=")
+    assert invite["invite_path"].startswith("/invite?code=")
     assert invite["invite_url"].endswith(invite["invite_path"])
     code = invite["code"]
 

--- a/tests/unit/users/test_invites.py
+++ b/tests/unit/users/test_invites.py
@@ -30,7 +30,7 @@ def test_generate_invite_code_shape() -> None:
     code = generate_invite_code()
     assert len(code) == 11
     assert code.isalnum()
-    assert invite_path(code) == f"/?invite={code}"
+    assert invite_path(code) == f"/invite?code={code}"
 
 
 def test_invite_repo_redeem_once(db: SqlitePool) -> None:


### PR DESCRIPTION
## Summary
- Canonical invite links are now `/invite?code=…` (API + copy URL); drop the unused `/?invite=` redirect path.
- Invite redemption UI: viewport-fixed scrollport so short steps stay vertically centered and the registration step scrolls on mobile.
- First-paint boot splash: centered Octop logo + circular spinner (follows system light/dark) before JS mounts.
- Setup admin email input gets a leading Mail icon like the other fields.
- Remove the chat-page “打开远程手机” floating button and phone dock tab (standalone remote-phone control page unchanged).

## Test plan
- [ ] Create invite in Admin → Users; copied URL is `…/invite?code=…` and opens the invite wizard directly
- [ ] Invite step 1 (code): card is vertically centered on desktop and mobile
- [ ] Invite step 2 (register): tall form scrolls; password fields reachable on a short phone viewport
- [ ] Cold load any page in a fresh browser/profile: logo spinner appears immediately (not a blank/top-stuck bar)
- [ ] Setup wizard admin step: email field has a leading icon
- [ ] Chat page: no Smartphone float button; browser/terminal/file dock still work
- [ ] `uv run pytest tests/unit/users/test_invites.py tests/integration/test_invites_api.py -q`
- [ ] `cd dashboard && npx vitest run src/pages/Chat/hooks/useChatDockPanel.test.ts`


Made with [Cursor](https://cursor.com)