### PR TITLE
fix(dashboard): stop Firefox infinite reload on modulepreload errors

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -140,10 +140,20 @@
     <script>
       (function () {
         var KEY = "octop:chunk-reload";
+        // Firefox fires error on <link rel="modulepreload"> for /assets/*.js
+        // even when the file is fine; treating those as stale chunks caused
+        // infinite location.reload() loops (and aborted real dynamic imports).
+        var recovering = false;
         function isAsset(url) {
           return typeof url === "string" && url.indexOf("/assets/") !== -1;
         }
+        function isStylesheetLink(el) {
+          if (!el || el.tagName !== "LINK") return false;
+          var rel = (el.rel || "").toLowerCase();
+          return rel.indexOf("stylesheet") !== -1;
+        }
         function recover() {
+          if (recovering) return;
           try {
             if (sessionStorage.getItem(KEY) === "1") {
               sessionStorage.removeItem(KEY);
@@ -151,6 +161,7 @@
             }
             sessionStorage.setItem(KEY, "1");
           } catch (e) {}
+          recovering = true;
           var reload = function () {
             location.reload();
           };
@@ -185,7 +196,8 @@
             var t = e.target;
             if (!t || !t.tagName) return;
             if (t.tagName === "SCRIPT" && isAsset(t.src)) recover();
-            if (t.tagName === "LINK" && isAsset(t.href)) recover();
+            // Only stylesheets — never modulepreload / preload (Firefox noise).
+            if (isStylesheetLink(t) && isAsset(t.href)) recover();
           },
           true,
         );

--- a/dashboard/src/main.tsx
+++ b/dashboard/src/main.tsx
@@ -60,8 +60,11 @@ if (typeof window !== "undefined") {
 
 void initI18n()
   .then(() => {
-    clearChunkReloadFlag();
     createRoot(document.getElementById("root")!).render(<App />);
+    // Delay clearing the one-shot reload guard until after first paint / lazy
+    // chunks settle. Clearing immediately let Firefox modulepreload noise and
+    // aborted dynamic imports re-arm an infinite reload loop.
+    window.setTimeout(() => clearChunkReloadFlag(), 4000);
   })
   .catch((err: unknown) => {
     if (tryReloadOnStaleChunk(err)) return;

--- a/dashboard/src/utils/reloadOnStaleChunk.test.ts
+++ b/dashboard/src/utils/reloadOnStaleChunk.test.ts
@@ -5,6 +5,7 @@ import {
   bustServiceWorkerAndReload,
   clearChunkReloadFlag,
   isChunkLoadError,
+  isStylesheetAssetLink,
   tryReloadOnStaleChunk,
 } from "./reloadOnStaleChunk";
 
@@ -19,6 +20,16 @@ describe("isChunkLoadError", () => {
     ).toBe(true);
   });
 
+  it("matches Firefox dynamic import failures", () => {
+    expect(
+      isChunkLoadError(
+        new TypeError(
+          "error loading dynamically imported module: https://x/assets/vendor-markdown.js",
+        ),
+      ),
+    ).toBe(true);
+  });
+
   it("matches ChunkLoadError name", () => {
     const err = new Error("Loading chunk 3 failed.");
     err.name = "ChunkLoadError";
@@ -28,6 +39,22 @@ describe("isChunkLoadError", () => {
   it("rejects unrelated errors", () => {
     expect(isChunkLoadError(new Error("Network error"))).toBe(false);
     expect(isChunkLoadError(null)).toBe(false);
+  });
+});
+
+describe("isStylesheetAssetLink", () => {
+  it("accepts stylesheet links under /assets/", () => {
+    const link = document.createElement("link");
+    link.rel = "stylesheet";
+    link.href = "https://example.com/assets/index.abc.css";
+    expect(isStylesheetAssetLink(link)).toBe(true);
+  });
+
+  it("rejects modulepreload asset links (Firefox false positives)", () => {
+    const link = document.createElement("link");
+    link.rel = "modulepreload";
+    link.href = "https://example.com/assets/vendor-markdown.abc.js";
+    expect(isStylesheetAssetLink(link)).toBe(false);
   });
 });
 
@@ -46,6 +73,7 @@ describe("tryReloadOnStaleChunk", () => {
   beforeEach(() => {
     sessionStorage.clear();
     reload = stubReload();
+    clearChunkReloadFlag();
   });
 
   afterEach(() => {
@@ -64,9 +92,26 @@ describe("tryReloadOnStaleChunk", () => {
     expect(tryReloadOnStaleChunk(err)).toBe(true);
     await vi.waitFor(() => expect(reload).toHaveBeenCalledOnce());
     reload.mockClear();
-    expect(tryReloadOnStaleChunk(err)).toBe(false);
+
+    // New document after reload: in-memory guard resets; session flag remains.
+    vi.resetModules();
+    const mod = await import("./reloadOnStaleChunk");
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { reload },
+    });
+
+    expect(mod.tryReloadOnStaleChunk(err)).toBe(false);
     expect(reload).not.toHaveBeenCalled();
     expect(sessionStorage.getItem("octop:chunk-reload")).toBeNull();
+  });
+
+  it("ignores concurrent chunk errors without clearing the one-shot flag", async () => {
+    const err = new Error("Failed to fetch dynamically imported module: /a.js");
+    expect(tryReloadOnStaleChunk(err)).toBe(true);
+    expect(tryReloadOnStaleChunk(err)).toBe(true);
+    await vi.waitFor(() => expect(reload).toHaveBeenCalledOnce());
+    expect(sessionStorage.getItem("octop:chunk-reload")).toBe("1");
   });
 
   it("ignores non-chunk errors", () => {
@@ -107,7 +152,17 @@ describe("index.html boot recover", () => {
     const html = readFileSync(resolve(__dirname, "../../index.html"), "utf8");
     expect(html).toContain('var KEY = "octop:chunk-reload"');
     expect(html).toContain("serviceWorker");
+    expect(html).toContain("isStylesheetLink");
+    expect(html).toContain("modulepreload");
     expect(html).not.toMatch(/<script type="module">[\s\S]*octop:chunk-reload/);
+  });
+
+  it("does not recover on arbitrary LINK asset errors", () => {
+    const html = readFileSync(resolve(__dirname, "../../index.html"), "utf8");
+    expect(html).not.toMatch(
+      /t\.tagName === "LINK" && isAsset\(t\.href\)\) recover\(\)/,
+    );
+    expect(html).toContain("isStylesheetLink(t) && isAsset(t.href)");
   });
 });
 

--- a/dashboard/src/utils/reloadOnStaleChunk.ts
+++ b/dashboard/src/utils/reloadOnStaleChunk.ts
@@ -15,8 +15,18 @@ const CHUNK_ERROR_RE =
  */
 let navigatingAway = false;
 
+/** In-memory guard: concurrent asset errors must not clear-and-rearm the flag. */
+let reloadScheduled = false;
+
 export function markNavigatingAway(): void {
   navigatingAway = true;
+}
+
+/** True for stylesheet links only — Firefox spuriously errors on modulepreload. */
+export function isStylesheetAssetLink(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLLinkElement)) return false;
+  if (!target.href.includes("/assets/")) return false;
+  return /\bstylesheet\b/i.test(target.rel || "");
 }
 
 export function isChunkLoadError(error: unknown): boolean {
@@ -52,10 +62,12 @@ export async function bustServiceWorkerAndReload(): Promise<void> {
 export function tryReloadOnStaleChunk(error: unknown): boolean {
   if (typeof window === "undefined") return false;
   if (navigatingAway) return false;
+  if (reloadScheduled) return true;
   if (!isChunkLoadError(error)) return false;
 
   try {
     if (sessionStorage.getItem(RELOAD_FLAG_KEY) === "1") {
+      // Already reloaded once this cycle — give up (do not loop).
       sessionStorage.removeItem(RELOAD_FLAG_KEY);
       return false;
     }
@@ -64,6 +76,7 @@ export function tryReloadOnStaleChunk(error: unknown): boolean {
     // Private mode / quota — still attempt a single reload without the guard.
   }
 
+  reloadScheduled = true;
   console.warn("[Octop] Stale chunk detected; reloading once.", error);
   void bustServiceWorkerAndReload();
   return true;
@@ -71,6 +84,7 @@ export function tryReloadOnStaleChunk(error: unknown): boolean {
 
 /** Clear the one-shot flag after a successful boot so a later deploy can recover again. */
 export function clearChunkReloadFlag(): void {
+  reloadScheduled = false;
   if (typeof window === "undefined") return;
   try {
     sessionStorage.removeItem(RELOAD_FLAG_KEY);
@@ -111,14 +125,11 @@ export function installChunkLoadRecovery(): void {
         );
         return;
       }
-      if (
-        target instanceof HTMLLinkElement &&
-        target.href.includes("/assets/")
-      ) {
+      // Ignore modulepreload / preload link errors (Firefox false positives).
+      if (isStylesheetAssetLink(target)) {
+        const href = (target as HTMLLinkElement).href;
         tryReloadOnStaleChunk(
-          new Error(
-            `Failed to fetch dynamically imported module: ${target.href}`,
-          ),
+          new Error(`Failed to fetch dynamically imported module: ${href}`),
         );
       }
     },


### PR DESCRIPTION
## Summary
- Firefox spuriously fires `error` on `<link rel="modulepreload">` for `/assets/*.js` even when files return HTTP 200
- Stale-chunk recovery treated those as failed assets → `location.reload()` loop, aborting real dynamic imports
- Only recover on stylesheet link failures; ignore modulepreload/preload link noise
- Add in-memory `reloadScheduled` guard and delay `clearChunkReloadFlag()` until lazy chunks settle after first render

## Test plan
- [x] `npm test -- --run src/utils/reloadOnStaleChunk.test.ts` (16 tests)
- [x] Manual Firefox Nightly verification on `octop.misthios.cn` with temporary deploy — chat page stable, no infinite reload