### PR TITLE
feat(dashboard,backend): native clipboard fallback and chat UI polish

### DIFF
--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -18,7 +18,6 @@
         "antd": "^5.29.1",
         "antd-style": "^3.7.1",
         "build": "^0.1.4",
-        "copy-to-clipboard": "^4.0.2",
         "docx-preview": "^0.3.2",
         "i18next": "^25.8.4",
         "jszip": "^3.10.1",
@@ -5574,12 +5573,6 @@
       "funding": {
         "url": "https://github.com/sponsors/mesqueeb"
       }
-    },
-    "node_modules/copy-to-clipboard": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-4.0.2.tgz",
-      "integrity": "sha512-gklSft7IuhriZKHKpuoA1fpJSLPNgvUMWMo5BlnzAJm0zNKnznoSv23IjtNqclx8eKi6ZcdvFFzYEER/+U1LoQ==",
-      "license": "MIT"
     },
     "node_modules/core-js-compat": {
       "version": "3.49.0",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -30,7 +30,6 @@
     "antd": "^5.29.1",
     "antd-style": "^3.7.1",
     "build": "^0.1.4",
-    "copy-to-clipboard": "^4.0.2",
     "docx-preview": "^0.3.2",
     "i18next": "^25.8.4",
     "jszip": "^3.10.1",

--- a/dashboard/src/pages/Chat/components/ChatInputActionsRow.tsx
+++ b/dashboard/src/pages/Chat/components/ChatInputActionsRow.tsx
@@ -45,7 +45,8 @@ import { isSttAvailable } from "../../../hooks/useVoiceInput";
 import { resolveTurnModelOverride } from "../utils/chatMessages";
 import styles from "../index.module.less";
 
-type MobilePickerKey =
+/** Shared by mobile drawers and narrow-desktop popovers. */
+type CompactPickerKey =
   | "model"
   | "connector"
   | "knowledge"
@@ -174,8 +175,12 @@ export default function ChatInputActionsRow({
   const [reasoningModelRef, setReasoningModelRef] = useState<string | null>(
     null,
   );
+  /** Mobile-only bottom drawer for the overflow ("more") menu. */
   const [mobileOverflowOpen, setMobileOverflowOpen] = useState(false);
-  const [mobilePicker, setMobilePicker] = useState<MobilePickerKey | null>(
+  /** Narrow-desktop overflow popover (tools / skills / …). */
+  const [overflowPopoverOpen, setOverflowPopoverOpen] = useState(false);
+  /** Active sub-picker for compact layouts (drawer on mobile, panel in popover). */
+  const [compactPicker, setCompactPicker] = useState<CompactPickerKey | null>(
     null,
   );
 
@@ -231,17 +236,17 @@ export default function ChatInputActionsRow({
     selectedSkills.length +
     selectedTargetAgents.length;
 
-  const closeMobilePicker = () => {
-    setMobilePicker(null);
+  const closeCompactPicker = () => {
+    setCompactPicker(null);
     setReasoningModelRef(null);
   };
 
-  const openMobilePicker = (key: MobilePickerKey) => {
+  const openCompactPicker = (key: CompactPickerKey) => {
     if (isMobile) setMobileOverflowOpen(false);
-    setMobilePicker(key);
+    setCompactPicker(key);
   };
 
-  const mobilePickerTitle: Record<MobilePickerKey, string> = {
+  const compactPickerTitle: Record<CompactPickerKey, string> = {
     model: t("chat.selectModel", "Select model"),
     connector: t("connectors.chatPicker"),
     knowledge: t("chat.knowledgePicker"),
@@ -372,7 +377,7 @@ export default function ChatInputActionsRow({
             }`}
             onClick={() => {
               onModelChange?.(null);
-              closeMobilePicker();
+              closeCompactPicker();
               setModelPickerOpen(false);
             }}
           >
@@ -400,7 +405,7 @@ export default function ChatInputActionsRow({
                   className={styles.modelMenuSelect}
                   onClick={() => {
                     onModelChange?.(active ? null : value);
-                    closeMobilePicker();
+                    closeCompactPicker();
                     setModelPickerOpen(false);
                   }}
                 >
@@ -457,7 +462,7 @@ export default function ChatInputActionsRow({
           }
           onSelect={(command) => {
             setShortcutOpen(false);
-            closeMobilePicker();
+            closeCompactPicker();
             onSlashShortcutSelect(command);
           }}
           onHover={() => undefined}
@@ -472,7 +477,7 @@ export default function ChatInputActionsRow({
         <button
           type="button"
           className={styles.mobileOverflowItem}
-          onClick={() => openMobilePicker("connector")}
+          onClick={() => openCompactPicker("connector")}
         >
           <span className={styles.mobileOverflowItemMain}>
             <Link2 size={18} />
@@ -492,7 +497,7 @@ export default function ChatInputActionsRow({
         <button
           type="button"
           className={styles.mobileOverflowItem}
-          onClick={() => openMobilePicker("knowledge")}
+          onClick={() => openCompactPicker("knowledge")}
         >
           <span className={styles.mobileOverflowItemMain}>
             <BookOpen size={18} />
@@ -512,7 +517,7 @@ export default function ChatInputActionsRow({
         <button
           type="button"
           className={styles.mobileOverflowItem}
-          onClick={() => openMobilePicker("skill")}
+          onClick={() => openCompactPicker("skill")}
         >
           <span className={styles.mobileOverflowItemMain}>
             <Sparkles size={18} />
@@ -534,7 +539,7 @@ export default function ChatInputActionsRow({
         <button
           type="button"
           className={styles.mobileOverflowItem}
-          onClick={() => openMobilePicker("expert")}
+          onClick={() => openCompactPicker("expert")}
         >
           <span className={styles.mobileOverflowItemMain}>
             <GraduationCap size={18} />
@@ -556,7 +561,7 @@ export default function ChatInputActionsRow({
         <button
           type="button"
           className={styles.mobileOverflowItem}
-          onClick={() => openMobilePicker("shortcut")}
+          onClick={() => openCompactPicker("shortcut")}
         >
           <span className={styles.mobileOverflowItemMain}>
             <Zap size={18} />
@@ -570,8 +575,8 @@ export default function ChatInputActionsRow({
     </div>
   );
 
-  const renderMobilePickerContent = () => {
-    switch (mobilePicker) {
+  const renderCompactPickerContent = () => {
+    switch (compactPicker) {
       case "model":
         return modelMenu;
       case "connector":
@@ -580,7 +585,7 @@ export default function ChatInputActionsRow({
             connectors={availableConnectors ?? []}
             selectedConnectors={selectedConnectors}
             onConnectorsChange={onConnectorsChange!}
-            onNavigateAway={closeMobilePicker}
+            onNavigateAway={closeCompactPicker}
           />
         );
       case "knowledge":
@@ -589,7 +594,7 @@ export default function ChatInputActionsRow({
             knowledgeBases={availableKnowledgeBases ?? []}
             selectedKnowledgeBaseIds={selectedKnowledgeBaseIds}
             onKnowledgeBaseIdsChange={onKnowledgeBaseIdsChange!}
-            onNavigateAway={closeMobilePicker}
+            onNavigateAway={closeCompactPicker}
           />
         );
       case "skill":
@@ -598,7 +603,7 @@ export default function ChatInputActionsRow({
             skills={availableSkills ?? []}
             selectedSkills={selectedSkills}
             onSkillsChange={onSkillsChange!}
-            onNavigateAway={closeMobilePicker}
+            onNavigateAway={closeCompactPicker}
           />
         );
       case "expert":
@@ -607,7 +612,7 @@ export default function ChatInputActionsRow({
             agents={availableExperts ?? []}
             selectedAgentIds={selectedTargetAgents}
             onAgentsChange={onTargetAgentsChange!}
-            onNavigateAway={closeMobilePicker}
+            onNavigateAway={closeCompactPicker}
           />
         );
       case "shortcut":
@@ -617,17 +622,17 @@ export default function ChatInputActionsRow({
     }
   };
 
-  const compactPickerContent = mobilePicker ? (
+  const compactPickerContent = compactPicker ? (
     <div className={styles.compactPickerPanel}>
       <button
         type="button"
         className={styles.compactPickerBack}
-        onClick={closeMobilePicker}
+        onClick={closeCompactPicker}
       >
         <ChevronLeft size={16} />
-        <span>{mobilePickerTitle[mobilePicker]}</span>
+        <span>{compactPickerTitle[compactPicker]}</span>
       </button>
-      {renderMobilePickerContent()}
+      {renderCompactPickerContent()}
     </div>
   ) : (
     renderMobileOverflowMenu()
@@ -643,7 +648,7 @@ export default function ChatInputActionsRow({
               : ""
           }`}
           type="button"
-          onClick={isMobile ? () => setMobilePicker("model") : undefined}
+          onClick={isMobile ? () => setCompactPicker("model") : undefined}
         >
           <Cpu size={16} />
         </button>
@@ -654,11 +659,7 @@ export default function ChatInputActionsRow({
             overflowBadgeCount > 0 ? styles.secondaryBtnActive : ""
           }`}
           type="button"
-          onClick={
-            isMobile
-              ? () => setMobileOverflowOpen(true)
-              : () => setMobilePicker(null)
-          }
+          onClick={isMobile ? () => setMobileOverflowOpen(true) : undefined}
         >
           <MoreHorizontal size={16} />
           {overflowBadgeCount > 0 && (
@@ -679,6 +680,7 @@ export default function ChatInputActionsRow({
                 open={modelPickerOpen}
                 onOpenChange={(open) => {
                   setModelPickerOpen(open);
+                  if (open) setOverflowPopoverOpen(false);
                   if (!open) setReasoningModelRef(null);
                 }}
                 overlayClassName={styles.modelPopover}
@@ -702,10 +704,18 @@ export default function ChatInputActionsRow({
               <Popover
                 trigger="click"
                 placement="topLeft"
+                open={overflowPopoverOpen}
                 overlayClassName={styles.skillPickerPopover}
                 content={compactPickerContent}
                 onOpenChange={(open) => {
-                  if (!open) closeMobilePicker();
+                  setOverflowPopoverOpen(open);
+                  if (open) {
+                    setModelPickerOpen(false);
+                    setCompactPicker(null);
+                    setReasoningModelRef(null);
+                  } else {
+                    closeCompactPicker();
+                  }
                 }}
               >
                 {overflowButton}
@@ -726,16 +736,16 @@ export default function ChatInputActionsRow({
                 {renderMobileOverflowMenu()}
               </Drawer>
               <Drawer
-                open={mobilePicker !== null}
-                onClose={closeMobilePicker}
+                open={compactPicker !== null}
+                onClose={closeCompactPicker}
                 placement="bottom"
                 height="auto"
-                title={mobilePicker ? mobilePickerTitle[mobilePicker] : ""}
+                title={compactPicker ? compactPickerTitle[compactPicker] : ""}
                 className={styles.mobilePickerDrawer}
                 styles={{ body: { padding: 0 } }}
                 destroyOnHidden
               >
-                {renderMobilePickerContent()}
+                {renderCompactPickerContent()}
               </Drawer>
             </>
           )}

--- a/dashboard/src/pages/Chat/components/MessageBubble.tsx
+++ b/dashboard/src/pages/Chat/components/MessageBubble.tsx
@@ -386,18 +386,28 @@ export function ToolDetailsInline({
   if (registration && registration.id !== "default") {
     const Comp = registration.component;
     return (
-      <ToolUiErrorBoundary propsForFallback={props}>
-        <Comp {...props} />
-      </ToolUiErrorBoundary>
+      <div data-octop-tool-renderer="">
+        <ToolUiErrorBoundary propsForFallback={props}>
+          <Comp {...props} />
+        </ToolUiErrorBoundary>
+      </div>
     );
   }
 
   // Structured plugin envelope without a loaded custom renderer — still show a card.
   if (parsed.octopUi) {
-    return <BuiltinOctopUiFallback {...props} />;
+    return (
+      <div data-octop-tool-renderer="">
+        <BuiltinOctopUiFallback {...props} />
+      </div>
+    );
   }
 
-  return <DefaultToolRenderer {...props} />;
+  return (
+    <div data-octop-tool-renderer="">
+      <DefaultToolRenderer {...props} />
+    </div>
+  );
 }
 
 function MessageBubble({

--- a/dashboard/src/pages/Chat/components/ScrollToBottomButton.tsx
+++ b/dashboard/src/pages/Chat/components/ScrollToBottomButton.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef, useState } from "react";
 import { ChevronDown } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import styles from "../index.module.less";
@@ -13,10 +14,65 @@ export default function ScrollToBottomButton({
 }: ScrollToBottomButtonProps) {
   const { t } = useTranslation();
   const label = t("chat.scrollToBottom");
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const [overlapsTool, setOverlapsTool] = useState(false);
+
+  useEffect(() => {
+    if (!visible) return;
+
+    const button = buttonRef.current;
+    const wrapper = button?.closest(`.${styles.messageListWrapper}`);
+    const scroller = wrapper?.querySelector(`.${styles.messageList}`);
+    if (!button || !wrapper || !scroller) return;
+
+    let frame = 0;
+    const updateOverlap = () => {
+      cancelAnimationFrame(frame);
+      frame = requestAnimationFrame(() => {
+        const buttonRect = button.getBoundingClientRect();
+        const toolRenderers = wrapper.querySelectorAll<HTMLElement>(
+          "[data-octop-tool-renderer]",
+        );
+        const overlaps = Array.from(toolRenderers).some((tool) => {
+          const toolRect = tool.getBoundingClientRect();
+          return (
+            buttonRect.left < toolRect.right &&
+            buttonRect.right > toolRect.left &&
+            buttonRect.top < toolRect.bottom &&
+            buttonRect.bottom > toolRect.top
+          );
+        });
+        setOverlapsTool(overlaps);
+      });
+    };
+
+    updateOverlap();
+    scroller.addEventListener("scroll", updateOverlap, { passive: true });
+    window.addEventListener("resize", updateOverlap);
+
+    const resizeObserver =
+      typeof ResizeObserver === "undefined"
+        ? null
+        : new ResizeObserver(updateOverlap);
+    resizeObserver?.observe(wrapper);
+    wrapper
+      .querySelectorAll<HTMLElement>("[data-octop-tool-renderer]")
+      .forEach((tool) => resizeObserver?.observe(tool));
+
+    return () => {
+      cancelAnimationFrame(frame);
+      scroller.removeEventListener("scroll", updateOverlap);
+      window.removeEventListener("resize", updateOverlap);
+      resizeObserver?.disconnect();
+    };
+  }, [visible]);
+
+  const actuallyVisible = visible && !overlapsTool;
   return (
     <button
+      ref={buttonRef}
       className={`${styles.scrollToBottomBtn} ${
-        visible
+        actuallyVisible
           ? styles.scrollToBottomBtnVisible
           : styles.scrollToBottomBtnHidden
       }`}
@@ -24,8 +80,8 @@ export default function ScrollToBottomButton({
       type="button"
       title={label}
       aria-label={label}
-      aria-hidden={!visible}
-      tabIndex={visible ? 0 : -1}
+      aria-hidden={!actuallyVisible}
+      tabIndex={actuallyVisible ? 0 : -1}
     >
       <ChevronDown size={16} strokeWidth={2.5} aria-hidden />
       <span>{label}</span>

--- a/dashboard/src/sw-register.test.ts
+++ b/dashboard/src/sw-register.test.ts
@@ -11,17 +11,18 @@ function mockRegistration(opts: {
   installing?: FakeWorker | null;
   controller?: { scriptURL: string } | null;
 }) {
-  const listeners = new Map<string, Array<() => void>>();
+  const registrationListeners = new Map<string, Array<() => void>>();
+  const swListeners = new Map<string, Array<() => void>>();
   const registration = {
     waiting: opts.waiting ?? null,
     installing: opts.installing ?? null,
     addEventListener: (type: string, fn: () => void) => {
-      const list = listeners.get(type) ?? [];
+      const list = registrationListeners.get(type) ?? [];
       list.push(fn);
-      listeners.set(type, list);
+      registrationListeners.set(type, list);
     },
     emit: (type: string) => {
-      for (const fn of listeners.get(type) ?? []) fn();
+      for (const fn of registrationListeners.get(type) ?? []) fn();
     },
     update: vi.fn(),
   };
@@ -31,6 +32,25 @@ function mockRegistration(opts: {
       register: vi.fn().mockResolvedValue(registration),
       getRegistrations: vi.fn().mockResolvedValue([]),
       controller: opts.controller ?? null,
+      addEventListener: (
+        type: string,
+        fn: () => void,
+        _options?: { once?: boolean },
+      ) => {
+        const list = swListeners.get(type) ?? [];
+        list.push(fn);
+        swListeners.set(type, list);
+      },
+      removeEventListener: (type: string, fn: () => void) => {
+        const list = swListeners.get(type) ?? [];
+        swListeners.set(
+          type,
+          list.filter((listener) => listener !== fn),
+        );
+      },
+      emit: (type: string) => {
+        for (const fn of [...(swListeners.get(type) ?? [])]) fn();
+      },
     },
   });
   return registration;
@@ -83,5 +103,80 @@ describe("registerProductionSW", () => {
 
     expect(waiting.postMessage).not.toHaveBeenCalled();
     expect(onReady).toHaveBeenCalledOnce();
+  });
+});
+
+describe("applyUpdate", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.useFakeTimers();
+    vi.stubGlobal("location", {
+      ...window.location,
+      reload: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("reloads immediately when no waiting worker is pending", async () => {
+    mockRegistration({ waiting: null, controller: null });
+    const { applyUpdate } = await import("./sw-register");
+
+    await applyUpdate();
+
+    expect(window.location.reload).toHaveBeenCalledOnce();
+  });
+
+  it("waits for controllerchange before reloading", async () => {
+    const waiting: FakeWorker = {
+      state: "installed",
+      postMessage: vi.fn(),
+      addEventListener: vi.fn(),
+    };
+    mockRegistration({
+      waiting,
+      controller: { scriptURL: "https://x/sw.js" },
+    });
+
+    const { applyUpdate, registerProductionSW } = await import("./sw-register");
+    await registerProductionSW();
+
+    const pending = applyUpdate();
+    expect(waiting.postMessage).toHaveBeenCalledWith({ type: "SKIP_WAITING" });
+    expect(window.location.reload).not.toHaveBeenCalled();
+
+    (
+      navigator.serviceWorker as unknown as { emit: (type: string) => void }
+    ).emit("controllerchange");
+    await pending;
+
+    expect(window.location.reload).toHaveBeenCalledOnce();
+  });
+
+  it("reloads after timeout if controllerchange never fires", async () => {
+    const waiting: FakeWorker = {
+      state: "installed",
+      postMessage: vi.fn(),
+      addEventListener: vi.fn(),
+    };
+    mockRegistration({
+      waiting,
+      controller: { scriptURL: "https://x/sw.js" },
+    });
+
+    const { applyUpdate, registerProductionSW } = await import("./sw-register");
+    await registerProductionSW();
+
+    const pending = applyUpdate();
+    expect(window.location.reload).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(3000);
+    await pending;
+
+    expect(window.location.reload).toHaveBeenCalledOnce();
   });
 });

--- a/dashboard/src/utils/copyText.test.ts
+++ b/dashboard/src/utils/copyText.test.ts
@@ -1,31 +1,62 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
-
-const copyMock = vi.fn();
-
-vi.mock("copy-to-clipboard", () => ({
-  default: (text: string) => copyMock(text) as boolean,
-}));
-
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { copyText } from "./copyText";
 
 describe("copyText", () => {
   beforeEach(() => {
-    copyMock.mockReset();
+    vi.restoreAllMocks();
   });
 
-  it("returns false for empty text without calling copy", async () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns false for empty text", async () => {
     expect(await copyText("")).toBe(false);
-    expect(copyMock).not.toHaveBeenCalled();
   });
 
-  it("delegates to copy-to-clipboard", async () => {
-    copyMock.mockReturnValue(true);
+  it("uses Clipboard API in a secure context", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal("isSecureContext", true);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+
     expect(await copyText("hello")).toBe(true);
-    expect(copyMock).toHaveBeenCalledWith("hello");
+    expect(writeText).toHaveBeenCalledWith("hello");
   });
 
-  it("returns false when copy-to-clipboard fails", async () => {
-    copyMock.mockReturnValue(false);
-    expect(await copyText("hello")).toBe(false);
+  it("falls back to execCommand when Clipboard API is unavailable", async () => {
+    vi.stubGlobal("isSecureContext", false);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: undefined,
+    });
+    const execCommand = vi.fn().mockReturnValue(true);
+    Object.defineProperty(document, "execCommand", {
+      configurable: true,
+      value: execCommand,
+    });
+
+    expect(await copyText("hello")).toBe(true);
+    expect(execCommand).toHaveBeenCalledWith("copy");
+  });
+
+  it("falls back when Clipboard API rejects", async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error("denied"));
+    vi.stubGlobal("isSecureContext", true);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+    const execCommand = vi.fn().mockReturnValue(true);
+    Object.defineProperty(document, "execCommand", {
+      configurable: true,
+      value: execCommand,
+    });
+
+    expect(await copyText("hello")).toBe(true);
+    expect(writeText).toHaveBeenCalledWith("hello");
+    expect(execCommand).toHaveBeenCalledWith("copy");
   });
 });

--- a/dashboard/src/utils/copyText.ts
+++ b/dashboard/src/utils/copyText.ts
@@ -1,18 +1,41 @@
 /**
- * Copy text to the clipboard, including plain HTTP (non-secure) pages.
+ * Copy text to the clipboard with a legacy fallback for non-secure contexts.
  *
- * `navigator.clipboard` requires a secure context (https or localhost).
- * `copy-to-clipboard` falls back to execCommand so copy still works on
- * http:// admin hosts.
+ * The async Clipboard API is only available in secure contexts (https or
+ * localhost). When it is unavailable or rejects, fall back to a temporary
+ * textarea + execCommand so copy still works on plain-http admin pages.
+ *
+ * This is the only write-clipboard entry for the dashboard. Clipboard *read*
+ * (e.g. paste) stays at the call site — it still requires a secure context.
  *
  * @returns true when the text was copied, false otherwise.
  */
-import copy from "copy-to-clipboard";
-
 export async function copyText(text: string): Promise<boolean> {
   if (text === "") return false;
+
+  if (navigator.clipboard && window.isSecureContext) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch {
+      // fall through to the legacy path
+    }
+  }
+
   try {
-    return copy(text);
+    const textarea = document.createElement("textarea");
+    textarea.value = text;
+    textarea.setAttribute("readonly", "");
+    textarea.style.position = "fixed";
+    textarea.style.top = "0";
+    textarea.style.left = "0";
+    textarea.style.opacity = "0";
+    document.body.appendChild(textarea);
+    textarea.focus();
+    textarea.select();
+    const ok = document.execCommand("copy");
+    document.body.removeChild(textarea);
+    return ok;
   } catch {
     return false;
   }

--- a/src/octop/api/routers/mobile/shell_ws.py
+++ b/src/octop/api/routers/mobile/shell_ws.py
@@ -10,6 +10,7 @@ import logging
 import os
 import signal
 import subprocess
+from functools import partial
 from typing import Any
 
 from fastapi import APIRouter, Query, WebSocket, WebSocketDisconnect
@@ -37,6 +38,10 @@ def _read_nonblock(fd: int) -> bytes | None:
         if exc.errno in (errno.EAGAIN, errno.EWOULDBLOCK):
             return None
         return b""
+
+
+def _write_pty(fd: int, data: bytes) -> None:
+    os.write(fd, data)
 
 
 async def _send_json(ws: WebSocket, payload: dict[str, Any]) -> None:
@@ -76,7 +81,8 @@ async def adb_shell_ws(
         return
 
     device = (serial or "").strip()
-    if not device or device not in list_devices():
+    connected = await asyncio.to_thread(list_devices)
+    if not device or device not in connected:
         await _send_json(websocket, {"type": "error", "message": "device unavailable"})
         await websocket.close(code=4003, reason="device unavailable")
         return
@@ -126,16 +132,26 @@ async def adb_shell_ws(
     try:
         while True:
             raw = await websocket.receive_text()
-            msg = json.loads(raw)
+            try:
+                msg = json.loads(raw)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(msg, dict):
+                continue
             t = msg.get("type")
             if t == "input":
                 data = msg.get("data")
                 if isinstance(data, str) and data:
-                    os.write(master_fd, data.encode("utf-8", errors="replace"))
+                    await loop.run_in_executor(
+                        None,
+                        _write_pty,
+                        master_fd,
+                        data.encode("utf-8", errors="replace"),
+                    )
             elif t == "resize":
                 c = int(msg.get("cols") or cols)
                 r = int(msg.get("rows") or rows)
-                _set_winsize(master_fd, c, r)
+                await loop.run_in_executor(None, _set_winsize, master_fd, c, r)
     except WebSocketDisconnect:
         pass
     finally:
@@ -149,7 +165,7 @@ async def adb_shell_ws(
             with contextlib.suppress(OSError, ProcessLookupError):
                 posix_compat.killpg(posix_compat.getpgid(proc.pid), signal.SIGTERM)
             with contextlib.suppress(subprocess.TimeoutExpired):
-                proc.wait(timeout=1)
+                await loop.run_in_executor(None, partial(proc.wait, timeout=1))
         code = proc.poll()
         if code is not None:
             await _send_json(websocket, {"type": "exit", "code": code})

--- a/src/octop/infra/browser/setup.py
+++ b/src/octop/infra/browser/setup.py
@@ -10,6 +10,7 @@ import os
 import shutil
 import subprocess
 import sys
+import tempfile
 import time
 from collections.abc import AsyncIterator
 from pathlib import Path
@@ -23,24 +24,40 @@ def _sse(event: dict[str, object]) -> str:
     return f"data: {json.dumps(event)}\n\n"
 
 
-def _runtime_dir_for_uid(uid: int | None = None) -> Path:
-    if not sys.platform.startswith("linux"):
-        import tempfile
+def _is_linux() -> bool:
+    return sys.platform.startswith("linux")
 
-        return Path(tempfile.gettempdir()) / f"runtime-harness-browser-{os.getpid()}"
-    if uid is None:
-        uid = os.getuid() if hasattr(os, "getuid") else 0
-    return Path(f"/tmp/runtime-harness-browser-{uid}")
+
+def _temp_scope_token(uid: int | None = None) -> str:
+    """Stable per-user suffix for temp dirs (never process id).
+
+    Linux/macOS use ``uid`` / ``getuid()``. Windows has no ``getuid`` — use
+    ``USERNAME`` / ``USER`` so relocated profiles survive process restarts.
+    """
+    if uid is not None:
+        return str(uid)
+    getuid = getattr(os, "getuid", None)
+    if callable(getuid):
+        return str(getuid())
+    for key in ("USERNAME", "USER"):
+        value = (os.environ.get(key) or "").strip()
+        if value:
+            return value
+    return "default"
+
+
+def _runtime_dir_for_uid(uid: int | None = None) -> Path:
+    token = _temp_scope_token(uid)
+    if _is_linux():
+        return Path(f"/tmp/runtime-harness-browser-{token}")
+    return Path(tempfile.gettempdir()) / f"runtime-harness-browser-{token}"
 
 
 def _relocated_profiles_root_for_uid(uid: int | None = None) -> Path:
-    if not sys.platform.startswith("linux"):
-        import tempfile
-
-        return Path(tempfile.gettempdir()) / f"harness-browser-profiles-{os.getpid()}"
-    if uid is None:
-        uid = os.getuid() if hasattr(os, "getuid") else 0
-    return Path(f"/tmp/harness-browser-profiles-{uid}")
+    token = _temp_scope_token(uid)
+    if _is_linux():
+        return Path(f"/tmp/harness-browser-profiles-{token}")
+    return Path(tempfile.gettempdir()) / f"harness-browser-profiles-{token}"
 
 
 def ensure_chrome_runtime_env() -> Path:
@@ -147,7 +164,7 @@ def _probe_dir_writable(directory: Path) -> bool:
         probe = directory / f".octop-write-{os.getpid()}"
         probe.write_text("ok", encoding="utf-8")
         probe.unlink()
-        if sys.platform.startswith("linux"):
+        if _is_linux():
             link = directory / f".octop-link-{os.getpid()}"
             link.symlink_to("probe-target")
             link.unlink()

--- a/src/octop/infra/connectors/gateway/cli_install.py
+++ b/src/octop/infra/connectors/gateway/cli_install.py
@@ -85,6 +85,13 @@ def _user_npm_prefix() -> tuple[str, str]:
     return prefix, _prefix_bin_dir(prefix)
 
 
+def _manual_install_command(npm_package: str, *, prefix: str | None = None) -> str:
+    """Shell command users can paste; include ``--prefix`` when global is not writable."""
+    if prefix:
+        return f"npm install -g --prefix {prefix} {npm_package}"
+    return f"npm install -g {npm_package}"
+
+
 def _prefix_writable(prefix: str) -> bool:
     if not prefix:
         return False
@@ -151,11 +158,17 @@ def install_connector_cli(kind: str) -> dict[str, Any]:
     # 自动降级到用户级目录 ~/.npm-global 安装，避免 EACCES 导致安装失败。
     prefix, _ = _npm_prefix_info(npm)
     install_args = [npm, "install", "-g"]
+    user_prefix: str | None = None
     if not _prefix_writable(prefix):
         user_prefix, _user_bin = _user_npm_prefix()
         with contextlib.suppress(OSError):
             os.makedirs(user_prefix, exist_ok=True)
         install_args += ["--prefix", user_prefix]
+        # Keep error / guide text aligned with the command that actually ran.
+        status = {
+            **status,
+            "install_command": _manual_install_command(status["npm_package"], prefix=user_prefix),
+        }
 
     try:
         completed = subprocess.run(
@@ -180,17 +193,27 @@ def install_connector_cli(kind: str) -> dict[str, Any]:
         msg = f"npm install 失败（exit {completed.returncode}）"
         if detail:
             msg = f"{msg}：{detail}"
-        if "--prefix" in install_args:
-            msg = f"{msg}。已尝试写入用户级目录（~/.npm-global）仍失败，请在主机手动执行：{status['install_command']}"
+        if user_prefix is not None:
+            msg = (
+                f"{msg}。已尝试写入用户级目录（~/.npm-global）仍失败，"
+                f"请在主机手动执行：{status['install_command']}"
+            )
         else:
             msg = f"{msg}。请在主机手动执行：{status['install_command']}"
         return _fail(status, msg)
 
     # 降级安装到用户级目录后，把该 bin 目录加入进程 PATH，使状态检测与后续 CLI 调用可见。
-    if "--prefix" in install_args:
+    if user_prefix is not None:
         ensure_cli_path()
 
     refreshed = cli_install_status(kind)
+    if user_prefix is not None:
+        refreshed = {
+            **refreshed,
+            "install_command": _manual_install_command(
+                refreshed["npm_package"], prefix=user_prefix
+            ),
+        }
     if not refreshed["installed"]:
         return _fail(
             refreshed,

--- a/tests/integration/test_subagents_api.py
+++ b/tests/integration/test_subagents_api.py
@@ -103,7 +103,7 @@ async def test_catalog_divisions(env: Any) -> None:
     r = await c.get("/api/subagent-catalog/divisions", headers=auth)
     assert r.status_code == 200, r.text
     rows = r.json()
-    assert len(rows) == 16
+    assert len(rows) == 19
     assert any(row["id"] == "engineering" and row["count"] > 0 for row in rows)
 
 

--- a/tests/unit/agents/test_subagent_catalog.py
+++ b/tests/unit/agents/test_subagent_catalog.py
@@ -192,7 +192,7 @@ def test_bundled_library_non_empty() -> None:
     catalog = SubagentCatalog(default_package_root())
     catalog.refresh()
     assert len(catalog.list_summaries()) > 100
-    assert len(catalog.list_divisions()) == 16
+    assert len(catalog.list_divisions()) == 19
     assert catalog.get("engineering-software-architect") is not None
 
 

--- a/tests/unit/browser/test_browser_setup.py
+++ b/tests/unit/browser/test_browser_setup.py
@@ -11,6 +11,9 @@ import pytest
 
 from octop.infra.browser.setup import (
     _probe_dir_writable,
+    _relocated_profiles_root_for_uid,
+    _runtime_dir_for_uid,
+    _temp_scope_token,
     chrome_source_for_path,
     clear_profile_locks,
     ensure_chrome_runtime_env,
@@ -118,6 +121,58 @@ def test_ensure_chrome_runtime_env_forces_tmp_dir(
     assert path.is_dir()
     assert os.access(path, os.W_OK | os.X_OK)
     assert S_IMODE(path.stat().st_mode) == 0o700
+
+
+def test_non_linux_temp_dirs_use_gettempdir_with_stable_token(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Windows must not use a literal /tmp path (drive-root PermissionError)."""
+    from octop.infra.browser import setup as browser_setup
+
+    fake_tmp = tmp_path / "WinTemp"
+    fake_tmp.mkdir()
+    monkeypatch.setattr(browser_setup.sys, "platform", "win32")
+    monkeypatch.setattr(browser_setup.tempfile, "gettempdir", lambda: str(fake_tmp))
+
+    runtime = _runtime_dir_for_uid(uid=7)
+    profiles = _relocated_profiles_root_for_uid(uid=7)
+
+    assert runtime == fake_tmp / "runtime-harness-browser-7"
+    assert profiles == fake_tmp / "harness-browser-profiles-7"
+    # Same inputs → same paths across "process restarts" (no pid in the name).
+    assert _runtime_dir_for_uid(uid=7) == runtime
+    assert _relocated_profiles_root_for_uid(uid=7) == profiles
+
+
+def test_temp_scope_token_uses_username_when_getuid_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from octop.infra.browser import setup as browser_setup
+
+    # Simulate Windows: getuid absent / not callable.
+    monkeypatch.setattr(browser_setup.os, "getuid", object())
+    monkeypatch.setenv("USERNAME", "OctopUser")
+    monkeypatch.delenv("USER", raising=False)
+
+    assert _temp_scope_token() == "OctopUser"
+    assert _temp_scope_token(uid=3) == "3"
+
+
+def test_probe_dir_writable_skips_symlink_on_non_linux(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from octop.infra.browser import setup as browser_setup
+
+    monkeypatch.setattr(browser_setup.sys, "platform", "win32")
+
+    def _forbid_symlink(self: Path, *args: object, **kwargs: object) -> None:
+        raise AssertionError("symlink probe must not run on non-Linux")
+
+    monkeypatch.setattr(Path, "symlink_to", _forbid_symlink)
+
+    target = tmp_path / "profile"
+    assert _probe_dir_writable(target) is True
+    assert target.is_dir()
 
 
 @posix_only

--- a/tests/unit/connectors/test_cli_install.py
+++ b/tests/unit/connectors/test_cli_install.py
@@ -138,6 +138,51 @@ def test_install_degrades_to_user_prefix_when_global_not_writable(
     assert "--prefix" in install_call
     assert str(home / ".npm-global") in install_call
     assert cli_install._user_npm_prefix()[0] == str(home / ".npm-global")
+    # Success path still returns the prefixed command so UI/docs stay consistent.
+    assert out["install_command"] == (f"npm install -g --prefix {home / '.npm-global'} @wecom/cli")
+
+
+def test_install_failure_message_uses_prefixed_command(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Any
+) -> None:
+    """When global prefix is not writable, failure guidance must not suggest bare -g."""
+    home = tmp_path / "home"
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+
+    def _which(name: str) -> str | None:
+        if name == "npm":
+            return fake_bin_path("npm")
+        return None
+
+    def _run(argv: list[str], **kwargs: Any) -> Any:
+        del kwargs
+        if argv[1:3] == ["config", "get"]:
+
+            class _Cfg:
+                returncode = 0
+                stdout = "/usr/local"
+                stderr = ""
+
+            return _Cfg()
+
+        class _Failed:
+            returncode = 243
+            stdout = ""
+            stderr = "EACCES: permission denied"
+
+        return _Failed()
+
+    monkeypatch.setattr(cli_install.shutil, "which", _which)
+    monkeypatch.setattr(cli_install.subprocess, "run", _run)
+    monkeypatch.setattr(cli_install.os, "access", lambda _p, _m: False)
+
+    out = cli_install.install_connector_cli("wecom-cli")
+    assert out["ok"] is False
+    prefixed = f"npm install -g --prefix {home / '.npm-global'} @wecom/cli"
+    assert out["install_command"] == prefixed
+    assert prefixed in out["error"]
+    assert "npm install -g @wecom/cli" not in out["error"].replace(prefixed, "")
 
 
 def test_ensure_cli_path_injects_user_bin(monkeypatch: pytest.MonkeyPatch, tmp_path: Any) -> None:


### PR DESCRIPTION
## Summary
Splits the original working-tree diff into two focused PRs (this is the dashboard + backend half; the FnOS packaging restructure is in a separate PR).

- Replace the `copy-to-clipboard` dependency with a native clipboard helper (`navigator.clipboard` + `execCommand` fallback) in `dashboard/src/utils/copyText.ts`.
- Chat UI polish: `ChatInputActionsRow`, `MessageBubble`, `ScrollToBottomButton` refinements and updated PWA service-worker registration tests.
- Backend: mobile shell websocket hardening (`api/routers/mobile/shell_ws.py`), browser setup (`infra/browser/setup.py`), and connector CLI install (`infra/connectors/gateway/cli_install.py`) with accompanying unit tests.

## Notes
- The first commit (`fix(tests): align subagent catalog division count with bundled library`) is included as the base of this branch to keep `develop` green — the bundled subagent catalog now loads 19 divisions (272 agents), which two pre-existing tests still asserted as 16. The same fix base is carried by the companion FnOS PR.
- Pre-commit hook (`make all` + dashboard build) passes on both commits.

## Test plan
- `uv run pytest -m "not live"` and the dashboard `npm run build` run green via the pre-commit hook.
- `uv run pytest tests/unit/browser tests/unit/connectors -q` for the backend changes.
- Dashboard: `cd dashboard && npx tsc --noEmit`.