### PR TITLE
feat(onnx): race Hugging Face and hf-mirror for model downloads

### DIFF
--- a/src/octop/infra/agents/providers/onnx_catalog.py
+++ b/src/octop/infra/agents/providers/onnx_catalog.py
@@ -98,6 +98,14 @@ def _fastembed_meta_map() -> dict[str, dict[str, Any]]:
     return out
 
 
+def _hf_repo_from_sources(sources: object) -> str | None:
+    """Read the Hugging Face repo id from fastembed ``sources`` (dict or ModelSource)."""
+    raw = sources.get("hf") if isinstance(sources, dict) else getattr(sources, "hf", None)
+    if isinstance(raw, str) and raw.strip():
+        return raw.strip()
+    return None
+
+
 def get_onnx_model_meta(model_id: str) -> dict[str, Any]:
     """Return size / HF source metadata for a model id."""
     meta = _fastembed_meta_map().get(model_id) or {}
@@ -109,10 +117,7 @@ def get_onnx_model_meta(model_id: str) -> dict[str, Any]:
         size_gb = None
     if size_gb is None:
         size_gb = _FALLBACK_SIZE_GB.get(model_id)
-    sources = meta.get("sources") if isinstance(meta.get("sources"), dict) else {}
-    hf_source = sources.get("hf") if isinstance(sources, dict) else None
-    if not isinstance(hf_source, str) or not hf_source.strip():
-        hf_source = _HF_SOURCE_FALLBACK.get(model_id)
+    hf_source = _hf_repo_from_sources(meta.get("sources")) or _HF_SOURCE_FALLBACK.get(model_id)
     return {
         "id": model_id,
         "size_gb": size_gb,
@@ -135,10 +140,7 @@ def list_onnx_catalog_models() -> list[dict[str, Any]]:
                 size_gb = float(size) if size is not None else _FALLBACK_SIZE_GB.get(model_id)
             except (TypeError, ValueError):
                 size_gb = _FALLBACK_SIZE_GB.get(model_id)
-            sources = item.get("sources") if isinstance(item.get("sources"), dict) else {}
-            hf = sources.get("hf") if isinstance(sources, dict) else None
-            if not isinstance(hf, str) or not hf.strip():
-                hf = _HF_SOURCE_FALLBACK.get(model_id)
+            hf = _hf_repo_from_sources(item.get("sources")) or _HF_SOURCE_FALLBACK.get(model_id)
             return _model_entry(
                 model_id,
                 recommended=rec,

--- a/src/octop/infra/agents/providers/onnx_download.py
+++ b/src/octop/infra/agents/providers/onnx_download.py
@@ -3,18 +3,18 @@
 from __future__ import annotations
 
 import logging
+import os
 import time
 from collections.abc import Callable
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
 from contextlib import redirect_stderr, redirect_stdout
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, TextIO
+from typing import Any
 
 import httpx
 
 from octop.infra.agents.providers.onnx_catalog import get_onnx_model_meta
-from octop.infra.utils.paths import PathLayout
 
 logger = logging.getLogger(__name__)
 
@@ -46,6 +46,8 @@ class DownloadCandidate:
 
 
 ProbeFn = Callable[[str, float], float]
+# n bytes so far, real total if known, tqdm description.
+SnapshotProgressFn = Callable[[int, int | None, str], None]
 
 
 def _hf_repo_id(model_name: str) -> str:
@@ -80,6 +82,9 @@ def build_download_candidates(model_name: str) -> list[DownloadCandidate]:
 def probe_source(url: str, timeout_s: float = _PROBE_TIMEOUT_S) -> float:
     """Return TTFB in seconds for a 1 KiB range GET. Raises on HTTP/network errors."""
     started = time.monotonic()
+    # Local-only: OCTOP_DEBUG_SLOW_HF=<seconds> delays huggingface.co probes.
+    if url.startswith(HF_ENDPOINT_OFFICIAL):
+        time.sleep(10)
     with httpx.Client(
         timeout=httpx.Timeout(timeout_s, connect=min(3.0, timeout_s)),
         follow_redirects=True,
@@ -92,24 +97,15 @@ def probe_source(url: str, timeout_s: float = _PROBE_TIMEOUT_S) -> float:
     return time.monotonic() - started
 
 
-def race_download_sources(
-    candidates: list[DownloadCandidate],
-    *,
-    probe: ProbeFn = probe_source,
-    timeout_s: float = _PROBE_TIMEOUT_S,
-) -> list[DownloadCandidate]:
-    """Probe candidates in parallel and return them fastest-first.
-
-    Failed probes are omitted. If every probe fails, the original candidate
-    order is returned so the caller can still attempt a full download.
-    """
-    if not candidates:
-        return []
-    ranked: list[tuple[float, DownloadCandidate]] = []
-    workers = min(len(candidates), 2)
-    with ThreadPoolExecutor(max_workers=workers) as pool:
-        futures = {pool.submit(probe, cand.probe_url, timeout_s): cand for cand in candidates}
-        for fut in as_completed(futures):
+def _first_probe_success(
+    futures: dict[Future[float], DownloadCandidate],
+) -> tuple[DownloadCandidate, float] | None:
+    """Wait until one probe succeeds; ignore failures and keep waiting."""
+    pending: set[Future[float]] = set(futures)
+    while pending:
+        done, pending = wait(pending, return_when=FIRST_COMPLETED)
+        finished: list[tuple[float, DownloadCandidate]] = []
+        for fut in done:
             cand = futures[fut]
             try:
                 ttfb = fut.result()
@@ -118,22 +114,53 @@ def race_download_sources(
                 continue
             if ttfb < 0:
                 continue
-            ranked.append((ttfb, cand))
-    ranked.sort(key=lambda item: item[0])
-    if not ranked:
+            finished.append((ttfb, cand))
+        if finished:
+            finished.sort(key=lambda item: item[0])
+            ttfb, cand = finished[0]
+            return cand, ttfb
+    return None
+
+
+def race_download_sources(
+    candidates: list[DownloadCandidate],
+    *,
+    probe: ProbeFn = probe_source,
+    timeout_s: float = _PROBE_TIMEOUT_S,
+) -> list[DownloadCandidate]:
+    """Race probes in parallel; first success wins, the rest are fallbacks.
+
+    Losing probes are cancelled instead of being joined, so a blocked official
+    source cannot stall a fast mirror. If every probe fails, catalog order
+    is returned so the caller can still attempt a full download.
+    """
+    if not candidates:
+        return []
+    pool = ThreadPoolExecutor(max_workers=min(len(candidates), 2))
+    try:
+        futures = {pool.submit(probe, cand.probe_url, timeout_s): cand for cand in candidates}
+        result = _first_probe_success(futures)
+    finally:
+        pool.shutdown(wait=False, cancel_futures=True)
+    if result is None:
         logger.info("ONNX source probes all failed; falling back to catalog order")
         return list(candidates)
-    winner = ranked[0][1]
+    winner, winner_ttfb = result
     logger.info(
         "ONNX source race winner=%s ttfb=%.3fs (n=%d)",
         winner.kind,
-        ranked[0][0],
-        len(ranked),
+        winner_ttfb,
+        len(candidates),
     )
-    return [item[1] for item in ranked]
+    return [winner] + [c for c in candidates if c.kind != winner.kind]
 
 
-def download_model_raced(model_name: str, cache_dir: Path) -> str:
+def download_model_raced(
+    model_name: str,
+    cache_dir: Path,
+    *,
+    on_progress: SnapshotProgressFn | None = None,
+) -> str:
     """Race sources and download *model_name* into *cache_dir*. Return winner kind."""
     cache_dir.mkdir(parents=True, exist_ok=True)
     candidates = build_download_candidates(model_name)
@@ -141,7 +168,7 @@ def download_model_raced(model_name: str, cache_dir: Path) -> str:
     errors: list[str] = []
     for cand in ordered:
         try:
-            _download_hf_snapshot(cand, cache_dir)
+            _download_hf_snapshot(cand, cache_dir, on_progress=on_progress)
             logger.info("ONNX model %s downloaded from %s", model_name, cand.kind)
             return cand.kind
         except Exception as exc:
@@ -151,47 +178,45 @@ def download_model_raced(model_name: str, cache_dir: Path) -> str:
     raise RuntimeError(f"All embedding download sources failed: {detail}")
 
 
-def _tqdm_to_log(log_file: TextIO) -> type[Any] | None:
-    """Build a tqdm subclass that writes progress bars into *log_file*."""
+def _progress_tqdm(on_progress: SnapshotProgressFn) -> type[Any] | None:
+    """tqdm subclass that forwards n/total; bars themselves go to redirected stderr."""
     try:
         from tqdm.auto import tqdm as Tqdm
     except ImportError:
         return None
 
-    class LogTqdm(Tqdm):  # type: ignore[misc]
-        def __init__(self, *args: Any, **kwargs: Any) -> None:
-            kwargs["file"] = log_file
-            kwargs["disable"] = False
-            kwargs.setdefault("mininterval", 1.0)
-            super().__init__(*args, **kwargs)
+    class ProgressTqdm(Tqdm):  # type: ignore[misc]
+        def update(self, n: float | None = 1) -> Any:
+            result = super().update(n)
+            desc = str(self.desc or "")
+            total = int(self.total) if self.total and "reconstruct" in desc.lower() else None
+            on_progress(int(self.n or 0), total, desc)
+            return result
 
-    return LogTqdm
+    return ProgressTqdm
 
 
-def _download_hf_snapshot(cand: DownloadCandidate, cache_dir: Path) -> None:
+def _download_hf_snapshot(
+    cand: DownloadCandidate,
+    cache_dir: Path,
+    *,
+    on_progress: SnapshotProgressFn | None = None,
+) -> None:
     try:
         from huggingface_hub import snapshot_download
     except ImportError as exc:
         raise RuntimeError("huggingface_hub is required for HF model downloads") from exc
-    log_path = PathLayout.from_env().ensure_log()
-    logger.info(
-        "ONNX HF snapshot %s via %s (progress log: %s)",
-        cand.hf_repo,
-        cand.kind,
-        log_path,
-    )
-    with log_path.open("a", encoding="utf-8") as log_file:
-        log_file.write(
-            f"\n=== {time.strftime('%Y-%m-%d %H:%M:%S')} {cand.kind} {cand.hf_repo} ===\n"
+    logger.info("ONNX HF snapshot %s via %s", cand.hf_repo, cand.kind)
+    tqdm_cls = _progress_tqdm(on_progress) if on_progress is not None else None
+    with (
+        open(os.devnull, "w", encoding="utf-8") as sink,
+        redirect_stdout(sink),
+        redirect_stderr(sink),
+    ):
+        snapshot_download(
+            repo_id=cand.hf_repo,
+            cache_dir=str(cache_dir),
+            endpoint=cand.hf_endpoint,
+            allow_patterns=list(_HF_ALLOW_PATTERNS),
+            tqdm_class=tqdm_cls,
         )
-        log_file.flush()
-        # tqdm + hf_xet warnings write stdout/stderr directly; keep them off the
-        # server console and append into ~/.octop/logs/octop.log instead.
-        with redirect_stdout(log_file), redirect_stderr(log_file):
-            snapshot_download(
-                repo_id=cand.hf_repo,
-                cache_dir=str(cache_dir),
-                endpoint=cand.hf_endpoint,
-                allow_patterns=list(_HF_ALLOW_PATTERNS),
-                tqdm_class=_tqdm_to_log(log_file),
-            )

--- a/src/octop/infra/agents/providers/onnx_download.py
+++ b/src/octop/infra/agents/providers/onnx_download.py
@@ -1,0 +1,161 @@
+"""Race Hugging Face and hf-mirror, then download from the winner."""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
+from pathlib import Path
+
+import httpx
+
+from octop.infra.agents.providers.onnx_catalog import get_onnx_model_meta
+
+logger = logging.getLogger(__name__)
+
+HF_ENDPOINT_OFFICIAL = "https://huggingface.co"
+HF_ENDPOINT_MIRROR = "https://hf-mirror.com"
+
+_PROBE_TIMEOUT_S = 4.0
+_USER_AGENT = "octop-onnx-download"
+_HF_ALLOW_PATTERNS = (
+    "config.json",
+    "tokenizer.json",
+    "tokenizer_config.json",
+    "special_tokens_map.json",
+    "preprocessor_config.json",
+    "*.onnx",
+    "onnx/*.onnx",
+    "onnx/*.json",
+)
+
+
+@dataclass(frozen=True)
+class DownloadCandidate:
+    """One Hugging Face endpoint that can be probed and then fetched."""
+
+    kind: str
+    probe_url: str
+    hf_endpoint: str
+    hf_repo: str
+
+
+ProbeFn = Callable[[str, float], float]
+
+
+def _hf_repo_id(model_name: str) -> str:
+    """Resolve the Hugging Face repo: catalog ``hf_source``, else the model id."""
+    meta = get_onnx_model_meta(model_name)
+    hf_repo = meta.get("hf_source")
+    if not isinstance(hf_repo, str) or not hf_repo.strip():
+        hf_repo = model_name
+    return hf_repo.strip()
+
+
+def build_download_candidates(model_name: str) -> list[DownloadCandidate]:
+    """Build official HF + hf-mirror candidates; URLs are inferred from the repo id."""
+    hf_repo = _hf_repo_id(model_name)
+    probe_file = "config.json"
+    return [
+        DownloadCandidate(
+            kind="hf",
+            probe_url=f"{HF_ENDPOINT_OFFICIAL}/{hf_repo}/resolve/main/{probe_file}",
+            hf_endpoint=HF_ENDPOINT_OFFICIAL,
+            hf_repo=hf_repo,
+        ),
+        DownloadCandidate(
+            kind="hf-mirror",
+            probe_url=f"{HF_ENDPOINT_MIRROR}/{hf_repo}/resolve/main/{probe_file}",
+            hf_endpoint=HF_ENDPOINT_MIRROR,
+            hf_repo=hf_repo,
+        ),
+    ]
+
+
+def probe_source(url: str, timeout_s: float = _PROBE_TIMEOUT_S) -> float:
+    """Return TTFB in seconds for a 1 KiB range GET. Raises on HTTP/network errors."""
+    started = time.monotonic()
+    with httpx.Client(
+        timeout=httpx.Timeout(timeout_s, connect=min(3.0, timeout_s)),
+        follow_redirects=True,
+        headers={"User-Agent": _USER_AGENT},
+    ) as client:
+        response = client.get(url, headers={"Range": "bytes=0-1023"})
+        if response.status_code not in {200, 206}:
+            response.raise_for_status()
+        _ = response.content[:16]
+    return time.monotonic() - started
+
+
+def race_download_sources(
+    candidates: list[DownloadCandidate],
+    *,
+    probe: ProbeFn = probe_source,
+    timeout_s: float = _PROBE_TIMEOUT_S,
+) -> list[DownloadCandidate]:
+    """Probe candidates in parallel and return them fastest-first.
+
+    Failed probes are omitted. If every probe fails, the original candidate
+    order is returned so the caller can still attempt a full download.
+    """
+    if not candidates:
+        return []
+    ranked: list[tuple[float, DownloadCandidate]] = []
+    workers = min(len(candidates), 2)
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        futures = {pool.submit(probe, cand.probe_url, timeout_s): cand for cand in candidates}
+        for fut in as_completed(futures):
+            cand = futures[fut]
+            try:
+                ttfb = fut.result()
+            except Exception as exc:
+                logger.info("ONNX source probe failed (%s): %s", cand.kind, exc)
+                continue
+            if ttfb < 0:
+                continue
+            ranked.append((ttfb, cand))
+    ranked.sort(key=lambda item: item[0])
+    if not ranked:
+        logger.info("ONNX source probes all failed; falling back to catalog order")
+        return list(candidates)
+    winner = ranked[0][1]
+    logger.info(
+        "ONNX source race winner=%s ttfb=%.3fs (n=%d)",
+        winner.kind,
+        ranked[0][0],
+        len(ranked),
+    )
+    return [item[1] for item in ranked]
+
+
+def download_model_raced(model_name: str, cache_dir: Path) -> str:
+    """Race sources and download *model_name* into *cache_dir*. Return winner kind."""
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    candidates = build_download_candidates(model_name)
+    ordered = race_download_sources(candidates)
+    errors: list[str] = []
+    for cand in ordered:
+        try:
+            _download_hf_snapshot(cand, cache_dir)
+            logger.info("ONNX model %s downloaded from %s", model_name, cand.kind)
+            return cand.kind
+        except Exception as exc:
+            logger.warning("ONNX download via %s failed: %s", cand.kind, exc)
+            errors.append(f"{cand.kind}: {exc}")
+    detail = "; ".join(errors) if errors else "no sources"
+    raise RuntimeError(f"All embedding download sources failed: {detail}")
+
+
+def _download_hf_snapshot(cand: DownloadCandidate, cache_dir: Path) -> None:
+    try:
+        from huggingface_hub import snapshot_download
+    except ImportError as exc:
+        raise RuntimeError("huggingface_hub is required for HF model downloads") from exc
+    snapshot_download(
+        repo_id=cand.hf_repo,
+        cache_dir=str(cache_dir),
+        endpoint=cand.hf_endpoint,
+        allow_patterns=list(_HF_ALLOW_PATTERNS),
+    )

--- a/src/octop/infra/agents/providers/onnx_download.py
+++ b/src/octop/infra/agents/providers/onnx_download.py
@@ -6,12 +6,15 @@ import logging
 import time
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from contextlib import redirect_stderr, redirect_stdout
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any, TextIO
 
 import httpx
 
 from octop.infra.agents.providers.onnx_catalog import get_onnx_model_meta
+from octop.infra.utils.paths import PathLayout
 
 logger = logging.getLogger(__name__)
 
@@ -148,14 +151,47 @@ def download_model_raced(model_name: str, cache_dir: Path) -> str:
     raise RuntimeError(f"All embedding download sources failed: {detail}")
 
 
+def _tqdm_to_log(log_file: TextIO) -> type[Any] | None:
+    """Build a tqdm subclass that writes progress bars into *log_file*."""
+    try:
+        from tqdm.auto import tqdm as Tqdm
+    except ImportError:
+        return None
+
+    class LogTqdm(Tqdm):  # type: ignore[misc]
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            kwargs["file"] = log_file
+            kwargs["disable"] = False
+            kwargs.setdefault("mininterval", 1.0)
+            super().__init__(*args, **kwargs)
+
+    return LogTqdm
+
+
 def _download_hf_snapshot(cand: DownloadCandidate, cache_dir: Path) -> None:
     try:
         from huggingface_hub import snapshot_download
     except ImportError as exc:
         raise RuntimeError("huggingface_hub is required for HF model downloads") from exc
-    snapshot_download(
-        repo_id=cand.hf_repo,
-        cache_dir=str(cache_dir),
-        endpoint=cand.hf_endpoint,
-        allow_patterns=list(_HF_ALLOW_PATTERNS),
+    log_path = PathLayout.from_env().ensure_log()
+    logger.info(
+        "ONNX HF snapshot %s via %s (progress log: %s)",
+        cand.hf_repo,
+        cand.kind,
+        log_path,
     )
+    with log_path.open("a", encoding="utf-8") as log_file:
+        log_file.write(
+            f"\n=== {time.strftime('%Y-%m-%d %H:%M:%S')} {cand.kind} {cand.hf_repo} ===\n"
+        )
+        log_file.flush()
+        # tqdm + hf_xet warnings write stdout/stderr directly; keep them off the
+        # server console and append into ~/.octop/logs/octop.log instead.
+        with redirect_stdout(log_file), redirect_stderr(log_file):
+            snapshot_download(
+                repo_id=cand.hf_repo,
+                cache_dir=str(cache_dir),
+                endpoint=cand.hf_endpoint,
+                allow_patterns=list(_HF_ALLOW_PATTERNS),
+                tqdm_class=_tqdm_to_log(log_file),
+            )

--- a/src/octop/infra/agents/providers/onnx_download.py
+++ b/src/octop/infra/agents/providers/onnx_download.py
@@ -82,9 +82,6 @@ def build_download_candidates(model_name: str) -> list[DownloadCandidate]:
 def probe_source(url: str, timeout_s: float = _PROBE_TIMEOUT_S) -> float:
     """Return TTFB in seconds for a 1 KiB range GET. Raises on HTTP/network errors."""
     started = time.monotonic()
-    # Local-only: OCTOP_DEBUG_SLOW_HF=<seconds> delays huggingface.co probes.
-    if url.startswith(HF_ENDPOINT_OFFICIAL):
-        time.sleep(10)
     with httpx.Client(
         timeout=httpx.Timeout(timeout_s, connect=min(3.0, timeout_s)),
         follow_redirects=True,

--- a/src/octop/infra/agents/providers/onnx_service.py
+++ b/src/octop/infra/agents/providers/onnx_service.py
@@ -26,6 +26,7 @@ from octop.infra.agents.providers.onnx_catalog import (
     get_onnx_model_meta,
     list_onnx_catalog_models,
 )
+from octop.infra.agents.providers.onnx_download import download_model_raced
 from octop.infra.utils.paths import PathLayout
 from octop.infra.utils.runtime_packages import (
     PackageInstallSpec,
@@ -554,36 +555,19 @@ class OnnxDownloadManager:
         watcher.start()
         self._set(status=OnnxDownloadStatus.DOWNLOADING, progress=0.08)
         try:
+            winner = download_model_raced(model_name, cache)
+            logger.info("ONNX model %s fetched from %s", model_name, winner)
+            mark_model_downloaded(model_name)
             try:
                 from fastembed import TextEmbedding
 
                 self._set(
                     status=OnnxDownloadStatus.LOADING,
-                    progress=max(0.15, self.state.progress),
+                    progress=max(0.90, self.state.progress),
                 )
                 TextEmbedding(model_name=model_name, cache_dir=str(cache))
-                mark_model_downloaded(model_name)
-                self._set(progress=0.95)
-                return
             except ImportError:
                 pass
-
-            try:
-                from huggingface_hub import snapshot_download
-            except ImportError as exc:
-                raise RuntimeError(
-                    "Local embedding download requires optional components that "
-                    "could not be loaded. Enable the ONNX service to install them "
-                    "automatically."
-                ) from exc
-
-            repo_id = str(meta.get("hf_source") or model_name)
-            self._set(
-                status=OnnxDownloadStatus.DOWNLOADING,
-                progress=max(0.12, self.state.progress),
-            )
-            snapshot_download(repo_id=repo_id, cache_dir=str(cache))
-            mark_model_downloaded(model_name)
             self._set(progress=0.95)
         finally:
             stop.set()

--- a/src/octop/infra/agents/providers/onnx_service.py
+++ b/src/octop/infra/agents/providers/onnx_service.py
@@ -333,6 +333,13 @@ def _dir_size_bytes(path: Path) -> int:
     return total
 
 
+def _ui_progress_from_bytes(n: int, total: int | None) -> float | None:
+    """Return downloaded-bytes fraction, or None when size is unknown."""
+    if not total or total <= 0:
+        return None
+    return min(1.0, max(0.0, n / total))
+
+
 def load_config(settings_get: Any) -> OnnxServiceConfig:
     raw = settings_get(_SETTINGS_KEY)
     if not raw:
@@ -498,7 +505,7 @@ class OnnxDownloadManager:
             }:
                 raise RuntimeError("another ONNX download is already running")
             self._state.status = OnnxDownloadStatus.DOWNLOADING
-            self._state.progress = 0.05
+            self._state.progress = 0.0
             self._state.error = None
             self._state.model_name = model_name
             self._state.task_id = task_id
@@ -540,35 +547,52 @@ class OnnxDownloadManager:
 
         stop = threading.Event()
         baseline = _dir_size_bytes(cache)
+        snapshot_total: int | None = None
+        best_bytes = 0
+
+        def _apply_bytes(n: int, total: int | None) -> None:
+            nonlocal snapshot_total, best_bytes
+            if total and total > 0:
+                snapshot_total = max(snapshot_total or 0, total)
+            best_bytes = max(best_bytes, n)
+            denom = snapshot_total
+            if expected_bytes:
+                denom = max(denom or 0, expected_bytes)
+            ratio = _ui_progress_from_bytes(best_bytes, denom)
+            if ratio is None:
+                return
+            with self._lock:
+                if self._state.status != OnnxDownloadStatus.DOWNLOADING:
+                    return
+                if ratio <= self._state.progress:
+                    return
+                self._state.progress = ratio
+                self._state.updated_at = time.time()
 
         def _watch() -> None:
             while not stop.wait(0.5):
                 grown = max(0, _dir_size_bytes(cache) - baseline)
-                if expected_bytes and expected_bytes > 0:
-                    ratio = min(0.92, 0.08 + 0.84 * (grown / expected_bytes))
-                else:
-                    # Unknown size: creep toward 0.85 while bytes keep growing.
-                    ratio = min(0.85, 0.08 + (grown / (200 * 1024 * 1024)) * 0.7)
-                self._set(status=OnnxDownloadStatus.DOWNLOADING, progress=ratio)
+                _apply_bytes(grown, None)
+
+        def _on_tqdm(n: int, total: int | None, desc: str) -> None:
+            if "fetching" in desc.lower():
+                return
+            _apply_bytes(n, total)
 
         watcher = threading.Thread(target=_watch, name="onnx-dl-progress", daemon=True)
         watcher.start()
-        self._set(status=OnnxDownloadStatus.DOWNLOADING, progress=0.08)
+        self._set(status=OnnxDownloadStatus.DOWNLOADING, progress=0.0)
         try:
-            winner = download_model_raced(model_name, cache)
+            winner = download_model_raced(model_name, cache, on_progress=_on_tqdm)
             logger.info("ONNX model %s fetched from %s", model_name, winner)
             mark_model_downloaded(model_name)
             try:
                 from fastembed import TextEmbedding
 
-                self._set(
-                    status=OnnxDownloadStatus.LOADING,
-                    progress=max(0.90, self.state.progress),
-                )
+                self._set(status=OnnxDownloadStatus.LOADING)
                 TextEmbedding(model_name=model_name, cache_dir=str(cache))
             except ImportError:
                 pass
-            self._set(progress=0.95)
         finally:
             stop.set()
             watcher.join(timeout=2.0)

--- a/src/octop/infra/utils/paths.py
+++ b/src/octop/infra/utils/paths.py
@@ -38,6 +38,11 @@ class PathLayout:
         out.mkdir(parents=True, exist_ok=True)
         return out
 
+    def ensure_log(self) -> Path:
+        """Create the logs directory and return ``octop.log``."""
+        self.ensure_logs_dir()
+        return self.log
+
     @property
     def config(self) -> Path:
         return self.root / "config.json"

--- a/tests/unit/agents/test_onnx_download.py
+++ b/tests/unit/agents/test_onnx_download.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 
 from octop.infra.agents.providers.onnx_catalog import get_onnx_model_meta
@@ -13,6 +14,7 @@ from octop.infra.agents.providers.onnx_download import (
     download_model_raced,
     race_download_sources,
 )
+from octop.infra.utils.paths import PathLayout
 
 
 def test_bge_small_zh_infers_hf_repo_without_fastembed(monkeypatch) -> None:
@@ -132,3 +134,43 @@ def test_download_uses_winner_then_falls_back(monkeypatch, tmp_path: Path) -> No
     winner = download_model_raced("BAAI/bge-small-zh-v1.5", tmp_path)
     assert winner == "hf-mirror"
     assert tried == ["hf", "hf-mirror"]
+
+
+def test_hf_snapshot_progress_goes_to_log_not_stdout(monkeypatch, tmp_path: Path, capsys) -> None:
+    import types
+
+    monkeypatch.setenv("OCTOP_HOME", str(tmp_path))
+
+    def fake_snapshot_download(**_kwargs: object) -> str:
+        print("Downloading bytes: fake-progress", flush=True)
+        print("Warning: unauthenticated requests", file=sys.stderr, flush=True)
+        return "ok"
+
+    hub = sys.modules.get("huggingface_hub")
+    if hub is None:
+        hub = types.ModuleType("huggingface_hub")
+        monkeypatch.setitem(sys.modules, "huggingface_hub", hub)
+    monkeypatch.setattr(hub, "snapshot_download", fake_snapshot_download, raising=False)
+
+    from octop.infra.agents.providers.onnx_download import _download_hf_snapshot
+
+    _download_hf_snapshot(
+        DownloadCandidate(
+            kind="hf-mirror",
+            probe_url="http://mirror",
+            hf_endpoint=HF_ENDPOINT_MIRROR,
+            hf_repo="Qdrant/bge-small-zh-v1.5",
+        ),
+        tmp_path / "cache",
+    )
+
+    captured = capsys.readouterr()
+    assert "fake-progress" not in captured.out
+    assert "unauthenticated" not in captured.err
+
+    log_path = PathLayout.from_env().log
+    assert log_path == tmp_path / "logs" / "octop.log"
+    text = log_path.read_text(encoding="utf-8")
+    assert "hf-mirror Qdrant/bge-small-zh-v1.5" in text
+    assert "Downloading bytes: fake-progress" in text
+    assert "Warning: unauthenticated requests" in text

--- a/tests/unit/agents/test_onnx_download.py
+++ b/tests/unit/agents/test_onnx_download.py
@@ -1,0 +1,134 @@
+"""Tests for ONNX source race + download."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from octop.infra.agents.providers.onnx_catalog import get_onnx_model_meta
+from octop.infra.agents.providers.onnx_download import (
+    HF_ENDPOINT_MIRROR,
+    HF_ENDPOINT_OFFICIAL,
+    DownloadCandidate,
+    build_download_candidates,
+    download_model_raced,
+    race_download_sources,
+)
+
+
+def test_bge_small_zh_infers_hf_repo_without_fastembed(monkeypatch) -> None:
+    from octop.infra.agents.providers import onnx_catalog as catalog
+
+    monkeypatch.setattr(catalog, "_fastembed_meta_map", lambda: {})
+    meta = get_onnx_model_meta("BAAI/bge-small-zh-v1.5")
+    assert meta["hf_source"] == "Qdrant/bge-small-zh-v1.5"
+    assert "direct_url" not in meta
+
+
+def test_candidates_are_hf_and_mirror_with_inferred_urls(monkeypatch) -> None:
+    from octop.infra.agents.providers import onnx_catalog as catalog
+
+    monkeypatch.setattr(catalog, "_fastembed_meta_map", lambda: {})
+    cands = build_download_candidates("BAAI/bge-small-zh-v1.5")
+    assert [c.kind for c in cands] == ["hf", "hf-mirror"]
+    assert cands[0].probe_url == (
+        f"{HF_ENDPOINT_OFFICIAL}/Qdrant/bge-small-zh-v1.5/resolve/main/config.json"
+    )
+    assert cands[1].probe_url == (
+        f"{HF_ENDPOINT_MIRROR}/Qdrant/bge-small-zh-v1.5/resolve/main/config.json"
+    )
+    assert cands[0].hf_endpoint == HF_ENDPOINT_OFFICIAL
+    assert cands[1].hf_endpoint == HF_ENDPOINT_MIRROR
+
+
+def test_unknown_model_uses_model_id_as_hf_repo(monkeypatch) -> None:
+    from octop.infra.agents.providers import onnx_catalog as catalog
+
+    monkeypatch.setattr(catalog, "_fastembed_meta_map", lambda: {})
+    cands = build_download_candidates("jinaai/jina-embeddings-v2-base-zh")
+    assert [c.kind for c in cands] == ["hf", "hf-mirror"]
+    assert cands[0].hf_repo == "jinaai/jina-embeddings-v2-base-zh"
+    assert cands[0].probe_url.startswith(
+        f"{HF_ENDPOINT_OFFICIAL}/jinaai/jina-embeddings-v2-base-zh/"
+    )
+    assert cands[1].probe_url.startswith(f"{HF_ENDPOINT_MIRROR}/jinaai/jina-embeddings-v2-base-zh/")
+
+
+def test_race_orders_by_ttfb_and_skips_failures() -> None:
+    cands = [
+        DownloadCandidate(
+            kind="hf",
+            probe_url="http://hf",
+            hf_endpoint=HF_ENDPOINT_OFFICIAL,
+            hf_repo="org/model",
+        ),
+        DownloadCandidate(
+            kind="hf-mirror",
+            probe_url="http://mirror",
+            hf_endpoint=HF_ENDPOINT_MIRROR,
+            hf_repo="org/model",
+        ),
+    ]
+
+    def probe(url: str, timeout_s: float) -> float:
+        if url.endswith("hf"):
+            raise TimeoutError("official blocked")
+        return 0.12
+
+    ranked = race_download_sources(cands, probe=probe)
+    assert [c.kind for c in ranked] == ["hf-mirror"]
+
+
+def test_race_keeps_catalog_order_when_all_probes_fail() -> None:
+    cands = [
+        DownloadCandidate(
+            kind="hf",
+            probe_url="http://hf",
+            hf_endpoint=HF_ENDPOINT_OFFICIAL,
+            hf_repo="org/model",
+        ),
+        DownloadCandidate(
+            kind="hf-mirror",
+            probe_url="http://mirror",
+            hf_endpoint=HF_ENDPOINT_MIRROR,
+            hf_repo="org/model",
+        ),
+    ]
+
+    def probe(_url: str, _timeout_s: float) -> float:
+        raise OSError("offline")
+
+    ranked = race_download_sources(cands, probe=probe)
+    assert [c.kind for c in ranked] == ["hf", "hf-mirror"]
+
+
+def test_download_uses_winner_then_falls_back(monkeypatch, tmp_path: Path) -> None:
+    from octop.infra.agents.providers import onnx_download as mod
+
+    cands = [
+        DownloadCandidate(
+            kind="hf",
+            probe_url="http://hf",
+            hf_endpoint=HF_ENDPOINT_OFFICIAL,
+            hf_repo="Qdrant/bge-small-zh-v1.5",
+        ),
+        DownloadCandidate(
+            kind="hf-mirror",
+            probe_url="http://mirror",
+            hf_endpoint=HF_ENDPOINT_MIRROR,
+            hf_repo="Qdrant/bge-small-zh-v1.5",
+        ),
+    ]
+    tried: list[str] = []
+
+    monkeypatch.setattr(mod, "build_download_candidates", lambda _name: cands)
+    monkeypatch.setattr(mod, "race_download_sources", lambda items, **_kw: items)
+
+    def fake_download(cand: DownloadCandidate, cache_dir: Path) -> None:
+        tried.append(cand.kind)
+        if cand.kind == "hf":
+            raise RuntimeError("hf 403")
+
+    monkeypatch.setattr(mod, "_download_hf_snapshot", fake_download)
+    winner = download_model_raced("BAAI/bge-small-zh-v1.5", tmp_path)
+    assert winner == "hf-mirror"
+    assert tried == ["hf", "hf-mirror"]

--- a/tests/unit/agents/test_onnx_download.py
+++ b/tests/unit/agents/test_onnx_download.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import sys
+import threading
+import time
 from pathlib import Path
 
 from octop.infra.agents.providers.onnx_catalog import get_onnx_model_meta
@@ -14,7 +16,6 @@ from octop.infra.agents.providers.onnx_download import (
     download_model_raced,
     race_download_sources,
 )
-from octop.infra.utils.paths import PathLayout
 
 
 def test_bge_small_zh_infers_hf_repo_without_fastembed(monkeypatch) -> None:
@@ -77,7 +78,41 @@ def test_race_orders_by_ttfb_and_skips_failures() -> None:
         return 0.12
 
     ranked = race_download_sources(cands, probe=probe)
-    assert [c.kind for c in ranked] == ["hf-mirror"]
+    assert [c.kind for c in ranked] == ["hf-mirror", "hf"]
+
+
+def test_race_returns_before_slow_probe_finishes() -> None:
+    cands = [
+        DownloadCandidate(
+            kind="hf",
+            probe_url="http://hf",
+            hf_endpoint=HF_ENDPOINT_OFFICIAL,
+            hf_repo="org/model",
+        ),
+        DownloadCandidate(
+            kind="hf-mirror",
+            probe_url="http://mirror",
+            hf_endpoint=HF_ENDPOINT_MIRROR,
+            hf_repo="org/model",
+        ),
+    ]
+    release = threading.Event()
+
+    def probe(url: str, _timeout_s: float) -> float:
+        if url.endswith("hf"):
+            release.wait(timeout=5)
+            return 5.0
+        return 0.05
+
+    started = time.monotonic()
+    try:
+        ranked = race_download_sources(cands, probe=probe)
+        elapsed = time.monotonic() - started
+    finally:
+        release.set()
+
+    assert [c.kind for c in ranked] == ["hf-mirror", "hf"]
+    assert elapsed < 0.5
 
 
 def test_race_keeps_catalog_order_when_all_probes_fail() -> None:
@@ -125,7 +160,7 @@ def test_download_uses_winner_then_falls_back(monkeypatch, tmp_path: Path) -> No
     monkeypatch.setattr(mod, "build_download_candidates", lambda _name: cands)
     monkeypatch.setattr(mod, "race_download_sources", lambda items, **_kw: items)
 
-    def fake_download(cand: DownloadCandidate, cache_dir: Path) -> None:
+    def fake_download(cand: DownloadCandidate, cache_dir: Path, **_kwargs: object) -> None:
         tried.append(cand.kind)
         if cand.kind == "hf":
             raise RuntimeError("hf 403")
@@ -136,14 +171,19 @@ def test_download_uses_winner_then_falls_back(monkeypatch, tmp_path: Path) -> No
     assert tried == ["hf", "hf-mirror"]
 
 
-def test_hf_snapshot_progress_goes_to_log_not_stdout(monkeypatch, tmp_path: Path, capsys) -> None:
+def test_hf_snapshot_emits_tqdm_byte_progress(monkeypatch, tmp_path: Path) -> None:
     import types
 
     monkeypatch.setenv("OCTOP_HOME", str(tmp_path))
+    seen: list[tuple[int, int | None, str]] = []
 
-    def fake_snapshot_download(**_kwargs: object) -> str:
-        print("Downloading bytes: fake-progress", flush=True)
-        print("Warning: unauthenticated requests", file=sys.stderr, flush=True)
+    def fake_snapshot_download(**kwargs: object) -> str:
+        tqdm_class = kwargs.get("tqdm_class")
+        assert callable(tqdm_class)
+        transfer = tqdm_class(total=1_000_000, desc="Downloading bytes", unit="B")
+        transfer.update(400_000)
+        reconstruct = tqdm_class(total=800_000, desc="Reconstructing", unit="B")
+        reconstruct.update(800_000)
         return "ok"
 
     hub = sys.modules.get("huggingface_hub")
@@ -162,15 +202,8 @@ def test_hf_snapshot_progress_goes_to_log_not_stdout(monkeypatch, tmp_path: Path
             hf_repo="Qdrant/bge-small-zh-v1.5",
         ),
         tmp_path / "cache",
+        on_progress=lambda n, total, desc: seen.append((n, total, desc)),
     )
 
-    captured = capsys.readouterr()
-    assert "fake-progress" not in captured.out
-    assert "unauthenticated" not in captured.err
-
-    log_path = PathLayout.from_env().log
-    assert log_path == tmp_path / "logs" / "octop.log"
-    text = log_path.read_text(encoding="utf-8")
-    assert "hf-mirror Qdrant/bge-small-zh-v1.5" in text
-    assert "Downloading bytes: fake-progress" in text
-    assert "Warning: unauthenticated requests" in text
+    assert (400_000, None, "Downloading bytes") in seen
+    assert (800_000, 800_000, "Reconstructing") in seen

--- a/tests/unit/agents/test_onnx_service.py
+++ b/tests/unit/agents/test_onnx_service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import sys
 from types import SimpleNamespace
 
 import pytest
@@ -13,8 +14,11 @@ from octop.infra.agents.providers.onnx_catalog import (
     list_onnx_catalog_models,
 )
 from octop.infra.agents.providers.onnx_service import (
+    OnnxDownloadManager,
     OnnxDownloadState,
+    OnnxDownloadStatus,
     OnnxServiceConfig,
+    _ui_progress_from_bytes,
     embedding_models_dir,
     is_model_downloaded,
     load_config,
@@ -22,6 +26,62 @@ from octop.infra.agents.providers.onnx_service import (
     save_config,
     status_payload,
 )
+
+
+def test_ui_progress_from_bytes_is_byte_fraction() -> None:
+    assert _ui_progress_from_bytes(0, 100) == pytest.approx(0.0)
+    assert _ui_progress_from_bytes(50, 100) == pytest.approx(0.50)
+    assert _ui_progress_from_bytes(100, 100) == pytest.approx(1.0)
+    assert _ui_progress_from_bytes(200, 100) == pytest.approx(1.0)
+    assert _ui_progress_from_bytes(50, None) is None
+    assert _ui_progress_from_bytes(50, 0) is None
+
+
+def test_download_sync_reports_tqdm_bytes(monkeypatch, tmp_path) -> None:
+    from octop.infra.agents.providers import onnx_service as mod
+
+    monkeypatch.setenv("OCTOP_HOME", str(tmp_path))
+    mgr = OnnxDownloadManager()
+    mgr._set(
+        status=OnnxDownloadStatus.DOWNLOADING,
+        progress=0.0,
+        model_name="BAAI/bge-small-zh-v1.5",
+    )
+    seen: list[float] = []
+
+    def fake_raced(
+        model_name: str,
+        cache_dir: object,
+        *,
+        on_progress: object = None,
+    ) -> str:
+        del model_name, cache_dir
+        assert callable(on_progress)
+        on_progress(50, 100, "Reconstructing")
+        seen.append(mgr.state.progress)
+        on_progress(100, 100, "Reconstructing")
+        seen.append(mgr.state.progress)
+        return "hf-mirror"
+
+    monkeypatch.setattr(mod, "download_model_raced", fake_raced)
+    monkeypatch.setattr(mod, "mark_model_downloaded", lambda _name: None)
+    monkeypatch.setattr(mod, "is_model_downloaded", lambda _name: False)
+    monkeypatch.setattr(
+        mod,
+        "get_onnx_model_meta",
+        lambda _name: {"size_gb": 100 / (1024**3)},
+    )
+
+    class _FakeEmbed:
+        def __init__(self, **_kwargs: object) -> None:
+            return None
+
+    fastembed = SimpleNamespace(TextEmbedding=_FakeEmbed)
+    monkeypatch.setitem(sys.modules, "fastembed", fastembed)
+
+    mgr._download_sync("BAAI/bge-small-zh-v1.5")
+    assert seen[0] == pytest.approx(0.50)
+    assert seen[1] == pytest.approx(1.0)
 
 
 def test_catalog_includes_finnie_presets() -> None:

--- a/tests/unit/test_paths.py
+++ b/tests/unit/test_paths.py
@@ -19,7 +19,7 @@ def test_root_paths(tmp_path: Path):
 def test_log_dir_creation(tmp_path: Path):
     p = PathLayout(tmp_path / ".octop")
     assert not (tmp_path / ".octop" / "logs").exists()
-    p.ensure_logs_dir()
+    assert p.ensure_log() == tmp_path / ".octop" / "logs" / "octop.log"
     assert (tmp_path / ".octop" / "logs").is_dir()
     assert p.log == tmp_path / ".octop" / "logs" / "octop.log"
 


### PR DESCRIPTION
## Summary

- Download local ONNX embedding models by racing Hugging Face and hf-mirror, then fetching from the faster source (with fallback).
- Infer snapshot URLs from the catalog HF repo id (or the model id) so each model does not need a hand-written download URL.
- Drop the previous official-only `snapshot_download` path in the ONNX download manager.

## Target branch

- [x] Base is **`develop`** (feature / fix — default)
- [ ] Base is **`main`** (`release/*` or `hotfix/*` only)

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / chore
- [ ] Release / hotfix

## Test plan

- `uv run pytest tests/unit/agents/test_onnx_download.py tests/unit/agents/test_onnx_service.py -q` — 28 passed
- Did not run `make all` on this branch

- [ ] `make all` passes locally
- [x] Added/updated tests

## Checklist

- [ ] Updated `CHANGELOG.md` (if user-facing)
- [ ] README / docs updated (if needed)

Made with [Cursor](https://cursor.com)