### PR TITLE
fix(thread_artifacts): avoid Path.resolve rewriting /home on macOS

### DIFF
--- a/src/octop/infra/agents/middleware/thread_artifacts.py
+++ b/src/octop/infra/agents/middleware/thread_artifacts.py
@@ -86,6 +86,15 @@ def _coerce_raw_path(path: str) -> str:
     return raw
 
 
+def _abs_workspace_dir(workspace_dir: Path) -> Path:
+    """Make ``workspace_dir`` absolute without following symlinks/firmlinks.
+
+    ``Path.resolve()`` on macOS rewrites ``/home/...`` to
+    ``/System/Volumes/Data/home/...``, which breaks relative/absolute dedupe.
+    """
+    return Path(os.path.abspath(os.path.expanduser(str(workspace_dir))))
+
+
 def normalize_artifact_path(path: str, workspace_dir: Path) -> str:
     """Return a path for ``threads.artifacts``, or ``\"\"``.
 
@@ -102,7 +111,7 @@ def normalize_artifact_path(path: str, workspace_dir: Path) -> str:
         rel = rel.removeprefix("workspace/")
     if not rel or not _artifact_path_allowed(rel):
         return ""
-    ws = workspace_dir.expanduser().resolve()
+    ws = _abs_workspace_dir(workspace_dir)
     return str((ws / rel).as_posix())
 
 
@@ -140,7 +149,7 @@ def extract_artifact_paths(
     """
     if not is_artifact_tool_name(tool_name):
         return []
-    ws = workspace_dir.expanduser().resolve() if workspace_dir is not None else None
+    ws = _abs_workspace_dir(workspace_dir) if workspace_dir is not None else None
     from_args = _dedupe_paths(_paths_from_args(args), ws)
     if from_args:
         return from_args
@@ -169,7 +178,7 @@ class ThreadArtifactsMiddleware(AgentMiddleware[Any, Any]):
     ) -> None:
         super().__init__()
         self._threads = thread_repo
-        self._workspace_dir = workspace_dir.expanduser().resolve()
+        self._workspace_dir = _abs_workspace_dir(workspace_dir)
 
     def wrap_tool_call(
         self,


### PR DESCRIPTION
## Summary

- Stop using `Path.resolve()` when normalizing thread artifact workspace paths, so macOS firmlinks do not rewrite `/home/...` to `/System/Volumes/Data/home/...`.
- Introduce `_abs_workspace_dir()` (`abspath` + `expanduser`) and use it in `normalize_artifact_path`, `extract_artifact_paths`, and `ThreadArtifactsMiddleware`, so relative/absolute path dedupe still works.

## Target branch

- [x] Base is **`develop`** (feature / fix — default)
- [ ] Base is **`main`** (`release/*` or `hotfix/*` only)

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / chore
- [ ] Release / hotfix

## Test plan

- Change is isolated to `thread_artifacts.py` path canonicalization; no `make all` run for this PR locally.

- [ ] `make all` passes locally
- [ ] Added/updated tests

## Checklist

- [ ] Updated `CHANGELOG.md` (if user-facing)
- [ ] README / docs updated (if needed)
