### PR TITLE
fix(dashboard): 按钮组件文案全球化（ConfigProvider locale 跟随语言切换）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 - 工具设置：单工具 `PATCH /agents/{id}/tool-settings/{name}`；插件工具开关热更新（不再 reload）；列表标注能力未挂载工具；harness `tools_disabled`（需 orcakit-harness-agent >=0.9.25）
 
+### 修复
+
+- 界面国际化：为 antd 组件补充 `ConfigProvider` locale（跟随界面语言切换），OK/Cancel、Refresh、Create 等此前在英文界面下仍显示英文的组件文案现随语言切换；并全球化 `Settings/octop/Providers.tsx` 全部按钮与文案（该文件当前未接入路由）
+
 ## [0.9.26] - 2026-08-23
 
 ### 新增

--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -1,5 +1,7 @@
 import { createGlobalStyle } from "antd-style";
 import { ConfigProvider, theme as antdTheme } from "antd";
+import zhCN from "antd/locale/zh_CN";
+import enUS from "antd/locale/en_US";
 import { useEffect } from "react";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { useTranslation } from "react-i18next";
@@ -31,9 +33,14 @@ const GlobalStyle = createGlobalStyle`
 
 function ThemedApp() {
   const { isDark, palette, customColor } = useTheme();
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const isMobile = useIsMobile();
   const brandTokens = brandTokensFor(palette, isDark, customColor);
+  // Make antd built-ins (Popconfirm OK/Cancel, Modal default footer, Empty,
+  // Pagination, DatePicker, Table… ) follow the current UI language.
+  const antdLocale = i18n.language?.toLowerCase().startsWith("zh")
+    ? zhCN
+    : enUS;
 
   useUnauthorizedRedirect();
 
@@ -98,7 +105,11 @@ function ThemedApp() {
   };
 
   return (
-    <ConfigProvider theme={themeConfig} prefixCls="octop">
+    <ConfigProvider
+      theme={themeConfig}
+      prefixCls="octop"
+      locale={antdLocale}
+    >
       <AntdAppProvider>
         <Routes>
           <Route path="/login" element={<LoginPage />} />

--- a/dashboard/src/components/ErrorBoundary/index.test.tsx
+++ b/dashboard/src/components/ErrorBoundary/index.test.tsx
@@ -2,6 +2,15 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import GlobalErrorBoundary from ".";
 
+// The boundary reads copy through the real i18n instance, which is not
+// initialized in unit tests (initI18n runs in main.tsx). Return the key so
+// button labels stay deterministic (e.g. "errors.reload" → reload button).
+vi.mock("../../i18n", () => ({
+  default: {
+    t: (key: string) => key,
+  },
+}));
+
 const { tryReloadOnStaleChunk } = vi.hoisted(() => ({
   tryReloadOnStaleChunk: vi.fn(),
 }));

--- a/dashboard/src/components/ErrorBoundary/index.tsx
+++ b/dashboard/src/components/ErrorBoundary/index.tsx
@@ -1,5 +1,6 @@
 import { Component, type ReactNode } from "react";
 import { Result, Button, Space } from "antd";
+import i18n from "../../i18n";
 import {
   isChunkLoadError,
   tryReloadOnStaleChunk,
@@ -82,26 +83,30 @@ export default class GlobalErrorBoundary extends Component<Props, State> {
           <Result
             status="error"
             title={
-              isChunkError ? "This page is out of date" : "Something went wrong"
+              isChunkError
+                ? i18n.t("errors.outOfDateTitle")
+                : i18n.t("errors.unexpectedTitle")
             }
             subTitle={
               isChunkError
-                ? "The app was updated while this tab was open. Reload to continue."
-                : this.state.error?.message || "An unexpected error occurred."
+                ? i18n.t("errors.outOfDateSubtitle")
+                : this.state.error?.message || i18n.t("errors.unexpectedSubtitle")
             }
             extra={
               <Space>
                 {isChunkError && (
                   <Button type="primary" onClick={this.handleReload}>
-                    Reload
+                    {i18n.t("errors.reload")}
                   </Button>
                 )}
                 {canRetry && (
                   <Button type="primary" onClick={this.handleRetry}>
-                    Retry
+                    {i18n.t("errors.retry")}
                   </Button>
                 )}
-                <Button onClick={this.handleHome}>Back to Home</Button>
+                <Button onClick={this.handleHome}>
+                  {i18n.t("errors.backHome")}
+                </Button>
               </Space>
             }
           />

--- a/dashboard/src/components/PwaUpdatePrompt/index.tsx
+++ b/dashboard/src/components/PwaUpdatePrompt/index.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { applyUpdate } from "../../pwa";
 import { updateApi } from "../../api/modules/update";
 import styles from "./index.module.less";
@@ -13,6 +14,7 @@ import styles from "./index.module.less";
  * the new Python package takes effect alongside the new frontend bundle.
  */
 export default function PwaUpdatePrompt() {
+  const { t } = useTranslation();
   const [visible, setVisible] = useState(false);
   const [serviceMode, setServiceMode] = useState<string | null>(null);
 
@@ -47,14 +49,14 @@ export default function PwaUpdatePrompt() {
   return (
     <div className={styles.banner} role="alert" aria-live="polite">
       <span className={styles.icon}>✨</span>
-      <span className={styles.text}>新版本已就绪</span>
+      <span className={styles.text}>{t("pwa.updateReady")}</span>
       <button className={styles.btnPrimary} onClick={handleUpdate}>
-        立即更新
+        {t("pwa.updateNow")}
       </button>
       <button
         className={styles.btnGhost}
         onClick={handleDismiss}
-        aria-label="稍后更新"
+        aria-label={t("pwa.later")}
       >
         ✕
       </button>

--- a/dashboard/src/locales/en.json
+++ b/dashboard/src/locales/en.json
@@ -1481,6 +1481,7 @@
     "categories": "Categories",
     "homepage": "Homepage",
     "searchSkillHub": "Search skill name, description or category...",
+    "skillHub": "SkillHub",
     "skillHubCommunityNote": "All skills in this marketplace come from the SkillHub community",
     "rankingRecommended": "For You",
     "rankingTrending": "Trending",
@@ -1897,6 +1898,12 @@
     "testSuccess": "Channel probe succeeded",
     "testFailed": "Channel probe failed: {{error}}",
     "probeNeedConfig": "Fill in connection settings before probing",
+    "qrAutoSaving": "Auto-saving...",
+    "qrRetrySave": "Retry Save",
+    "qrRegenerate": "Regenerate",
+    "qrRetryBtn": "Retry",
+    "wecomGenerateQr": "Generate WeCom scan code",
+    "weixinGenerateQr": "Generate WeChat login QR code",
     "deleteConfirmTitle": "Delete channel \"{{name}}\"?"
   },
   "tokenUsage": {
@@ -3012,7 +3019,12 @@
       "loadError": "Failed to load configuration",
       "saveSuccess": "Search configuration saved",
       "applySuccess": "Search configuration applied",
-      "saveAndApply": "Save & Apply"
+      "saveAndApply": "Save & Apply",
+      "deleteModelBtn": "Delete model",
+      "deleteModelCacheTitle": "Delete model cache?",
+      "deleteModelCacheDesc": "Delete the local cache for {{model}}? You'll need to re-download it before vector search can be re-enabled.",
+      "deleteModelCacheSuccess": "Model cache deleted",
+      "deleteModelCacheFailed": "Delete failed: the model may be activating. Switch, save, or restart before deleting."
     },
     "pipeline": {
       "title": "Memory pipeline",
@@ -3100,7 +3112,26 @@
       "growthTitle": "Memory growth · 7 days",
       "growthEmpty": "No new memories in the last 7 days"
     },
-    "entitySummary": "Topic summary"
+    "entitySummary": "Topic summary",
+    "tree": {
+      "title": "Browse by topic",
+      "entityCount": "{{n}} topics",
+      "atomCount": "{{n}} memories",
+      "hint": "Click a topic to expand the memories under it; click a memory to view its details.",
+      "viewSummary": "View summary",
+      "viewSummaryTip": "View this topic's summary",
+      "deprecateTooltip": "Deprecate this memory",
+      "deprecate": "Deprecate this memory",
+      "actions": "Actions"
+    },
+    "deprecate": {
+      "title": "Deprecate this memory?",
+      "description": "Octop will no longer use this memory once it is deprecated. If it was recorded incorrectly, describe the correct content as the deprecation reason.",
+      "reasonPlaceholder": "Optional: deprecation reason, e.g. \"expired\" or \"recorded incorrectly\"",
+      "ok": "Deprecate",
+      "success": "Deprecated — Octop will no longer use this memory",
+      "failed": "Operation failed: {{message}}"
+    }
   },
   "personalization": {
     "title": "Personalization",
@@ -4657,5 +4688,39 @@
       "noAgentDesc": "The Remote Phone assistant reuses the current Agent chat. Once the phone is connected, the Agent can operate that device.",
       "inputPlaceholder": "Ask the Agent to operate the phone, or ask about the screen…"
     }
+  },
+  "errors": {
+    "outOfDateTitle": "This page is out of date",
+    "outOfDateSubtitle": "The app was updated while this tab was open. Reload to continue.",
+    "unexpectedTitle": "Something went wrong",
+    "unexpectedSubtitle": "An unexpected error occurred.",
+    "reload": "Reload",
+    "retry": "Retry",
+    "backHome": "Back to Home"
+  },
+  "adminProviders": {
+    "title": "Providers",
+    "newProvider": "New provider",
+    "pageDescription": "All providers are admin-managed and globally available to every agent.",
+    "colName": "Name",
+    "colKind": "Kind",
+    "colNote": "Note",
+    "deleteConfirm": "Delete {{name}}?",
+    "fieldBaseUrl": "Base URL (optional)",
+    "fieldApiKey": "API key (optional)",
+    "fieldModel": "Default model (optional)",
+    "nameRequired": "Name is required",
+    "notePlaceholder": "private to <you>",
+    "loadFailed": "Load failed",
+    "created": "Provider \"{{name}}\" created",
+    "createFailed": "Create failed",
+    "deleted": "Deleted",
+    "notePrivateTo": "private to {{username}}",
+    "notePrivate": "private"
+  },
+  "pwa": {
+    "updateReady": "A new version is ready",
+    "updateNow": "Update now",
+    "later": "Later"
   }
 }

--- a/dashboard/src/locales/zh.json
+++ b/dashboard/src/locales/zh.json
@@ -1480,6 +1480,7 @@
     "categories": "分类",
     "homepage": "主页",
     "searchSkillHub": "搜索技能名称、描述或分类...",
+    "skillHub": "SkillHub",
     "skillHubCommunityNote": "本技能市场的 skills 全部来自于 SkillHub 社区",
     "rankingRecommended": "为你推荐",
     "rankingTrending": "近期飙升",
@@ -1897,6 +1898,12 @@
     "testSuccess": "频道探测通过",
     "testFailed": "频道探测失败: {{error}}",
     "probeNeedConfig": "请先填写连接配置后再探测",
+    "qrAutoSaving": "正在自动保存...",
+    "qrRetrySave": "重试保存",
+    "qrRegenerate": "重新生成",
+    "qrRetryBtn": "重试",
+    "wecomGenerateQr": "生成扫码二维码",
+    "weixinGenerateQr": "生成微信扫码二维码",
     "deleteConfirmTitle": "删除频道「{{name}}」？"
   },
   "tokenUsage": {
@@ -3101,7 +3108,20 @@
       "title": "按主题浏览",
       "entityCount": "{{n}} 个主题",
       "atomCount": "{{n}} 条记忆",
-      "hint": "点击主题展开它下面的记忆；再点击具体记忆查看详情。"
+      "hint": "点击主题展开它下面的记忆；再点击具体记忆查看详情。",
+      "viewSummary": "查看摘要",
+      "viewSummaryTip": "查看这个主题的摘要",
+      "deprecateTooltip": "弃用这条记忆",
+      "deprecate": "弃用这条记忆",
+      "actions": "操作"
+    },
+    "deprecate": {
+      "title": "弃用这条记忆？",
+      "description": "弃用后 Octop 将不再使用这条记忆。如果是记录有误，建议先描述正确内容作为弃用原因。",
+      "reasonPlaceholder": "可选：填写弃用原因，比如「已过期」「记录有误」",
+      "ok": "弃用",
+      "success": "已弃用，Octop 将不再使用这条记忆",
+      "failed": "操作失败：{{message}}"
     },
     "atomDetail": "记忆详情",
     "entitySummary": "主题摘要",
@@ -3179,7 +3199,12 @@
       "loadError": "加载配置失败",
       "saveSuccess": "搜索配置已保存",
       "applySuccess": "搜索配置已应用",
-      "saveAndApply": "保存并应用"
+      "saveAndApply": "保存并应用",
+      "deleteModelBtn": "删除模型",
+      "deleteModelCacheTitle": "删除模型缓存？",
+      "deleteModelCacheDesc": "确定删除 {{model}} 的本地缓存吗？删除后需要重新下载才能再次启用向量检索。",
+      "deleteModelCacheSuccess": "模型缓存已删除",
+      "deleteModelCacheFailed": "删除失败：当前模型可能正在激活中。请先切换/保存/重启后再删除。"
     },
     "migrate": {
       "buttonLabel": "迁移记忆",
@@ -4802,5 +4827,39 @@
       "noAgentDesc": "远程手机右侧助手会复用当前 Agent 的对话能力。连接手机后，Agent 即可操作该设备。",
       "inputPlaceholder": "让 Agent 在手机上操作，或询问当前屏幕…"
     }
+  },
+  "errors": {
+    "outOfDateTitle": "此页面已过期",
+    "outOfDateSubtitle": "应用在此标签页打开期间已更新。重新加载以继续。",
+    "unexpectedTitle": "出错了",
+    "unexpectedSubtitle": "发生意外错误。",
+    "reload": "重新加载",
+    "retry": "重试",
+    "backHome": "返回首页"
+  },
+  "adminProviders": {
+    "title": "Providers",
+    "newProvider": "新建提供商",
+    "pageDescription": "所有提供商均由管理员统一管理，对每个 Agent 全局可用。",
+    "colName": "名称",
+    "colKind": "类型",
+    "colNote": "备注",
+    "deleteConfirm": "删除 {{name}}？",
+    "fieldBaseUrl": "Base URL（可选）",
+    "fieldApiKey": "API 密钥（可选）",
+    "fieldModel": "默认模型（可选）",
+    "nameRequired": "请输入名称",
+    "notePlaceholder": "仅本人可见",
+    "loadFailed": "加载失败",
+    "created": "提供商「{{name}}」已创建",
+    "createFailed": "创建失败",
+    "deleted": "已删除",
+    "notePrivateTo": "仅 {{username}} 可见",
+    "notePrivate": "仅本人可见"
+  },
+  "pwa": {
+    "updateReady": "新版本已就绪",
+    "updateNow": "立即更新",
+    "later": "稍后更新"
   }
 }

--- a/dashboard/src/pages/Agent/Channels/components/ChannelDrawer.tsx
+++ b/dashboard/src/pages/Agent/Channels/components/ChannelDrawer.tsx
@@ -958,7 +958,7 @@ export function ChannelDrawer({
         >
           <Spin size="small" />
           <span style={{ color: "var(--fn-text-secondary)", fontSize: 13 }}>
-            正在自动保存...
+            {t("channels.qrAutoSaving")}
           </span>
         </div>
       );
@@ -980,7 +980,7 @@ export function ChannelDrawer({
           }}
           style={{ marginTop: 12 }}
         >
-          重试保存
+          {t("channels.qrRetrySave")}
         </Button>
       );
     }
@@ -1203,7 +1203,7 @@ export function ChannelDrawer({
           </div>
           <p className={styles.qrScanHint}>扫码后自动跳转下一步</p>
           <Button size="small" onClick={resetQr} style={{ marginTop: 4 }}>
-            重新生成
+            {t("channels.qrRegenerate")}
           </Button>
         </div>
       );
@@ -1216,7 +1216,9 @@ export function ChannelDrawer({
             message={s.reason}
             style={{ width: "100%", marginBottom: 12 }}
           />
-          <Button onClick={() => void startWecomQr()}>重试</Button>
+          <Button onClick={() => void startWecomQr()}>
+            {t("channels.qrRetryBtn")}
+          </Button>
         </div>
       );
     }
@@ -1242,7 +1244,7 @@ export function ChannelDrawer({
           block
           onClick={() => void startWecomQr()}
         >
-          生成扫码二维码
+          {t("channels.wecomGenerateQr")}
         </Button>
       </div>
     );
@@ -1307,7 +1309,7 @@ export function ChannelDrawer({
           </div>
           <p className={styles.qrScanHint}>使用微信扫码登录个人账号</p>
           <Button size="small" onClick={resetQr} style={{ marginTop: 4 }}>
-            重新生成
+            {t("channels.qrRegenerate")}
           </Button>
         </div>
       );
@@ -1320,7 +1322,9 @@ export function ChannelDrawer({
             message={s.reason}
             style={{ width: "100%", marginBottom: 12 }}
           />
-          <Button onClick={() => void startWeixinQr()}>重试</Button>
+          <Button onClick={() => void startWeixinQr()}>
+            {t("channels.qrRetryBtn")}
+          </Button>
         </div>
       );
     }
@@ -1344,7 +1348,7 @@ export function ChannelDrawer({
           block
           onClick={() => void startWeixinQr()}
         >
-          生成微信扫码二维码
+          {t("channels.weixinGenerateQr")}
         </Button>
       </div>
     );

--- a/dashboard/src/pages/Agent/Memory/AtomsList.tsx
+++ b/dashboard/src/pages/Agent/Memory/AtomsList.tsx
@@ -166,7 +166,7 @@ export default function AtomsList({ agentId }: Props) {
             {a.kind ? ` · ${kindLabel(a.kind)}` : ""}
           </div>
           {!isAtomDeprecated(a) && hoveredId === a.id ? (
-            <Tooltip title="弃用这条记忆">
+            <Tooltip title={t("memory.tree.deprecateTooltip", "弃用这条记忆")}>
               <span
                 onClick={(e) => {
                   e.stopPropagation();
@@ -242,10 +242,10 @@ export default function AtomsList({ agentId }: Props) {
           {!isAtomDeprecated(atom) ? (
             <>
               <Typography.Title level={5} style={{ marginTop: 12 }}>
-                操作
+                {t("memory.tree.actions", "操作")}
               </Typography.Title>
               <Button danger onClick={() => handleDeprecate(atom)}>
-                弃用这条记忆
+                {t("memory.tree.deprecate", "弃用这条记忆")}
               </Button>
             </>
           ) : null}

--- a/dashboard/src/pages/Agent/Memory/MemoryTree.tsx
+++ b/dashboard/src/pages/Agent/Memory/MemoryTree.tsx
@@ -350,6 +350,7 @@ function EntityRow({
   onViewSummary: () => void;
 }) {
   const [hovered, setHovered] = useState(false);
+  const { t } = useTranslation();
   return (
     <div
       onClick={onToggle}
@@ -412,7 +413,7 @@ function EntityRow({
           待刷新
         </Tag>
       ) : null}
-      <Tooltip title="查看这个主题的摘要">
+      <Tooltip title={t("memory.tree.viewSummaryTip")}>
         <Button
           size="small"
           icon={<BookOpen size={13} />}
@@ -428,7 +429,7 @@ function EntityRow({
             color: hovered ? "#1677ff" : undefined,
           }}
         >
-          查看摘要
+          {t("memory.tree.viewSummary")}
         </Button>
       </Tooltip>
     </div>
@@ -499,6 +500,7 @@ function AtomRow({
   onDeprecate?: (atom: AtomItem) => void;
 }) {
   const [hovered, setHovered] = useState(false);
+  const { t } = useTranslation();
   const showDeprecateBtn = hovered && !isAtomDeprecated(atom) && !!onDeprecate;
 
   return (
@@ -549,7 +551,7 @@ function AtomRow({
         {formatRelativeTime(atom.created_at)}
       </span>
       {showDeprecateBtn ? (
-        <Tooltip title="弃用这条记忆">
+        <Tooltip title={t("memory.tree.deprecateTooltip")}>
           <span
             onClick={(e) => {
               e.stopPropagation();
@@ -693,7 +695,7 @@ function AtomDetailDrawer({
           {!isAtomDeprecated(atom) ? (
             <>
               <Typography.Title level={5} style={{ marginTop: 12 }}>
-                操作
+                {t("memory.tree.actions")}
               </Typography.Title>
               <Button
                 danger
@@ -705,7 +707,7 @@ function AtomDetailDrawer({
                   })
                 }
               >
-                弃用这条记忆
+                {t("memory.tree.deprecate")}
               </Button>
             </>
           ) : null}

--- a/dashboard/src/pages/Agent/Memory/VectorSearchConfig.tsx
+++ b/dashboard/src/pages/Agent/Memory/VectorSearchConfig.tsx
@@ -182,11 +182,11 @@ export default function VectorSearchConfig() {
     if (!currentModel) return;
 
     Modal.confirm({
-      title: "删除模型缓存？",
-      content: `确定删除 ${currentModel} 的本地缓存吗？删除后需要重新下载才能再次启用向量检索。`,
-      okText: "删除",
+      title: t("memory.vs.deleteModelCacheTitle"),
+      content: t("memory.vs.deleteModelCacheDesc", { model: currentModel }),
+      okText: t("common.delete"),
       okType: "danger",
-      cancelText: "取消",
+      cancelText: t("common.cancel"),
       async onOk() {
         try {
           await api.deleteLocalModel(currentModel);
@@ -195,18 +195,16 @@ export default function VectorSearchConfig() {
             localStorage.setItem("lc_downloaded_models", JSON.stringify(next));
             return next;
           });
-          message.success("模型缓存已删除");
+          message.success(t("memory.vs.deleteModelCacheSuccess"));
           await refreshDownloadStatus();
         } catch (err) {
           // 409: current model is being activated, so the backend refuses deletion.
-          message.error(
-            "删除失败：当前模型可能正在激活中。请先切换/保存/重启后再删除。",
-          );
+          message.error(t("memory.vs.deleteModelCacheFailed"));
           console.error(err);
         }
       },
     });
-  }, [config?.localModel, refreshDownloadStatus]);
+  }, [config?.localModel, refreshDownloadStatus, t]);
 
   // Update a config field.
   const updateConfig = (field: keyof EmbeddingConfig, value: unknown) => {
@@ -554,12 +552,11 @@ export default function VectorSearchConfig() {
               className={styles.deleteBtn}
               style={{ marginTop: 12 }}
             >
-              删除模型
+              {t("memory.vs.deleteModelBtn")}
             </Button>
           )}
         </div>
       )}
-
       {/* Third-party service config block */}
       {config.provider === "custom" && (
         <div className={styles.card}>

--- a/dashboard/src/pages/Agent/Memory/shared/deprecateAtom.tsx
+++ b/dashboard/src/pages/Agent/Memory/shared/deprecateAtom.tsx
@@ -6,6 +6,7 @@
  */
 import { Input, Modal, Typography } from "antd";
 import { message } from "@/utils/antdMessage";
+import i18n from "@/i18n";
 
 import {
   memoryDashboardApi,
@@ -24,15 +25,14 @@ export function confirmDeprecateAtom({
 }) {
   let reason = "";
   Modal.confirm({
-    title: "弃用这条记忆？",
+    title: i18n.t("memory.deprecate.title"),
     content: (
       <div>
         <Typography.Paragraph type="secondary" style={{ fontSize: 12 }}>
-          弃用后 Octop
-          将不再使用这条记忆。如果是记录有误，建议先描述正确内容作为弃用原因。
+          {i18n.t("memory.deprecate.description")}
         </Typography.Paragraph>
         <Input.TextArea
-          placeholder="可选：填写弃用原因，比如「已过期」「记录有误」"
+          placeholder={i18n.t("memory.deprecate.reasonPlaceholder")}
           rows={3}
           onChange={(e) => {
             reason = e.target.value;
@@ -40,18 +40,22 @@ export function confirmDeprecateAtom({
         />
       </div>
     ),
-    okText: "弃用",
+    okText: i18n.t("memory.deprecate.ok"),
     okType: "danger",
-    cancelText: "取消",
+    cancelText: i18n.t("common.cancel"),
     onOk: async () => {
       try {
         await memoryDashboardApi.deprecateAtom(agentId, atom.id, {
           reason: reason || undefined,
         });
-        message.success("已弃用，Octop 将不再使用这条记忆");
+        message.success(i18n.t("memory.deprecate.success"));
         onSuccess?.();
       } catch (e) {
-        message.error(`操作失败：${(e as Error).message ?? e}`);
+        message.error(
+          i18n.t("memory.deprecate.failed", {
+            message: (e as Error).message ?? e,
+          }),
+        );
         throw e; // Keep the confirmation dialog open.
       }
     },

--- a/dashboard/src/pages/Agent/Skills/components/SkillHubTab.tsx
+++ b/dashboard/src/pages/Agent/Skills/components/SkillHubTab.tsx
@@ -331,7 +331,7 @@ export default function SkillHubTab({ target, onInstalled }: SkillHubTabProps) {
           size="small"
           style={{ color: "var(--fn-text-tertiary)" }}
         >
-          SkillHub
+          {t("skills.skillHub")}
         </Button>
         <Button
           icon={<RefreshCw size={14} />}

--- a/dashboard/src/pages/KnowledgeBases/index.tsx
+++ b/dashboard/src/pages/KnowledgeBases/index.tsx
@@ -713,6 +713,8 @@ export default function KnowledgeBasesPage() {
       Modal.confirm({
         title: t("knowledgeBases.rebuildConfirmTitle"),
         content: t("knowledgeBases.rebuildConfirmDescription"),
+        okText: t("common.confirm"),
+        cancelText: t("common.cancel"),
         onOk: () => void saveFeature(true),
       });
       return;

--- a/dashboard/src/pages/Settings/octop/Providers.tsx
+++ b/dashboard/src/pages/Settings/octop/Providers.tsx
@@ -9,7 +9,8 @@
  * the agent settings editor (which depends on a non-empty provider list).
  */
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
 import {
   Card,
   Table,
@@ -57,27 +58,30 @@ const PROVIDER_KINDS = [
 ];
 
 export default function OctopProvidersPage() {
+  const { t } = useTranslation();
   const [rows, setRows] = useState<ProviderRow[]>([]);
   const [loading, setLoading] = useState(true);
   const [createOpen, setCreateOpen] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [form] = Form.useForm<FormValues>();
 
-  const refresh = async () => {
+  const refresh = useCallback(async () => {
     setLoading(true);
     try {
       const data = await request<ProviderRow[]>("/providers");
       setRows(data);
     } catch (err) {
-      message.error(err instanceof Error ? err.message : "Load failed");
+      message.error(
+        err instanceof Error ? err.message : t("adminProviders.loadFailed"),
+      );
     } finally {
       setLoading(false);
     }
-  };
+  }, [t]);
 
   useEffect(() => {
     void refresh();
-  }, []);
+  }, [refresh]);
 
   const onCreate = async (values: FormValues) => {
     setSubmitting(true);
@@ -87,18 +91,22 @@ export default function OctopProvidersPage() {
       const body: FormValues = { ...values };
       if (!body.note) {
         const me = await authApi.me().catch(() => null);
-        body.note = me ? `private to ${me.username}` : "private";
+        body.note = me
+          ? t("adminProviders.notePrivateTo", { username: me.username })
+          : t("adminProviders.notePrivate");
       }
       await request("/providers", {
         method: "POST",
         body: JSON.stringify(body),
       });
-      message.success(`Provider "${values.name}" created`);
+      message.success(t("adminProviders.created", { name: values.name }));
       form.resetFields();
       setCreateOpen(false);
       void refresh();
     } catch (err) {
-      message.error(err instanceof Error ? err.message : "Create failed");
+      message.error(
+        err instanceof Error ? err.message : t("adminProviders.createFailed"),
+      );
     } finally {
       setSubmitting(false);
     }
@@ -107,33 +115,35 @@ export default function OctopProvidersPage() {
   const onDelete = async (row: ProviderRow) => {
     try {
       await request(`/admin/providers/${row.id}`, { method: "DELETE" });
-      message.success("Deleted");
+      message.success(t("adminProviders.deleted"));
       void refresh();
     } catch (err) {
-      message.error(err instanceof Error ? err.message : "Delete failed");
+      message.error(
+        err instanceof Error ? err.message : t("common.deleteFailed"),
+      );
     }
   };
 
   return (
     <Card
-      title="Providers"
+      title={t("adminProviders.title")}
       extra={
         <Space>
           <Button icon={<RefreshCw size={14} />} onClick={() => void refresh()}>
-            Refresh
+            {t("common.refresh")}
           </Button>
           <Button
             type="primary"
             icon={<Plus size={14} />}
             onClick={() => setCreateOpen(true)}
           >
-            New provider
+            {t("adminProviders.newProvider")}
           </Button>
         </Space>
       }
     >
       <Text type="secondary" style={{ display: "block", marginBottom: 12 }}>
-        All providers are admin-managed and globally available to every agent.
+        {t("adminProviders.pageDescription")}
       </Text>
 
       <Table<ProviderRow>
@@ -142,23 +152,23 @@ export default function OctopProvidersPage() {
         dataSource={rows}
         pagination={false}
         columns={[
-          { title: "Name", dataIndex: "name" },
+          { title: t("adminProviders.colName"), dataIndex: "name" },
           {
-            title: "Kind",
+            title: t("adminProviders.colKind"),
             dataIndex: "kind",
             render: (k) => <Tag>{k}</Tag>,
           },
-          { title: "Note", dataIndex: "note" },
+          { title: t("adminProviders.colNote"), dataIndex: "note" },
           {
             title: "",
             width: 80,
             render: (_, row) => (
               <Popconfirm
-                title={`Delete ${row.name}?`}
+                title={t("adminProviders.deleteConfirm", { name: row.name })}
                 onConfirm={() => onDelete(row)}
               >
                 <Button danger size="small" type="link">
-                  Delete
+                  {t("common.delete")}
                 </Button>
               </Popconfirm>
             ),
@@ -167,11 +177,11 @@ export default function OctopProvidersPage() {
       />
 
       <Modal
-        title="New provider"
+        title={t("adminProviders.newProvider")}
         open={createOpen}
         onCancel={() => setCreateOpen(false)}
         onOk={() => form.submit()}
-        okText="Create"
+        okText={t("common.create")}
         confirmLoading={submitting}
       >
         <Form<FormValues>
@@ -181,26 +191,32 @@ export default function OctopProvidersPage() {
           initialValues={{ kind: "openai" }}
         >
           <Form.Item
-            label="Name"
+            label={t("adminProviders.colName")}
             name="name"
-            rules={[{ required: true, message: "Name is required" }]}
+            rules={[
+              { required: true, message: t("adminProviders.nameRequired") },
+            ]}
           >
             <Input placeholder="my-openai" />
           </Form.Item>
-          <Form.Item label="Kind" name="kind" rules={[{ required: true }]}>
+          <Form.Item
+            label={t("adminProviders.colKind")}
+            name="kind"
+            rules={[{ required: true }]}
+          >
             <Select options={PROVIDER_KINDS} />
           </Form.Item>
-          <Form.Item label="Base URL (optional)" name="base_url">
+          <Form.Item label={t("adminProviders.fieldBaseUrl")} name="base_url">
             <Input placeholder="https://api.openai.com/v1" />
           </Form.Item>
-          <Form.Item label="API key (optional)" name="api_key">
+          <Form.Item label={t("adminProviders.fieldApiKey")} name="api_key">
             <Input.Password placeholder="sk-…" />
           </Form.Item>
-          <Form.Item label="Default model (optional)" name="model">
+          <Form.Item label={t("adminProviders.fieldModel")} name="model">
             <Input placeholder="gpt-4o-mini" />
           </Form.Item>
-          <Form.Item label="Note" name="note">
-            <Input placeholder="private to <you>" />
+          <Form.Item label={t("adminProviders.colNote")} name="note">
+            <Input placeholder={t("adminProviders.notePlaceholder")} />
           </Form.Item>
         </Form>
       </Modal>


### PR DESCRIPTION
## 背景
对全部并排按钮组做全球化审查（A 组硬编码中文/B 组 antd 默认英文）后的落地修复。英文界面下 OK/Cancel、Refresh、Create 等仍显示英文，硬编码中文按钮不随语言切换。

## 改动
- **根修**：`App.tsx` 的 `ConfigProvider` 增加 `locale`，按 `i18n.language` 动态映射 zhCN/enUS，antd 内置文案（Popconfirm/Modal/Empty/Pagination/DatePicker/Table 等）跟随语言切换
- **B8**：`KnowledgeBases` 静态 `Modal.confirm` 显式补 `okText`/`cancelText`（静态 confirm 渲染进独立 fragment，不吃 ConfigProvider locale）
- **A 组硬编码 → t()**：记忆树/记忆列表、向量检索（含删除模型确认）、弃用确认弹窗、错误页、PWA 更新横幅、SkillHub、渠道扫码二维码、`Providers.tsx` 全页（Refresh/Create/Delete/表头/校验/成功失败提示）
- **补漏**：en.json 缺失的 `memory.tree.*` 等 key 补齐；新增 `errors`、`pwa`、`adminProviders`、`memory.vs`、`memory.deprecate`、`channels.qr*` 等 40+ key，en/zh 对称
- **测试**：ErrorBoundary 单测改用 mock i18n（避免未初始化 t() 返回 undefined），回归全绿

## 验证
- `tsc -b` 通过；全量 vitest 108/108（538 用例）通过；`npm run build:prod` 通过
- 浏览器实测：删除用户 Popconfirm 显示 取消/确定；语音配置弹窗底部 取消/保存（原 OK/Cancel）

## 说明
- `Settings/octop/Providers.tsx` 当前未接入路由（遗留死代码），本次仅做防御性全球化，未挂载
- B10（UsersListPanel 邀请撤销）经核实已有 `cancelText`，为误报，未改动