### PR TITLE
fix(fnos): 镜像命名空间改为 ghcr.io/jubaoliang/octop（小写，修正 buildx 大写 tag 报错）

### DIFF
--- a/.github/workflows/fnos-build-fpk.yml
+++ b/.github/workflows/fnos-build-fpk.yml
@@ -5,12 +5,12 @@ name: Build Octop FPK (template)
 # # then publishes GitHub releases (fixed version + rolling latest).
 # #
 # # To enable on your fork:
-# #   1. Replace ghcr.io/TencentCloud/octop with your own image namespace (or fork a copy).
+# #   1. Replace ghcr.io/jubaoliang/octop with your own image namespace (or fork a copy).
 # #   2. Optionally add a push trigger below (e.g. branches: [main]) so a rebuild happens
 # #      automatically on every upstream sync. It is intentionally workflow_dispatch-only
 # #      here so it never runs on the upstream repository.
 # #
-#   image  job：从仓库源码构建 Octop Docker 镜像，推送到 GHCR（ghcr.io/TencentCloud/octop:vanilla）
+#   image  job：从仓库源码构建 Octop Docker 镜像，推送到 GHCR（ghcr.io/jubaoliang/octop:vanilla）
 #   fpk    job：构建「Docker 版」飞牛安装包 Fnos-octop-vanilla-<ver>-<iter>.fpk（依赖 image，确保镜像已就绪）
 #   native job：构建「本地版（非 Docker）」飞牛安装包 Fnos-octop-vanilla-native-<ver>-<iter>.fpk。
 #               不内置 Python 运行时（依赖飞牛应用商店 Python 3.12），
@@ -99,8 +99,9 @@ jobs:
           file: fnos/docker/Dockerfile
           push: true
           tags: |
-            ghcr.io/TencentCloud/octop:vanilla
-            ghcr.io/TencentCloud/octop:vanilla-v${{ needs.version.outputs.version }}
+            ghcr.io/jubaoliang/octop:latest
+            ghcr.io/jubaoliang/octop:vanilla
+            ghcr.io/jubaoliang/octop:vanilla-v${{ needs.version.outputs.version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -304,7 +305,7 @@ jobs:
             echo "## 安装说明"
             echo ""
             echo "1. 飞牛应用中心 → 设置 → 手动安装应用，选择对应 .fpk。"
-            echo "2. Docker 版 **Fnos-octop-vanilla-${VER}-${ITER}.fpk**（约 80KB）：飞牛自动从 GHCR 拉取镜像运行，镜像为 \\"ghcr.io/TencentCloud/octop:vanilla\\"。"
+            echo "2. Docker 版 **Fnos-octop-vanilla-${VER}-${ITER}.fpk**（约 80KB）：飞牛自动从 GHCR 拉取镜像运行，镜像为 \\"ghcr.io/jubaoliang/octop:vanilla\\"。"
             echo "3. 本地版 **Fnos-octop-vanilla-native-${VER}-${ITER}.fpk**（约 200MB）：非 Docker，原生运行在飞牛主机；安装时自动关联系统 Python 3.12 开发工具；浏览器、远程桌面等附加组件在 Octop 应用内按需安装。"
             echo ""
             echo "---"

--- a/.github/workflows/fnos-build-fpk.yml
+++ b/.github/workflows/fnos-build-fpk.yml
@@ -5,12 +5,12 @@ name: Build Octop FPK (template)
 # # then publishes GitHub releases (fixed version + rolling latest).
 # #
 # # To enable on your fork:
-# #   1. Replace ghcr.io/jubaoliang/octop with your own image namespace (or fork a copy).
+# #   1. Replace jubaoliang/octop with your own image namespace (or fork a copy).
 # #   2. Optionally add a push trigger below (e.g. branches: [main]) so a rebuild happens
 # #      automatically on every upstream sync. It is intentionally workflow_dispatch-only
 # #      here so it never runs on the upstream repository.
 # #
-#   image  job：从仓库源码构建 Octop Docker 镜像，推送到 GHCR（ghcr.io/jubaoliang/octop:vanilla）
+#   image  job：从仓库源码构建 Octop Docker 镜像，推送到 Docker Hub（jubaoliang/octop:vanilla）
 #   fpk    job：构建「Docker 版」飞牛安装包 Fnos-octop-vanilla-<ver>-<iter>.fpk（依赖 image，确保镜像已就绪）
 #   native job：构建「本地版（非 Docker）」飞牛安装包 Fnos-octop-vanilla-native-<ver>-<iter>.fpk。
 #               不内置 Python 运行时（依赖飞牛应用商店 Python 3.12），
@@ -85,12 +85,12 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Login to GHCR
+      - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          # Docker Hub（与 docker-publish.yml 同一凭据，DOCKERHUB_USERNAME 为 jubaoliang 时推送 jubaoliang/octop）
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push image
         uses: docker/build-push-action@v6
@@ -99,9 +99,9 @@ jobs:
           file: fnos/docker/Dockerfile
           push: true
           tags: |
-            ghcr.io/jubaoliang/octop:latest
-            ghcr.io/jubaoliang/octop:vanilla
-            ghcr.io/jubaoliang/octop:vanilla-v${{ needs.version.outputs.version }}
+            jubaoliang/octop:latest
+            jubaoliang/octop:vanilla
+            jubaoliang/octop:vanilla-v${{ needs.version.outputs.version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -305,7 +305,7 @@ jobs:
             echo "## 安装说明"
             echo ""
             echo "1. 飞牛应用中心 → 设置 → 手动安装应用，选择对应 .fpk。"
-            echo "2. Docker 版 **Fnos-octop-vanilla-${VER}-${ITER}.fpk**（约 80KB）：飞牛自动从 GHCR 拉取镜像运行，镜像为 \\"ghcr.io/jubaoliang/octop:vanilla\\"。"
+            echo "2. Docker 版 **Fnos-octop-vanilla-${VER}-${ITER}.fpk**（约 80KB）：飞牛自动从 Docker Hub 拉取镜像运行，镜像为 \\"jubaoliang/octop:vanilla\\"。"
             echo "3. 本地版 **Fnos-octop-vanilla-native-${VER}-${ITER}.fpk**（约 200MB）：非 Docker，原生运行在飞牛主机；安装时自动关联系统 Python 3.12 开发工具；浏览器、远程桌面等附加组件在 Octop 应用内按需安装。"
             echo ""
             echo "---"

--- a/fnos/README.md
+++ b/fnos/README.md
@@ -19,10 +19,10 @@ After install, open the app (Docker: `http://<device-ip>:8088`, native: `http://
 
 | 版本 | 包名 | 体积 | 运行方式 | 依赖 |
 |------|------|------|----------|------|
-| **Docker 版** | `octop-<ver>.fpk` | ~8 KB | 飞牛自动从 `ghcr.io/jubaoliang/octop:latest` 拉镜像运行 | 宿主需有 Docker 运行时 |
+| **Docker 版** | `octop-<ver>.fpk` | ~8 KB | 飞牛自动从 Docker Hub 拉取 `jubaoliang/octop:latest` 镜像运行 | 宿主需有 Docker 运行时 |
 | **本地版（非 Docker）** | `octop-native-<ver>.fpk` | ~560 MB | 自带 Python 3.12 运行时 + 前端 + 全部附加组件 + Chromium，原生运行在飞牛主机 | 无需 Docker |
 
-- **Docker 版**实现为 FnOS `docker-project`：包体只含 `docker-compose.yaml` 与向导配置，运行时由飞牛拉取 GHCR 镜像。镜像已内置全部附加组件（`browser` 浏览器自动化 + `desktop` 桌面控制）与前端。
+- **Docker 版**实现为 FnOS `docker-project`：包体只含 `docker-compose.yaml` 与向导配置，运行时由飞牛从 Docker Hub 拉取镜像。镜像已内置全部附加组件（`browser` 浏览器自动化 + `desktop` 桌面控制）与前端。
 - **本地版**实现为 FnOS 原生 `app`：包内自带独立 Python 3.12 运行时、Octop 全部依赖、前端构建产物、Playwright Chromium，以及 `data-share` 共享数据目录，直接以进程方式运行，不依赖 Docker。
 
 > 两款包都在滚动发布 **`fnos-latest`**：<https://github.com/TencentCloud/Octop/releases/tag/fnos-latest>
@@ -44,7 +44,7 @@ fnos/
 │   │   └── install         # 安装向导（可配置管理员账号/密码、日志级别、LLM 密钥）
 │   ├── app/
 │   │   ├── docker/
-│   │   │   └── docker-compose.yaml   # 引用 ghcr.io/jubaoliang/octop:latest
+│   │   │   └── docker-compose.yaml   # 引用 jubaoliang/octop:latest
 │   │   └── ui/
 │   │       ├── config                # 桌面图标入口
 │   │       └── images/icon-{64,256}.png
@@ -64,7 +64,7 @@ fnos/
 ## 工作机制
 
 1. **源码同步**：`.github/workflows/zz-sync-upstream.yml` 每 6 小时把上游 `TencentCloud/Octop` 的更新合并进本仓 `main` 分支（使用仓库自带 `GITHUB_TOKEN`，无需 PAT）。
-2. **镜像构建**：`.github/workflows/fnos-build-fpk.yml` 的 `image` job 在 `main` 更新时，用 `fnos/docker/Dockerfile` 从仓库源码构建 Octop 镜像并推送到 `ghcr.io/jubaoliang/octop:latest`（含全部附加组件）。
+2. **镜像构建**：`.github/workflows/fnos-build-fpk.yml` 的 `image` job 在 `main` 更新时，用 `fnos/docker/Dockerfile` 从仓库源码构建 Octop 镜像并推送到 Docker Hub `jubaoliang/octop:latest`（含全部附加组件）。
 3. **安装包构建**：同一 workflow 的 `fpk` job 用 `scripts/build-fpk.sh` 把 `fnos/docker/` 打成 Docker 版 `.fpk`；`native` job 用 python-build-standalone 构建 Python 3.12 运行时、安装全部依赖与 Playwright Chromium，把 `fnos/native/` 打成本地版 `.fpk`（`continue-on-error`，失败不阻塞 Docker 版）。两者均以滚动发布 `fnos-latest` 提供下载。
 
 ## 本地构建 .fpk（无需 Docker）
@@ -84,6 +84,6 @@ bash scripts/build-fpk.sh native     # 仅本地版      → dist/octop-native-<
    - 不想依赖 Docker、希望自带运行时原生运行 → 选 `octop-native-<version>.fpk`
 2. 安装向导中设置管理员账号/密码、日志级别、LLM 密钥（可选）。
 3. 安装完成后桌面出现「Octop AI 助手」图标，浏览器打开 `http://<设备IP>:8088`。
-4. Docker 版镜像首次会从 `ghcr.io/jubaoliang/octop:latest` 拉取；请确保该镜像为公开（workflow 已自动设为 public）。本地版无需联网拉镜像，首次启动会按需要补装 Chromium 系统库（需 root 权限，已尽力处理）。
+4. Docker 版镜像首次会从 Docker Hub `jubaoliang/octop:latest` 拉取；请确保该镜像为公开（workflow 已自动设为 public）。本地版无需联网拉镜像，首次启动会按需要补装 Chromium 系统库（需 root 权限，已尽力处理）。
 
 > 服务端口固定为 `8088`（飞牛端口映射与桌面图标均据此）。附加组件（browser 浏览器自动化 + desktop 桌面控制）已在镜像中默认安装。

--- a/fnos/README.md
+++ b/fnos/README.md
@@ -19,7 +19,7 @@ After install, open the app (Docker: `http://<device-ip>:8088`, native: `http://
 
 | 版本 | 包名 | 体积 | 运行方式 | 依赖 |
 |------|------|------|----------|------|
-| **Docker 版** | `octop-<ver>.fpk` | ~8 KB | 飞牛自动从 `ghcr.io/TencentCloud/octop:latest` 拉镜像运行 | 宿主需有 Docker 运行时 |
+| **Docker 版** | `octop-<ver>.fpk` | ~8 KB | 飞牛自动从 `ghcr.io/jubaoliang/octop:latest` 拉镜像运行 | 宿主需有 Docker 运行时 |
 | **本地版（非 Docker）** | `octop-native-<ver>.fpk` | ~560 MB | 自带 Python 3.12 运行时 + 前端 + 全部附加组件 + Chromium，原生运行在飞牛主机 | 无需 Docker |
 
 - **Docker 版**实现为 FnOS `docker-project`：包体只含 `docker-compose.yaml` 与向导配置，运行时由飞牛拉取 GHCR 镜像。镜像已内置全部附加组件（`browser` 浏览器自动化 + `desktop` 桌面控制）与前端。
@@ -44,7 +44,7 @@ fnos/
 │   │   └── install         # 安装向导（可配置管理员账号/密码、日志级别、LLM 密钥）
 │   ├── app/
 │   │   ├── docker/
-│   │   │   └── docker-compose.yaml   # 引用 ghcr.io/TencentCloud/octop:latest
+│   │   │   └── docker-compose.yaml   # 引用 ghcr.io/jubaoliang/octop:latest
 │   │   └── ui/
 │   │       ├── config                # 桌面图标入口
 │   │       └── images/icon-{64,256}.png
@@ -64,7 +64,7 @@ fnos/
 ## 工作机制
 
 1. **源码同步**：`.github/workflows/zz-sync-upstream.yml` 每 6 小时把上游 `TencentCloud/Octop` 的更新合并进本仓 `main` 分支（使用仓库自带 `GITHUB_TOKEN`，无需 PAT）。
-2. **镜像构建**：`.github/workflows/fnos-build-fpk.yml` 的 `image` job 在 `main` 更新时，用 `fnos/docker/Dockerfile` 从仓库源码构建 Octop 镜像并推送到 `ghcr.io/TencentCloud/octop:latest`（含全部附加组件）。
+2. **镜像构建**：`.github/workflows/fnos-build-fpk.yml` 的 `image` job 在 `main` 更新时，用 `fnos/docker/Dockerfile` 从仓库源码构建 Octop 镜像并推送到 `ghcr.io/jubaoliang/octop:latest`（含全部附加组件）。
 3. **安装包构建**：同一 workflow 的 `fpk` job 用 `scripts/build-fpk.sh` 把 `fnos/docker/` 打成 Docker 版 `.fpk`；`native` job 用 python-build-standalone 构建 Python 3.12 运行时、安装全部依赖与 Playwright Chromium，把 `fnos/native/` 打成本地版 `.fpk`（`continue-on-error`，失败不阻塞 Docker 版）。两者均以滚动发布 `fnos-latest` 提供下载。
 
 ## 本地构建 .fpk（无需 Docker）
@@ -84,6 +84,6 @@ bash scripts/build-fpk.sh native     # 仅本地版      → dist/octop-native-<
    - 不想依赖 Docker、希望自带运行时原生运行 → 选 `octop-native-<version>.fpk`
 2. 安装向导中设置管理员账号/密码、日志级别、LLM 密钥（可选）。
 3. 安装完成后桌面出现「Octop AI 助手」图标，浏览器打开 `http://<设备IP>:8088`。
-4. Docker 版镜像首次会从 `ghcr.io/TencentCloud/octop:latest` 拉取；请确保该镜像为公开（workflow 已自动设为 public）。本地版无需联网拉镜像，首次启动会按需要补装 Chromium 系统库（需 root 权限，已尽力处理）。
+4. Docker 版镜像首次会从 `ghcr.io/jubaoliang/octop:latest` 拉取；请确保该镜像为公开（workflow 已自动设为 public）。本地版无需联网拉镜像，首次启动会按需要补装 Chromium 系统库（需 root 权限，已尽力处理）。
 
 > 服务端口固定为 `8088`（飞牛端口映射与桌面图标均据此）。附加组件（browser 浏览器自动化 + desktop 桌面控制）已在镜像中默认安装。

--- a/fnos/docker/Dockerfile
+++ b/fnos/docker/Dockerfile
@@ -7,7 +7,7 @@
 #   - desktop  （mss / pynput / pillow，桌面控制附加组件）
 #
 # 构建上下文必须为仓库根目录（fnpack / CI 中以仓库根为 context）：
-#   docker build -f fnos/docker/Dockerfile -t ghcr.io/TencentCloud/octop:latest .
+#   docker build -f fnos/docker/Dockerfile -t ghcr.io/jubaoliang/octop:latest .
 #
 # 国内加速（可选 build-arg）：
 #   PIP_INDEX_URL / PIP_TRUSTED_HOST / NPM_REGISTRY / APT_MIRROR

--- a/fnos/docker/Dockerfile
+++ b/fnos/docker/Dockerfile
@@ -7,7 +7,7 @@
 #   - desktop  （mss / pynput / pillow，桌面控制附加组件）
 #
 # 构建上下文必须为仓库根目录（fnpack / CI 中以仓库根为 context）：
-#   docker build -f fnos/docker/Dockerfile -t ghcr.io/jubaoliang/octop:latest .
+#   docker build -f fnos/docker/Dockerfile -t jubaoliang/octop:latest .
 #
 # 国内加速（可选 build-arg）：
 #   PIP_INDEX_URL / PIP_TRUSTED_HOST / NPM_REGISTRY / APT_MIRROR

--- a/fnos/docker/app/docker/docker-compose.yaml
+++ b/fnos/docker/app/docker/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   octop:
-    image: ghcr.io/TencentCloud/octop:latest
+    image: ghcr.io/jubaoliang/octop:latest
     container_name: octop
     restart: unless-stopped
     pull_policy: always

--- a/fnos/docker/app/docker/docker-compose.yaml
+++ b/fnos/docker/app/docker/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   octop:
-    image: ghcr.io/jubaoliang/octop:latest
+    image: jubaoliang/octop:latest
     container_name: octop
     restart: unless-stopped
     pull_policy: always

--- a/fnos/docker/manifest
+++ b/fnos/docker/manifest
@@ -1,7 +1,7 @@
 appname=octop
 version=0.9.15
 display_name=OCTOP
-desc=腾讯开源的多用户多智能体 AI 助手平台，支持 Web 控制台、CLI、IM 渠道与定时任务，数据全部本地存储。<br/><br/><strong>安装后使用：</strong><br/>在应用中心点击「打开」按钮即可进入 Web 控制台，默认地址 http://设备IP:8088。<br/>初始管理员账号：admin，初始密码：Octop123（首次登录后请在头像菜单修改密码）。<br/><br/><strong>首次登录后：</strong><br/>请在控制台「设置」中配置 LLM 模型、IM 渠道、远程桌面、浏览器等组件。<br/><br/>注意：Docker 版通过容器部署，会自动从 ghcr.io/TencentCloud/octop:latest 拉取镜像运行，已预装 browser / desktop 附加组件。
+desc=腾讯开源的多用户多智能体 AI 助手平台，支持 Web 控制台、CLI、IM 渠道与定时任务，数据全部本地存储。<br/><br/><strong>安装后使用：</strong><br/>在应用中心点击「打开」按钮即可进入 Web 控制台，默认地址 http://设备IP:8088。<br/>初始管理员账号：admin，初始密码：Octop123（首次登录后请在头像菜单修改密码）。<br/><br/><strong>首次登录后：</strong><br/>请在控制台「设置」中配置 LLM 模型、IM 渠道、远程桌面、浏览器等组件。<br/><br/>注意：Docker 版通过容器部署，会自动从 ghcr.io/jubaoliang/octop:latest 拉取镜像运行，已预装 browser / desktop 附加组件。
 source=thirdparty
 platform=all
 maintainer=TencentCloud OrcaKit

--- a/fnos/docker/manifest
+++ b/fnos/docker/manifest
@@ -1,7 +1,7 @@
 appname=octop
 version=0.9.15
 display_name=OCTOP
-desc=腾讯开源的多用户多智能体 AI 助手平台，支持 Web 控制台、CLI、IM 渠道与定时任务，数据全部本地存储。<br/><br/><strong>安装后使用：</strong><br/>在应用中心点击「打开」按钮即可进入 Web 控制台，默认地址 http://设备IP:8088。<br/>初始管理员账号：admin，初始密码：Octop123（首次登录后请在头像菜单修改密码）。<br/><br/><strong>首次登录后：</strong><br/>请在控制台「设置」中配置 LLM 模型、IM 渠道、远程桌面、浏览器等组件。<br/><br/>注意：Docker 版通过容器部署，会自动从 ghcr.io/jubaoliang/octop:latest 拉取镜像运行，已预装 browser / desktop 附加组件。
+desc=腾讯开源的多用户多智能体 AI 助手平台，支持 Web 控制台、CLI、IM 渠道与定时任务，数据全部本地存储。<br/><br/><strong>安装后使用：</strong><br/>在应用中心点击「打开」按钮即可进入 Web 控制台，默认地址 http://设备IP:8088。<br/>初始管理员账号：admin，初始密码：Octop123（首次登录后请在头像菜单修改密码）。<br/><br/><strong>首次登录后：</strong><br/>请在控制台「设置」中配置 LLM 模型、IM 渠道、远程桌面、浏览器等组件。<br/><br/>注意：Docker 版通过容器部署，会自动从 jubaoliang/octop:latest 拉取镜像运行，已预装 browser / desktop 附加组件。
 source=thirdparty
 platform=all
 maintainer=TencentCloud OrcaKit


### PR DESCRIPTION
## 问题

`fnos-build-fpk.yml` 中 Docker 镜像 tag 使用了 `ghcr.io/TencentCloud/octop:vanilla`——Docker 仓库名必须小写，大写 `TencentCloud` 会导致 buildx 报错：

```
invalid tag "ghcr.io/TencentCloud/octop:vanilla": repository name must be lowercase
```

另外镜像仓库位置也不对（应为 Docker Hub 而非 ghcr.io）。

## 修复

- 镜像命名空间统一改为 **`jubaoliang/octop`（Docker Hub）**，`docker pull jubaoliang/octop:latest` 无前缀即可拉取：
  - `.github/workflows/fnos-build-fpk.yml`（镜像 tags、注释、release 说明）
  - `fnos/README.md`、`fnos/docker/Dockerfile`、`fnos/docker/app/docker/docker-compose.yaml`、`fnos/docker/manifest`
- workflow 登录改为 **Docker Hub**：`DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN`（与 `docker-publish.yml` 同一套凭据）
- workflow 镜像 tags 增加 **`jubaoliang/octop:latest`**：Docker 版 FPK 的 `docker-compose.yaml` 按 `:latest` 拉取镜像，此前只推 `:vanilla`，飞牛安装 Docker 版后会拉不到镜像

## 说明

- 合并后请在飞牛上安装 Docker 版验证：镜像从 Docker Hub `jubaoliang/octop:latest` 拉取（需保持该镜像为公开）
- 若 `DOCKERHUB_USERNAME` 不是 jubaoliang，请将上述文件中的 `jubaoliang/octop` 替换为实际命名空间
