### PR TITLE
fix(dashboard): copy via copy-to-clipboard on HTTP pages

### DIFF
--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -18,6 +18,7 @@
         "antd": "^5.29.1",
         "antd-style": "^3.7.1",
         "build": "^0.1.4",
+        "copy-to-clipboard": "^4.0.2",
         "docx-preview": "^0.3.2",
         "i18next": "^25.8.4",
         "jszip": "^3.10.1",
@@ -4885,6 +4886,15 @@
         "react": ">=18"
       }
     },
+    "node_modules/antd/node_modules/copy-to-clipboard": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.3.tgz",
+      "integrity": "sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==",
+      "license": "MIT",
+      "dependencies": {
+        "toggle-selection": "^1.0.6"
+      }
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://mirrors.tencent.com/npm/argparse/-/argparse-2.0.1.tgz",
@@ -5566,13 +5576,10 @@
       }
     },
     "node_modules/copy-to-clipboard": {
-      "version": "3.3.3",
-      "resolved": "https://mirrors.tencent.com/npm/copy-to-clipboard/-/copy-to-clipboard-3.3.3.tgz",
-      "integrity": "sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==",
-      "license": "MIT",
-      "dependencies": {
-        "toggle-selection": "^1.0.6"
-      }
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-4.0.2.tgz",
+      "integrity": "sha512-gklSft7IuhriZKHKpuoA1fpJSLPNgvUMWMo5BlnzAJm0zNKnznoSv23IjtNqclx8eKi6ZcdvFFzYEER/+U1LoQ==",
+      "license": "MIT"
     },
     "node_modules/core-js-compat": {
       "version": "3.49.0",
@@ -13385,7 +13392,7 @@
     },
     "node_modules/toggle-selection": {
       "version": "1.0.6",
-      "resolved": "https://mirrors.tencent.com/npm/toggle-selection/-/toggle-selection-1.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
       "integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ==",
       "license": "MIT"
     },

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -30,6 +30,7 @@
     "antd": "^5.29.1",
     "antd-style": "^3.7.1",
     "build": "^0.1.4",
+    "copy-to-clipboard": "^4.0.2",
     "docx-preview": "^0.3.2",
     "i18next": "^25.8.4",
     "jszip": "^3.10.1",

--- a/dashboard/src/components/CopyableResourceId.tsx
+++ b/dashboard/src/components/CopyableResourceId.tsx
@@ -4,6 +4,7 @@ import { Copy } from "lucide-react";
 import { useTranslation } from "react-i18next";
 
 import { message } from "@/utils/antdMessage";
+import { copyText } from "@/utils/copyText";
 import styles from "./CopyableResourceId.module.less";
 
 type CopyableResourceIdProps = {
@@ -25,12 +26,9 @@ export function CopyableResourceId({
   const { t } = useTranslation();
 
   const copy = useCallback(async () => {
-    try {
-      await navigator.clipboard.writeText(value);
-      message.success(t("common.copied"));
-    } catch {
-      message.error(t("common.copyFailed"));
-    }
+    const ok = await copyText(value);
+    if (ok) message.success(t("common.copied"));
+    else message.error(t("common.copyFailed"));
   }, [t, value]);
 
   return (

--- a/dashboard/src/components/Markdown/index.tsx
+++ b/dashboard/src/components/Markdown/index.tsx
@@ -19,6 +19,7 @@ import {
   isAuthDownloadHref,
 } from "../AuthFileDownloadLink";
 import { isShellLanguage } from "../../utils/shellCodeBlock";
+import { copyText } from "../../utils/copyText";
 import { loadMermaid } from "./mermaidLoader";
 import { HighlightedCode } from "./syntaxHighlight";
 import { useMathPlugins } from "./mathPlugins";
@@ -223,23 +224,10 @@ function CodeCopyButton({ code }: { code: string }) {
   const [copied, setCopied] = useState(false);
 
   const handleCopy = async () => {
-    try {
-      await navigator.clipboard.writeText(code);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    } catch {
-      // fallback
-      const ta = document.createElement("textarea");
-      ta.value = code;
-      ta.style.position = "fixed";
-      ta.style.left = "-9999px";
-      document.body.appendChild(ta);
-      ta.select();
-      document.execCommand("copy");
-      ta.remove();
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    }
+    const ok = await copyText(code);
+    if (!ok) return;
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
   };
 
   return (

--- a/dashboard/src/components/MarkdownCopy/MarkdownCopy.tsx
+++ b/dashboard/src/components/MarkdownCopy/MarkdownCopy.tsx
@@ -7,6 +7,7 @@ import Markdown from "../Markdown/LazyMarkdown";
 import { useTranslation } from "react-i18next";
 import type { CSSProperties } from "react";
 import { stripFrontmatter } from "../../utils/markdown";
+import { copyText } from "../../utils/copyText";
 import styles from "./index.module.less";
 
 interface MarkdownCopyProps {
@@ -78,36 +79,9 @@ export function MarkdownCopy({
 
     setIsCopying(true);
     try {
-      if (navigator.clipboard && window.isSecureContext) {
-        try {
-          await navigator.clipboard.writeText(contentToCopy);
-        } catch {
-          // Clipboard API can fail in PWA standalone mode when the document
-          // loses focus briefly — fall through to execCommand.
-          const textArea = document.createElement("textarea");
-          textArea.value = contentToCopy;
-          textArea.style.position = "fixed";
-          textArea.style.left = "-999999px";
-          textArea.style.top = "-999999px";
-          document.body.appendChild(textArea);
-          textArea.focus();
-          textArea.select();
-          document.execCommand("copy");
-          textArea.remove();
-        }
-      } else {
-        const textArea = document.createElement("textarea");
-        textArea.value = contentToCopy;
-        textArea.style.position = "fixed";
-        textArea.style.left = "-999999px";
-        textArea.style.top = "-999999px";
-        document.body.appendChild(textArea);
-        textArea.focus();
-        textArea.select();
-        document.execCommand("copy");
-        textArea.remove();
-      }
-      message.success(t("common.copied"));
+      const ok = await copyText(contentToCopy);
+      if (ok) message.success(t("common.copied"));
+      else message.error(t("common.copyFailed"));
     } catch (err) {
       console.error("Failed to copy text: ", err);
       message.error(t("common.copyFailed"));

--- a/dashboard/src/pages/Admin/Storage/DockerEnvFooter.tsx
+++ b/dashboard/src/pages/Admin/Storage/DockerEnvFooter.tsx
@@ -15,6 +15,7 @@ import {
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { request } from "../../../api/request";
+import { copyText } from "../../../utils/copyText";
 import styles from "./dockerEnvFooter.module.less";
 
 export type DockerEnvStatus =
@@ -36,15 +37,6 @@ export interface DockerEnvResult {
   install_script?: string;
   agent_prompt?: string;
   can_auto_install?: boolean;
-}
-
-async function copyText(text: string): Promise<boolean> {
-  try {
-    await navigator.clipboard.writeText(text);
-    return true;
-  } catch {
-    return false;
-  }
 }
 
 export function DockerEnvFooter() {

--- a/dashboard/src/pages/Admin/Users/SsoPanel.tsx
+++ b/dashboard/src/pages/Admin/Users/SsoPanel.tsx
@@ -9,6 +9,7 @@ import {
   type OidcConfigPut,
 } from "../../../api/modules/sso";
 import { apiErrorMessage } from "../../../utils/apiError";
+import { copyText } from "../../../utils/copyText";
 
 interface SsoFormValues {
   enabled: boolean;
@@ -98,12 +99,9 @@ export default function SsoPanel() {
   };
 
   const copyRedirectUri = async () => {
-    try {
-      await navigator.clipboard.writeText(redirectUri);
-      message.success(t("adminSso.copySuccess"));
-    } catch {
-      message.error(t("adminSso.copyFailed"));
-    }
+    const ok = await copyText(redirectUri);
+    if (ok) message.success(t("adminSso.copySuccess"));
+    else message.error(t("adminSso.copyFailed"));
   };
 
   return (

--- a/dashboard/src/pages/Agent/Connectors/index.tsx
+++ b/dashboard/src/pages/Agent/Connectors/index.tsx
@@ -19,6 +19,7 @@ import PageShell from "../../../layouts/PageShell";
 import { useCurrentUser } from "../../../hooks/useCurrentUser";
 import { userCan } from "../../../utils/permissions";
 import { apiErrorMessage } from "../../../utils/apiError";
+import { copyText } from "../../../utils/copyText";
 import {
   clearFormDraft,
   loadFormDraft,
@@ -409,10 +410,10 @@ function ConnectorConfigDrawer({
   };
 
   const handleCopyInstallCommand = async (command: string) => {
-    try {
-      await navigator.clipboard.writeText(command);
+    const ok = await copyText(command);
+    if (ok) {
       message.success(t("connectors.cliInstallCopied", "安装命令已复制"));
-    } catch {
+    } else {
       message.error(
         t("connectors.clipboardDenied", "无法读取剪贴板，请手动粘贴"),
       );

--- a/dashboard/src/pages/Agent/Personalization/hooks/useFileEditor.ts
+++ b/dashboard/src/pages/Agent/Personalization/hooks/useFileEditor.ts
@@ -2,6 +2,7 @@ import { useState, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 
 import { message } from "@/utils/antdMessage";
+import { copyText } from "@/utils/copyText";
 
 export interface FileEditorState {
   content: string;
@@ -98,12 +99,9 @@ export function useFileEditor(): [FileEditorState, FileEditorActions] {
   }, []);
 
   const copyToClipboard = useCallback(async () => {
-    try {
-      await navigator.clipboard.writeText(content);
-      message.success(t("common.copied"));
-    } catch {
-      message.error(t("common.copyFailed"));
-    }
+    const ok = await copyText(content);
+    if (ok) message.success(t("common.copied"));
+    else message.error(t("common.copyFailed"));
   }, [content, t]);
 
   const state: FileEditorState = {

--- a/dashboard/src/pages/Chat/components/MessageBubble.tsx
+++ b/dashboard/src/pages/Chat/components/MessageBubble.tsx
@@ -29,6 +29,7 @@ import {
 } from "../../../utils/toolMediaBlocks";
 import { formatToolArguments } from "../../../utils/formatToolArguments";
 import { formatMessageTime } from "../../../utils/formatMessageTime";
+import { copyText } from "../../../utils/copyText";
 import { useServerTimezone } from "../../../hooks/useServerTimezone";
 import {
   useToolDisplayNames,
@@ -286,42 +287,14 @@ function CopyButton({ text }: { text: string }) {
 
   const handleCopy = useCallback(async () => {
     if (!text) return;
-    try {
-      if (navigator.clipboard && window.isSecureContext) {
-        try {
-          await navigator.clipboard.writeText(text);
-        } catch {
-          // Clipboard API can fail in PWA standalone mode when the document
-          // loses focus briefly on button press — fall through to execCommand.
-          const ta = document.createElement("textarea");
-          ta.value = text;
-          ta.style.position = "fixed";
-          ta.style.left = "-999999px";
-          ta.style.top = "-999999px";
-          document.body.appendChild(ta);
-          ta.focus();
-          ta.select();
-          document.execCommand("copy");
-          ta.remove();
-        }
-      } else {
-        const ta = document.createElement("textarea");
-        ta.value = text;
-        ta.style.position = "fixed";
-        ta.style.left = "-999999px";
-        ta.style.top = "-999999px";
-        document.body.appendChild(ta);
-        ta.focus();
-        ta.select();
-        document.execCommand("copy");
-        ta.remove();
-      }
-      setCopied(true);
-      antMessage.success(t("common.copied"));
-      setTimeout(() => setCopied(false), 2000);
-    } catch {
+    const ok = await copyText(text);
+    if (!ok) {
       antMessage.error(t("common.copyFailed"));
+      return;
     }
+    setCopied(true);
+    antMessage.success(t("common.copied"));
+    setTimeout(() => setCopied(false), 2000);
   }, [text, t]);
 
   return (

--- a/dashboard/src/pages/Experts/components/AgentCard.tsx
+++ b/dashboard/src/pages/Experts/components/AgentCard.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 import { Popconfirm, Switch, Tag, Tooltip } from "antd";
 import { message } from "@/utils/antdMessage";
+import { copyText } from "@/utils/copyText";
 
 import {
   Copy,
@@ -244,12 +245,9 @@ export const AgentCard = memo(function AgentCard({
   }, [agent.agent_id, setActiveAgent, navigate]);
 
   const copyAgentId = useCallback(async () => {
-    try {
-      await navigator.clipboard.writeText(agent.agent_id);
-      message.success(t("common.copied"));
-    } catch {
-      message.error(t("common.copyFailed"));
-    }
+    const ok = await copyText(agent.agent_id);
+    if (ok) message.success(t("common.copied"));
+    else message.error(t("common.copyFailed"));
   }, [agent.agent_id, t]);
 
   const reloadInstalledSubagents = useCallback(async () => {

--- a/dashboard/src/pages/Experts/components/AgentExpertsTable.tsx
+++ b/dashboard/src/pages/Experts/components/AgentExpertsTable.tsx
@@ -10,6 +10,7 @@ import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 import { Popconfirm, Switch, Tag, Tooltip } from "antd";
 import { message } from "@/utils/antdMessage";
+import { copyText } from "@/utils/copyText";
 import { ResizableTable } from "@/components/ResizableTable";
 
 import type { ColumnsType } from "antd/es/table";
@@ -236,12 +237,9 @@ export default function AgentExpertsTable({
 
   const copyAgentId = useCallback(
     async (agentId: string) => {
-      try {
-        await navigator.clipboard.writeText(agentId);
-        message.success(t("common.copied"));
-      } catch {
-        message.error(t("common.copyFailed"));
-      }
+      const ok = await copyText(agentId);
+      if (ok) message.success(t("common.copied"));
+      else message.error(t("common.copyFailed"));
     },
     [t],
   );

--- a/dashboard/src/pages/PwaDebug/index.tsx
+++ b/dashboard/src/pages/PwaDebug/index.tsx
@@ -9,6 +9,7 @@ import {
   DesktopInstallGuide,
   IosGuide,
 } from "../../components/PwaInstallPrompt";
+import { copyText } from "../../utils/copyText";
 
 interface CheckItem {
   id: string;
@@ -392,7 +393,8 @@ export default function PwaDebugPage() {
         .join("\n") +
       "\n\n--- raw log ---\n" +
       swLog.join("\n");
-    navigator.clipboard.writeText(text).then(() => {
+    void copyText(text).then((ok) => {
+      if (!ok) return;
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     });

--- a/dashboard/src/pages/Settings/octop/AdminAgentCard.tsx
+++ b/dashboard/src/pages/Settings/octop/AdminAgentCard.tsx
@@ -1,6 +1,7 @@
 import { memo, useCallback, useState } from "react";
 import { Popconfirm, Tag, Tooltip } from "antd";
 import { message } from "@/utils/antdMessage";
+import { copyText } from "@/utils/copyText";
 
 import { useTranslation } from "react-i18next";
 import {
@@ -86,12 +87,9 @@ export const AdminAgentCard = memo(function AdminAgentCard({
   }, [agent.agent_id, onRefresh, t]);
 
   const copyAgentId = useCallback(async () => {
-    try {
-      await navigator.clipboard.writeText(agent.agent_id);
-      message.success(t("common.copied"));
-    } catch {
-      message.error(t("common.copyFailed"));
-    }
+    const ok = await copyText(agent.agent_id);
+    if (ok) message.success(t("common.copied"));
+    else message.error(t("common.copyFailed"));
   }, [agent.agent_id, t]);
 
   return (

--- a/dashboard/src/utils/copyText.test.ts
+++ b/dashboard/src/utils/copyText.test.ts
@@ -1,0 +1,31 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const copyMock = vi.fn();
+
+vi.mock("copy-to-clipboard", () => ({
+  default: (text: string) => copyMock(text) as boolean,
+}));
+
+import { copyText } from "./copyText";
+
+describe("copyText", () => {
+  beforeEach(() => {
+    copyMock.mockReset();
+  });
+
+  it("returns false for empty text without calling copy", async () => {
+    expect(await copyText("")).toBe(false);
+    expect(copyMock).not.toHaveBeenCalled();
+  });
+
+  it("delegates to copy-to-clipboard", async () => {
+    copyMock.mockReturnValue(true);
+    expect(await copyText("hello")).toBe(true);
+    expect(copyMock).toHaveBeenCalledWith("hello");
+  });
+
+  it("returns false when copy-to-clipboard fails", async () => {
+    copyMock.mockReturnValue(false);
+    expect(await copyText("hello")).toBe(false);
+  });
+});

--- a/dashboard/src/utils/copyText.ts
+++ b/dashboard/src/utils/copyText.ts
@@ -1,38 +1,18 @@
 /**
- * Copy text to the clipboard with a legacy fallback for non-secure contexts.
+ * Copy text to the clipboard, including plain HTTP (non-secure) pages.
  *
- * The async Clipboard API is only available in secure contexts (https or
- * localhost). When it is unavailable or rejects, we fall back to a temporary
- * textarea + execCommand so the copy still works on plain-http admin pages.
+ * `navigator.clipboard` requires a secure context (https or localhost).
+ * `copy-to-clipboard` falls back to execCommand so copy still works on
+ * http:// admin hosts.
  *
  * @returns true when the text was copied, false otherwise.
  */
+import copy from "copy-to-clipboard";
+
 export async function copyText(text: string): Promise<boolean> {
   if (text === "") return false;
-
-  if (navigator.clipboard && window.isSecureContext) {
-    try {
-      await navigator.clipboard.writeText(text);
-      return true;
-    } catch {
-      // fall through to the legacy path
-    }
-  }
-
   try {
-    const textarea = document.createElement("textarea");
-    textarea.value = text;
-    textarea.setAttribute("readonly", "");
-    textarea.style.position = "fixed";
-    textarea.style.top = "0";
-    textarea.style.left = "0";
-    textarea.style.opacity = "0";
-    document.body.appendChild(textarea);
-    textarea.focus();
-    textarea.select();
-    const ok = document.execCommand("copy");
-    document.body.removeChild(textarea);
-    return ok;
+    return copy(text);
   } catch {
     return false;
   }


### PR DESCRIPTION
## Summary

- Dashboard copy used `navigator.clipboard`, which fails on plain HTTP admin hosts (not a secure context).
- Route all copy actions through `copyText` backed by `copy-to-clipboard` so HTTP pages still copy via execCommand fallback.
- Cover the helper with unit tests.

## Target branch

- [x] Base is **`develop`** (feature / fix — default)
- [ ] Base is **`main`** (`release/*` or `hotfix/*` only)

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / chore
- [ ] Release / hotfix

## Test plan

- `npx vitest run src/utils/copyText.test.ts` (3 passed)
- `npx eslint` on the touched dashboard files (clean)

- [ ] `make all` passes locally
- [x] Added/updated tests

## Checklist

- [ ] Updated `CHANGELOG.md` (if user-facing)
- [ ] README / docs updated (if needed)
