### PR TITLE
chore(dashboard): rename invite text to "邀请用户"

### DIFF
--- a/dashboard/src/locales/zh.json
+++ b/dashboard/src/locales/zh.json
@@ -4071,8 +4071,8 @@
   },
   "adminUsers": {
     "newUser": "新建用户",
-    "inviteUsers": "邀请新用户",
-    "inviteDrawerTitle": "邀请新用户",
+    "inviteUsers": "邀请用户",
+    "inviteDrawerTitle": "邀请用户",
     "inviteCreate": "创建邀请",
     "inviteCreateSuccess": "邀请已创建",
     "inviteCreateFailed": "创建邀请失败",


### PR DESCRIPTION
## 改动说明

将 admin/users 页面的按钮与邀请弹框标题文案由「邀请新用户」改为「邀请用户」：

- `adminUsers.inviteUsers`（按钮，UsersListPanel.tsx:1152）
- `adminUsers.inviteDrawerTitle`（弹框标题，InviteDrawer.tsx:134）

仅修改 `dashboard/src/locales/zh.json` 的值，键名未变，不影响前后端 i18n key parity；英文包 `en.json` 本就为 "Invite users"，已与中文保持一致。

## 验证

- 预提交钩子通过（`make precommit`：ruff + lint + typecheck + testmon-scoped test，All checks passed）
- `git status` 干净，仅包含 locales/zh.json 一处文案改动