### PR TITLE
fix(chat): use popovers for compact desktop pickers

### DIFF
--- a/dashboard/src/pages/Chat/chatInputPickers.partial.less
+++ b/dashboard/src/pages/Chat/chatInputPickers.partial.less
@@ -630,6 +630,30 @@
   }
 }
 
+.compactPickerPanel {
+  min-width: 280px;
+}
+
+.compactPickerBack {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  min-height: 40px;
+  padding: 8px 10px;
+  border: none;
+  border-bottom: 1px solid var(--fn-border-secondary, rgba(0, 0, 0, 0.06));
+  background: transparent;
+  color: var(--fn-text-secondary);
+  font-size: 13px;
+  cursor: pointer;
+
+  &:hover {
+    background: var(--fn-bg-hover, rgba(0, 0, 0, 0.03));
+    color: var(--fn-text-primary);
+  }
+}
+
 .mobileOverflowMenu {
   display: flex;
   flex-direction: column;

--- a/dashboard/src/pages/Chat/components/ChatInputActionsRow.test.tsx
+++ b/dashboard/src/pages/Chat/components/ChatInputActionsRow.test.tsx
@@ -1,0 +1,59 @@
+import { fireEvent, render, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { ResolvedModel } from "../../../api/types";
+import ChatInputActionsRow from "./ChatInputActionsRow";
+
+vi.mock("./ContextWindowRing", () => ({
+  default: () => null,
+}));
+
+const models: ResolvedModel[] = [
+  {
+    provider_id: 1,
+    provider_name: "Provider",
+    provider_kind: "openai",
+    model: "compact-model",
+    name: "Compact Model",
+    context_window: 128_000,
+  },
+];
+
+describe("ChatInputActionsRow compact pickers", () => {
+  it("uses a popover instead of a full-width drawer on narrow desktop", async () => {
+    const { container } = render(
+      <ChatInputActionsRow
+        isMobile={false}
+        isStreaming={false}
+        canSend={false}
+        text=""
+        polishing={false}
+        uploading={false}
+        recording={false}
+        transcribing={false}
+        availableModels={models}
+        onModelChange={vi.fn()}
+        slashPickerGroups={null}
+        slashMenuItems={[]}
+        onSlashShortcutSelect={vi.fn()}
+        onFileSelect={vi.fn()}
+        onNewChat={vi.fn()}
+        onPolish={vi.fn()}
+        onToggleVoice={vi.fn()}
+        onCancel={vi.fn()}
+        onSubmit={vi.fn()}
+      />,
+    );
+
+    const modelButton = container
+      .querySelector("svg.lucide-cpu")
+      ?.closest("button");
+    expect(modelButton).not.toBeNull();
+
+    fireEvent.click(modelButton!);
+
+    await waitFor(() => {
+      expect(document.querySelector(".ant-popover")).toBeInTheDocument();
+    });
+    expect(document.querySelector(".ant-drawer-content")).toBeNull();
+  });
+});

--- a/dashboard/src/pages/Chat/components/ChatInputActionsRow.tsx
+++ b/dashboard/src/pages/Chat/components/ChatInputActionsRow.tsx
@@ -237,7 +237,7 @@ export default function ChatInputActionsRow({
   };
 
   const openMobilePicker = (key: MobilePickerKey) => {
-    setMobileOverflowOpen(false);
+    if (isMobile) setMobileOverflowOpen(false);
     setMobilePicker(key);
   };
 
@@ -617,23 +617,76 @@ export default function ChatInputActionsRow({
     }
   };
 
+  const compactPickerContent = mobilePicker ? (
+    <div className={styles.compactPickerPanel}>
+      <button
+        type="button"
+        className={styles.compactPickerBack}
+        onClick={closeMobilePicker}
+      >
+        <ChevronLeft size={16} />
+        <span>{mobilePickerTitle[mobilePicker]}</span>
+      </button>
+      {renderMobilePickerContent()}
+    </div>
+  ) : (
+    renderMobileOverflowMenu()
+  );
+
   const renderSecondaryActions = () => {
     if (useCompactControls) {
+      const modelButton = (
+        <button
+          className={`${styles.secondaryBtn} ${
+            modelOverride || reasoningMode !== "auto" || reasoningEffort
+              ? styles.secondaryBtnModelActive
+              : ""
+          }`}
+          type="button"
+          onClick={isMobile ? () => setMobilePicker("model") : undefined}
+        >
+          <Cpu size={16} />
+        </button>
+      );
+      const overflowButton = (
+        <button
+          className={`${styles.secondaryBtn} ${
+            overflowBadgeCount > 0 ? styles.secondaryBtnActive : ""
+          }`}
+          type="button"
+          onClick={
+            isMobile
+              ? () => setMobileOverflowOpen(true)
+              : () => setMobilePicker(null)
+          }
+        >
+          <MoreHorizontal size={16} />
+          {overflowBadgeCount > 0 && (
+            <span className={styles.toolbarBadge}>{overflowBadgeCount}</span>
+          )}
+        </button>
+      );
+
       return (
         <>
-          {showModelPicker && (
-            <button
-              className={`${styles.secondaryBtn} ${
-                modelOverride || reasoningMode !== "auto" || reasoningEffort
-                  ? styles.secondaryBtnModelActive
-                  : ""
-              }`}
-              type="button"
-              onClick={() => setMobilePicker("model")}
-            >
-              <Cpu size={16} />
-            </button>
-          )}
+          {showModelPicker &&
+            (isMobile ? (
+              modelButton
+            ) : (
+              <Popover
+                trigger="click"
+                placement="topLeft"
+                open={modelPickerOpen}
+                onOpenChange={(open) => {
+                  setModelPickerOpen(open);
+                  if (!open) setReasoningModelRef(null);
+                }}
+                overlayClassName={styles.modelPopover}
+                content={modelMenu}
+              >
+                {modelButton}
+              </Popover>
+            ))}
           <button
             className={styles.secondaryBtn}
             onClick={onFileSelect}
@@ -642,46 +695,50 @@ export default function ChatInputActionsRow({
           >
             <Paperclip size={16} />
           </button>
-          {showOverflowMenu && (
-            <button
-              className={`${styles.secondaryBtn} ${
-                overflowBadgeCount > 0 ? styles.secondaryBtnActive : ""
-              }`}
-              type="button"
-              onClick={() => setMobileOverflowOpen(true)}
-            >
-              <MoreHorizontal size={16} />
-              {overflowBadgeCount > 0 && (
-                <span className={styles.toolbarBadge}>
-                  {overflowBadgeCount}
-                </span>
-              )}
-            </button>
+          {showOverflowMenu &&
+            (isMobile ? (
+              overflowButton
+            ) : (
+              <Popover
+                trigger="click"
+                placement="topLeft"
+                overlayClassName={styles.skillPickerPopover}
+                content={compactPickerContent}
+                onOpenChange={(open) => {
+                  if (!open) closeMobilePicker();
+                }}
+              >
+                {overflowButton}
+              </Popover>
+            ))}
+          {isMobile && (
+            <>
+              <Drawer
+                open={mobileOverflowOpen}
+                onClose={() => setMobileOverflowOpen(false)}
+                placement="bottom"
+                height="auto"
+                title={t("chat.composerMore", "更多工具")}
+                className={styles.mobilePickerDrawer}
+                styles={{ body: { padding: 0 } }}
+                destroyOnHidden
+              >
+                {renderMobileOverflowMenu()}
+              </Drawer>
+              <Drawer
+                open={mobilePicker !== null}
+                onClose={closeMobilePicker}
+                placement="bottom"
+                height="auto"
+                title={mobilePicker ? mobilePickerTitle[mobilePicker] : ""}
+                className={styles.mobilePickerDrawer}
+                styles={{ body: { padding: 0 } }}
+                destroyOnHidden
+              >
+                {renderMobilePickerContent()}
+              </Drawer>
+            </>
           )}
-          <Drawer
-            open={mobileOverflowOpen}
-            onClose={() => setMobileOverflowOpen(false)}
-            placement="bottom"
-            height="auto"
-            title={t("chat.composerMore", "更多工具")}
-            className={styles.mobilePickerDrawer}
-            styles={{ body: { padding: 0 } }}
-            destroyOnHidden
-          >
-            {renderMobileOverflowMenu()}
-          </Drawer>
-          <Drawer
-            open={mobilePicker !== null}
-            onClose={closeMobilePicker}
-            placement="bottom"
-            height="auto"
-            title={mobilePicker ? mobilePickerTitle[mobilePicker] : ""}
-            className={styles.mobilePickerDrawer}
-            styles={{ body: { padding: 0 } }}
-            destroyOnHidden
-          >
-            {renderMobilePickerContent()}
-          </Drawer>
         </>
       );
     }


### PR DESCRIPTION
## Summary

- use anchored popovers for model and tool pickers in compact desktop layouts
- keep bottom drawers for actual mobile layouts
- add a regression test ensuring narrow desktop pickers do not render a drawer

## Testing

- `npx prettier --check src/pages/Chat/components/ChatInputActionsRow.tsx src/pages/Chat/components/ChatInputActionsRow.test.tsx src/pages/Chat/chatInputPickers.partial.less`
- `npx eslint src/pages/Chat/components/ChatInputActionsRow.tsx src/pages/Chat/components/ChatInputActionsRow.test.tsx`
- `npx tsc -b --pretty false`
- `npm test -- --run src/pages/Chat/components/ChatInputActionsRow.test.tsx`
- `git diff --check`

Fixes #366