### PR TITLE
fix(auth): verify SSO ID tokens against discovery issuer

### DIFF
--- a/src/octop/infra/auth/sso/service.py
+++ b/src/octop/infra/auth/sso/service.py
@@ -322,7 +322,7 @@ class SsoService:
             return verify_id_token(
                 id_token,
                 jwks_uri=jwks_uri,
-                issuer=provider.issuer.rstrip("/"),
+                issuer=self._endpoint(discovery, "issuer"),
                 client_id=provider.client_id,
                 nonce=nonce,
                 httpx=client,

--- a/tests/unit/auth/test_sso_id_token.py
+++ b/tests/unit/auth/test_sso_id_token.py
@@ -49,6 +49,35 @@ def _token(
     )
 
 
+def test_verify_id_token_accepts_issuer_with_trailing_slash(
+    signing_key: rsa.RSAPrivateKey, jwks_client: httpx.Client
+) -> None:
+    issuer = "https://issuer.example/application/o/app/"
+    claims = verify_id_token(
+        _token(signing_key, issuer=issuer),
+        jwks_uri="https://issuer.example/jwks",
+        issuer=issuer,
+        client_id="octop-client",
+        nonce="nonce",
+        httpx=jwks_client,
+    )
+    assert claims["sub"] == "user-1"
+
+
+def test_verify_id_token_rejects_trailing_slash_mismatch(
+    signing_key: rsa.RSAPrivateKey, jwks_client: httpx.Client
+) -> None:
+    with pytest.raises(jwt.InvalidIssuerError):
+        verify_id_token(
+            _token(signing_key, issuer="https://issuer.example/application/o/app/"),
+            jwks_uri="https://issuer.example/jwks",
+            issuer="https://issuer.example/application/o/app",
+            client_id="octop-client",
+            nonce="nonce",
+            httpx=jwks_client,
+        )
+
+
 def test_verify_id_token_rejects_wrong_issuer(
     signing_key: rsa.RSAPrivateKey, jwks_client: httpx.Client
 ) -> None:

--- a/tests/unit/auth/test_sso_service.py
+++ b/tests/unit/auth/test_sso_service.py
@@ -306,9 +306,7 @@ async def test_callback_verifies_id_token_against_discovery_issuer(
             return_value={"sub": "subject-123"},
         ) as verify,
     ):
-        started = service.start_login(
-            redirect_after="/chat", public_base="https://octop.example"
-        )
+        started = service.start_login(redirect_after="/chat", public_base="https://octop.example")
         state = httpx.QueryParams(started["authorization_url"].split("?", 1)[1])["state"]
         result = await service.handle_callback(
             code="authorization-code",

--- a/tests/unit/auth/test_sso_service.py
+++ b/tests/unit/auth/test_sso_service.py
@@ -278,6 +278,50 @@ async def test_callback_exchanges_code_and_attaches_login_code(service: SsoServi
 
 
 @pytest.mark.asyncio
+async def test_callback_verifies_id_token_against_discovery_issuer(
+    service: SsoService,
+) -> None:
+    service._services.user_repo.create(username="admin", role="admin")
+    configure_provider(service, issuer="https://sso.example/application/o/app/")
+    discovery_issuer = "https://sso.example/application/o/app/"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/application/o/app/.well-known/openid-configuration":
+            return httpx.Response(
+                200,
+                json={
+                    "issuer": discovery_issuer,
+                    "authorization_endpoint": "https://sso.example/application/o/app/authorize",
+                    "token_endpoint": "https://sso.example/application/o/app/token",
+                    "jwks_uri": "https://sso.example/application/o/app/jwks",
+                },
+            )
+        assert request.url.path == "/application/o/app/token"
+        return httpx.Response(200, json={"id_token": "signed-id-token"})
+
+    with (
+        discovery_client(handler),
+        patch(
+            "octop.infra.auth.sso.service.verify_id_token",
+            return_value={"sub": "subject-123"},
+        ) as verify,
+    ):
+        started = service.start_login(
+            redirect_after="/chat", public_base="https://octop.example"
+        )
+        state = httpx.QueryParams(started["authorization_url"].split("?", 1)[1])["state"]
+        result = await service.handle_callback(
+            code="authorization-code",
+            state=state,
+            error=None,
+            public_base="https://octop.example",
+        )
+
+    assert result.url.startswith("https://octop.example/login/oidc/complete#code=")
+    assert verify.call_args.kwargs["issuer"] == discovery_issuer
+
+
+@pytest.mark.asyncio
 async def test_exchange_login_code_is_one_shot_and_writes_audit(service: SsoService) -> None:
     user = User(id=42, username="member", role=Role.USER, display_name=None)
     provider = configure_provider(service)


### PR DESCRIPTION
## Summary

ID token verification now uses the issuer from OIDC discovery instead of `provider.issuer.rstrip("/")`. Providers whose discovery `issuer` (and ID token `iss`) keep a trailing slash — e.g. Authentik `.../application/o/app/` — no longer fail with `InvalidIssuerError` after a successful discovery fetch.

Tests cover trailing-slash acceptance, slash-mismatch rejection, and callback passing the discovery issuer into `verify_id_token`.

## Target branch

- [x] Base is **`develop`** (feature / fix — default)
- [ ] Base is **`main`** (`release/*` or `hotfix/*` only)

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / chore
- [ ] Release / hotfix

## Test plan

- [x] Added/updated tests (`tests/unit/auth/test_sso_id_token.py`, `tests/unit/auth/test_sso_service.py`)
- [ ] `make all` passes locally

## Checklist

- [ ] Updated `CHANGELOG.md` (if user-facing)
- [ ] README / docs updated (if needed)
