### PR TITLE
fix(dashboard): wait for service worker activation before reload

### DIFF
--- a/dashboard/src/components/PwaUpdatePrompt/index.tsx
+++ b/dashboard/src/components/PwaUpdatePrompt/index.tsx
@@ -39,7 +39,7 @@ export default function PwaUpdatePrompt() {
     if (serviceMode) {
       updateApi.restartService().catch(() => {});
     }
-    applyUpdate();
+    await applyUpdate();
   };
 
   const handleDismiss = () => setVisible(false);

--- a/dashboard/src/pwa.ts
+++ b/dashboard/src/pwa.ts
@@ -10,5 +10,5 @@
 /** Apply the waiting Service Worker update. Delegates to sw-register at runtime. */
 export async function applyUpdate(): Promise<void> {
   const { applyUpdate: apply } = await import("./sw-register");
-  apply();
+  await apply();
 }

--- a/dashboard/src/sw-register.ts
+++ b/dashboard/src/sw-register.ts
@@ -32,12 +32,36 @@ async function unregisterAllServiceWorkers(): Promise<void> {
  * Apply a waiting Service Worker update and reload once.
  * Only called from explicit UI actions (PwaUpdatePrompt).
  */
-export function applyUpdate(): void {
+export async function applyUpdate(): Promise<void> {
   if (applyingUpdate) return;
   applyingUpdate = true;
-  if (pendingRegistration?.waiting) {
-    pendingRegistration.waiting.postMessage({ type: "SKIP_WAITING" });
+  const waiting = pendingRegistration?.waiting;
+  if (!waiting) {
+    window.location.reload();
+    return;
   }
+
+  // Wait until the new worker takes control before reloading. Reloading
+  // immediately after SKIP_WAITING can race activation, so the old worker
+  // serves the page again and the update prompt reappears after restart.
+  await new Promise<void>((resolve) => {
+    let settled = false;
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      window.clearTimeout(timeoutId);
+      navigator.serviceWorker.removeEventListener(
+        "controllerchange",
+        finish,
+      );
+      resolve();
+    };
+    const timeoutId = window.setTimeout(finish, 3000);
+    navigator.serviceWorker.addEventListener("controllerchange", finish, {
+      once: true,
+    });
+    waiting.postMessage({ type: "SKIP_WAITING" });
+  });
   window.location.reload();
 }
 


### PR DESCRIPTION
## Summary

- wait for the new service worker to take control before reloading
- avoid the activation race that can make the stale update prompt reappear after restart
- await the asynchronous update flow from the PWA prompt

## Testing

- `npx tsc -b --pretty false`
- `npm test -- --run src/sw-register.test.ts`
- `git diff --check`

Fixes #329