### PR TITLE
fix: gate update UI by permission and speed up local tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@
 
 ## [Unreleased]
 
+### 修复
+
+- 无「应用更新」权限时隐藏检查更新入口（按权限而非 admin 角色）
+- `/compact` 卸载路径展示兼容 `.octop/conversation_history/`
+
+### 其他
+
+- 测试：`pytest-xdist` 并行、`make test-fast`、`slow` 标记与隔离 HOME
+
 ## [0.9.27] - 2026-08-26
 
 ### 新增

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,8 @@ UV   := $(shell command -v uv 2>/dev/null)
 RUN  := $(if $(UV),uv run,)
 PYTHON := $(if $(UV),uv run python,python3)
 PIP  := $(if $(UV),uv pip,python3 -m pip)
+# Parallel workers for make test / make test-fast (override: make test PYTEST_JOBS=4)
+PYTEST_JOBS ?= auto
 
 # ─── Help ────────────────────────────────────────────────────────────────────
 
@@ -219,8 +221,13 @@ typecheck:
 
 .PHONY: test
 test:
-	@echo "[test] pytest (not live)..."
-	$(RUN) pytest -m "not live"
+	@echo "[test] pytest (not live, -n $(PYTEST_JOBS))..."
+	$(RUN) pytest -n $(PYTEST_JOBS) -m "not live"
+
+.PHONY: test-fast
+test-fast:
+	@echo "[test-fast] pytest (not live, not slow, -n $(PYTEST_JOBS))..."
+	$(RUN) pytest -n $(PYTEST_JOBS) -m "not live and not slow"
 
 .PHONY: test-live
 test-live:

--- a/dashboard/src/components/AppVersionBadge/index.tsx
+++ b/dashboard/src/components/AppVersionBadge/index.tsx
@@ -3,7 +3,8 @@ import { useNavigate } from "react-router-dom";
 import { Tooltip } from "antd";
 import { ArrowUpCircle } from "lucide-react";
 import { useUpdateStatus } from "../../hooks/useUpdateStatus";
-import { useUserRole } from "../../hooks/useUserRole";
+import { useCurrentUser } from "../../hooks/useCurrentUser";
+import { userCan } from "../../utils/permissions";
 import styles from "./index.module.less";
 
 interface AppVersionBadgeProps {
@@ -13,11 +14,11 @@ interface AppVersionBadgeProps {
 export default function AppVersionBadge({ isMobile }: AppVersionBadgeProps) {
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const role = useUserRole();
+  const user = useCurrentUser();
   const { status, hasUpdate } = useUpdateStatus();
 
-  const isAdmin = role === "admin";
-  if (!status?.current_version || !hasUpdate || !isAdmin) return null;
+  const canUpdate = userCan(user, "update");
+  if (!status?.current_version || !hasUpdate || !canUpdate) return null;
 
   const tooltip = t("header.versionUpdateAvailable", {
     current: status.current_version,

--- a/dashboard/src/components/AvatarDropdown.tsx
+++ b/dashboard/src/components/AvatarDropdown.tsx
@@ -43,6 +43,7 @@ import PaletteSwitcher from "./PaletteSwitcher";
 import type { OctopUser } from "../api/modules/auth";
 import { useLayoutMode } from "../context/LayoutModeContext";
 import type { LayoutMode } from "../layouts/layoutModeStorage";
+import { userCan } from "../utils/permissions";
 import styles from "./AvatarDropdown.module.less";
 
 const GITHUB_URL = "https://github.com/TencentCloud/Octop";
@@ -259,17 +260,19 @@ export default function AvatarDropdown({
         <span>{t("account.changePassword")}</span>
       </button>
 
-      <button
-        type="button"
-        className={styles.menuItem}
-        onClick={() => {
-          setMenuOpen(false);
-          navigate("/admin/advanced?tab=updates");
-        }}
-      >
-        <RefreshCw size={16} strokeWidth={1.8} />
-        <span>{t("account.checkUpdates")}</span>
-      </button>
+      {userCan(user, "update") && (
+        <button
+          type="button"
+          className={styles.menuItem}
+          onClick={() => {
+            setMenuOpen(false);
+            navigate("/admin/advanced?tab=updates");
+          }}
+        >
+          <RefreshCw size={16} strokeWidth={1.8} />
+          <span>{t("account.checkUpdates")}</span>
+        </button>
+      )}
 
       <Divider className={styles.menuDivider} />
 

--- a/dashboard/src/components/CurrentVersionBadge/index.tsx
+++ b/dashboard/src/components/CurrentVersionBadge/index.tsx
@@ -2,7 +2,8 @@ import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 import { Tooltip } from "antd";
 import { useUpdateStatus } from "../../hooks/useUpdateStatus";
-import { useUserRole } from "../../hooks/useUserRole";
+import { useCurrentUser } from "../../hooks/useCurrentUser";
+import { userCan } from "../../utils/permissions";
 import styles from "./index.module.less";
 
 interface CurrentVersionBadgeProps {
@@ -14,19 +15,19 @@ export default function CurrentVersionBadge({
 }: CurrentVersionBadgeProps) {
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const role = useUserRole();
+  const user = useCurrentUser();
   const { status } = useUpdateStatus();
 
   const version = status?.current_version;
   if (!version) return null;
 
-  const isAdmin = role === "admin";
-  const tooltip = isAdmin
+  const canUpdate = userCan(user, "update");
+  const tooltip = canUpdate
     ? t("header.currentVersionAdmin", { version })
     : t("header.currentVersion", { version });
   const label = `v${version}`;
 
-  if (isAdmin) {
+  if (canUpdate) {
     return (
       <Tooltip title={tooltip} mouseEnterDelay={0.35}>
         <button

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "apscheduler>=3.10,<4",
     "argon2-cffi>=23.1",
     "pyjwt>=2.8",
-    "orcakit-harness-agent[all]>=0.9.26",
+    "orcakit-harness-agent[all]>=0.9.27",
     "harness-memory>=0.9.7",
     "harness-gateway>=0.9.3",
     "cryptography>=41",
@@ -52,6 +52,7 @@ dev = [
     "pytest-asyncio>=0.23",
     "pytest-cov>=4.1",
     "pytest-testmon>=2.0",
+    "pytest-xdist>=3.6",
     "httpx>=0.27",
     "ruff>=0.4",
     "mypy>=1.10",
@@ -74,6 +75,7 @@ dev = [
     "pytest-asyncio>=0.23",
     "pytest-cov>=4.1",
     "pytest-testmon>=2.0",
+    "pytest-xdist>=3.6",
     "httpx>=0.27",
     "ruff>=0.4",
     "mypy>=1.10",
@@ -191,7 +193,8 @@ disable_error_code = ["attr-defined"]
 testpaths = ["tests"]
 asyncio_mode = "auto"
 markers = [
-    "live: tests that hit real LLM endpoints (skipped by default)",
+    "live: tests that hit real LLM / external services (skipped by default)",
+    "slow: expensive tests (integration boot, real harness, browser); skipped by make test-fast",
     "postgresql: tests that need a live PostgreSQL (set OCTOP_TEST_DATABASE_URL)",
 ]
 # The project pins a starlette fork (1.3.1) whose TestClient prefers a
@@ -202,4 +205,3 @@ markers = [
 filterwarnings = [
     "ignore::starlette.exceptions.StarletteDeprecationWarning",
 ]
-

--- a/src/octop/infra/backend/resolver.py
+++ b/src/octop/infra/backend/resolver.py
@@ -13,12 +13,12 @@ def default_agent_backend_spec(workspace_dir: Path) -> dict[str, Any]:
     """Harness backend for agents with no explicit ``backend`` in config.
 
     On POSIX this matches harness ``DEFAULT_BACKEND_SPEC`` (host-rooted virtual
-    paths). harness ``resolve_backend(..., workspace_dir=...)`` wraps that
-    host root in a composite whose ``artifacts_root`` is the agent workspace,
-    so deepagents conversation history stays writable. On Windows
-    ``root_dir='/'`` resolves to the process current-drive root, which often
-    differs from the drive hosting ``workspace_dir`` — scope the default to
-    the agent workspace instead.
+    paths). harness ``resolve_backend(..., workspace_dir=..., system_files_path=...)``
+    wraps that host root in a composite whose ``artifacts_root`` is the agent
+    workspace system-files prefix (Octop: ``.octop``), so deepagents conversation
+    history stays with skills / sessions. On Windows ``root_dir='/'`` resolves to
+    the process current-drive root, which often differs from the drive hosting
+    ``workspace_dir`` — scope the default to the agent workspace instead.
     """
     from harness_agent.backends import DEFAULT_BACKEND_SPEC  # noqa: PLC0415
 

--- a/src/octop/infra/gateway/slash/handlers/composite.py
+++ b/src/octop/infra/gateway/slash/handlers/composite.py
@@ -120,7 +120,15 @@ async def cmd_compact(
     if raw_path:
         p = Path(str(raw_path))
         # Prefer short workspace-relative display over absolute host paths.
-        short_path = f"conversation_history/{p.name}" if p.name else str(raw_path)
+        # Offloads land under ``{system_files_path}/conversation_history/``
+        # (Octop default: ``.octop/conversation_history/``).
+        parts = [part for part in p.parts if part not in ("/", "\\")]
+        if "conversation_history" in parts:
+            idx = parts.index("conversation_history")
+            start = idx - 1 if idx > 0 and parts[idx - 1].startswith(".") else idx
+            short_path = "/".join(parts[start:])
+        else:
+            short_path = f"conversation_history/{p.name}" if p.name else str(raw_path)
         await sink.text(
             tr("compact.done_offload", lang, count=count, short=tid[-6:], path=short_path)
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,17 +9,60 @@ import pytest
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 
+# Modules whose tests boot OctopServer, real harness, browser tooling, or bwrap.
+# Tagged ``slow`` so ``make test-fast`` can skip them during local iteration.
+_SLOW_TEST_MODULES = frozenset(
+    {
+        "tests/unit/browser/test_browser_setup.py",
+        "tests/unit/infra/utils/test_bwrap.py",
+        "tests/unit/agents/test_skills_hub_raw.py",
+        "tests/unit/agents/test_skillhub_market.py",
+        "tests/unit/gateway/test_attachment_hints.py",
+        "tests/unit/agents/test_agent_manager.py",
+        "tests/unit/agents/test_agent_registry.py",
+        "tests/unit/api/test_jwt_auth_middleware.py",
+        "tests/unit/api/test_openapi_meta.py",
+        "tests/unit/api/test_exception_handlers.py",
+    },
+)
+
+
+def _module_path(nodeid: str) -> str:
+    return nodeid.split("::", 1)[0]
+
+
+def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+    for item in items:
+        module = _module_path(item.nodeid)
+        if module in _SLOW_TEST_MODULES or module.startswith("tests/integration/"):
+            item.add_marker(pytest.mark.slow)
+
 
 @pytest.fixture(scope="session")
 def repo_root() -> Path:
     return _REPO_ROOT
 
 
-@pytest.fixture
-def tmp_octop_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Path]:
-    """Redirect ``HOME`` so ``~/.octop`` resolves under a tmpdir."""
-    home = tmp_path / "home"
-    home.mkdir()
+@pytest.fixture(autouse=True)
+def _isolated_user_home(
+    tmp_path_factory: pytest.TempPathFactory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> Path:
+    """Per-test HOME outside the test's ``tmp_path``.
+
+    Keeping HOME off ``tmp_path`` avoids polluting directory listings and
+    colliding with tests that create ``tmp_path / \"home\"`` themselves.
+    Required for xdist so workers never share ``~/.octop`` / CLI state.
+    """
+    home = tmp_path_factory.mktemp("user-home")
     monkeypatch.setenv("HOME", str(home))
     monkeypatch.setenv("USERPROFILE", str(home))
-    yield home / ".octop"
+    return home
+
+
+@pytest.fixture
+def tmp_octop_home(_isolated_user_home: Path) -> Iterator[Path]:
+    """Redirect ``~/.octop`` under the autouse isolated HOME."""
+    octop = _isolated_user_home / ".octop"
+    octop.mkdir(exist_ok=True)
+    yield octop

--- a/tests/unit/gateway/test_slash_compact.py
+++ b/tests/unit/gateway/test_slash_compact.py
@@ -98,6 +98,37 @@ async def test_cmd_compact_calls_harness_without_reset(ctx, dispatcher) -> None:
 
 
 @pytest.mark.asyncio
+async def test_cmd_compact_shows_octop_relative_offload_path(ctx, dispatcher) -> None:
+    await ctx.thread_registry.get_or_create_by_key(
+        session_key=ctx.session_key,
+        agent_id=ctx.agent_id,
+        user_id=ctx.user_id,
+        channel_type=ctx.channel_type,
+    )
+    tid = ctx.thread_registry.get_bound_thread_id(ctx.session_key)
+    assert tid
+
+    harness = MagicMock()
+    harness.acompact_conversation = AsyncMock(
+        return_value=CompactResult(
+            ok=True,
+            summarized_count=3,
+            preserved_count=4,
+            file_path=f"/home/wally/.octop/workspaces/X/.octop/conversation_history/{tid}.md",
+            reason="ok",
+        )
+    )
+    ctx.agent_manager.get_agent = MagicMock(return_value=harness)
+
+    sink = BufferSink()
+    await cmd_compact(dispatcher, SlashCommand("compact", ""), ctx, sink)
+
+    text = "\n".join(sink.lines)
+    assert ".octop/conversation_history/" in text
+    assert "/home/wally" not in text
+
+
+@pytest.mark.asyncio
 async def test_cmd_compact_uses_composer_model_ref(ctx, dispatcher) -> None:
     await ctx.thread_registry.get_or_create_by_key(
         session_key=ctx.session_key,

--- a/tests/unit/infra/setup/test_service.py
+++ b/tests/unit/infra/setup/test_service.py
@@ -372,11 +372,18 @@ def test_install_service_uses_bootstrap_target_not_bare_scope(
 
 
 def test_unit_path_launchd_user_is_under_home(monkeypatch: pytest.MonkeyPatch) -> None:
-    """User-scope macOS installs land in ~/Library/LaunchAgents (writable, no sudo)."""
+    """User-scope macOS installs land in ~/Library/LaunchAgents (writable, no sudo).
+
+    ``unit_path`` resolves the owner via passwd (not ``Path.home()`` / ``$HOME``),
+    so sudo installs still target the invoking user — match that here.
+    """
+    import pwd
+
     monkeypatch.setattr(service_mod, "is_root", lambda: False)
     monkeypatch.setenv("OCTOP_SERVICE_SCOPE", "user")
     path = unit_path("launchd")
-    assert path == Path.home() / "Library" / "LaunchAgents" / "octop.plist"
+    owner_home = Path(pwd.getpwnam(getpass.getuser()).pw_dir)
+    assert path == owner_home / "Library" / "LaunchAgents" / "octop.plist"
 
 
 def test_unit_path_launchd_system_is_under_library(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -959,6 +959,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a5/f5/397b61091120a9ca5001041dd7bf76c385b3bfd67a0e5bcb74b852bd22a4/evdev-1.9.3.tar.gz", hash = "sha256:2c140e01ac8437758fa23fe5c871397412461f42d421aa20241dc8fe8cfccbc9", size = 32723, upload-time = "2026-02-05T21:54:24.987Z" }
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "fastapi"
 version = "0.138.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2517,6 +2526,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-testmon" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
 ]
 local-embedding = [
@@ -2533,6 +2543,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-testmon" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
 ]
 
@@ -2559,7 +2570,7 @@ requires-dist = [
     { name = "mcp", specifier = ">=1.9,<2" },
     { name = "mss", marker = "extra == 'desktop'", specifier = ">=9.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.10" },
-    { name = "orcakit-harness-agent", extras = ["all"], specifier = ">=0.9.26" },
+    { name = "orcakit-harness-agent", extras = ["all"], specifier = ">=0.9.27" },
     { name = "pillow", specifier = ">=10.0" },
     { name = "playwright", specifier = ">=1.40" },
     { name = "playwright", marker = "extra == 'browser'", specifier = ">=1.40" },
@@ -2573,6 +2584,7 @@ requires-dist = [
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.1" },
     { name = "pytest-testmon", marker = "extra == 'dev'", specifier = ">=2.0" },
+    { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.6" },
     { name = "python-docx", specifier = ">=1.2.0" },
     { name = "python-pptx", specifier = ">=1.0" },
     { name = "questionary", specifier = ">=2.0" },
@@ -2594,6 +2606,7 @@ dev = [
     { name = "pytest-asyncio", specifier = ">=0.23" },
     { name = "pytest-cov", specifier = ">=4.1" },
     { name = "pytest-testmon", specifier = ">=2.0" },
+    { name = "pytest-xdist", specifier = ">=3.6" },
     { name = "ruff", specifier = ">=0.4" },
 ]
 
@@ -2731,7 +2744,7 @@ wheels = [
 
 [[package]]
 name = "orcakit-harness-agent"
-version = "0.9.26"
+version = "0.9.27"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "deepagents" },
@@ -2749,9 +2762,9 @@ dependencies = [
     { name = "mcp" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e4/74/c4724071aa68cec47fc9c82ed6e2c48b9fd491d6c66e2f79eb7af1ccdaf3/orcakit_harness_agent-0.9.26.tar.gz", hash = "sha256:e5998d15fff25870a5e7fce49b9cb840ee0c35dc6a5cc93d7b576532d0da069d", size = 1183490, upload-time = "2026-08-26T04:05:50.255Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d2/b1/bd9e23e840bf48d8cea12e0d24bae2caaecaf8e2364893466846f5f427e4/orcakit_harness_agent-0.9.27.tar.gz", hash = "sha256:40c7816f4a47ed610131c1442cc391198ca5519fcd650752803f14a85a075e54", size = 1182826, upload-time = "2026-08-26T10:50:24.475Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/dc/5c/3ed38b4625e03c673fe11f61942a765252a82cddc631e1b8d5abd7959511/orcakit_harness_agent-0.9.26-py3-none-any.whl", hash = "sha256:ea947905ab92affb438125123fc9ff2f3874fa80489d88081f2f863e4ecc12e8", size = 1408183, upload-time = "2026-08-26T04:05:46.49Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/16/446c4fc6c5a6f0c9f84b8c742ec325cb48b4c1e59572811cef17157811e4/orcakit_harness_agent-0.9.27-py3-none-any.whl", hash = "sha256:328898750cff1d98db3ac36ce5e8a776b47f8288955b8e2a79bdfabd52a90659", size = 1407139, upload-time = "2026-08-26T10:50:20.842Z" },
 ]
 
 [package.optional-dependencies]
@@ -3697,6 +3710,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/4d/1d/3e4230cc67cd6205bbe03c3527500c0ccaf7f0c78b436537eac71590ee4a/pytest_testmon-2.2.0.tar.gz", hash = "sha256:01f488e955ed0e0049777bee598bf1f647dd524e06f544c31a24e68f8d775a51", size = 23108, upload-time = "2025-12-01T07:30:24.76Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/61/55/ebb3c2f59fb089f08d00f764830d35780fc4e4c41dffcadafa3264682b65/pytest_testmon-2.2.0-py3-none-any.whl", hash = "sha256:2604ca44a54d61a2e830d9ce828b41a837075e4ebc1f81b148add8e90d34815b", size = 25199, upload-time = "2025-12-01T07:30:23.623Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Hide「检查更新」/版本更新入口 unless the user has the `update` module permission (`userCan`), matching advanced-settings tabs and the update API (supersedes admin-only approach in #438 / #393).
- Show `/compact` offload paths under `.octop/conversation_history/` when present; align default-backend docstring with harness `system_files_path`.
- Add `pytest-xdist`, `make test-fast` + `slow` markers, and per-test isolated `HOME` for parallel-safe runs; bump `orcakit-harness-agent` to `>=0.9.27`.

## Test plan
- [ ] `make all` (pre-commit already green on this branch)
- [ ] Non-admin without `update`: avatar menu and update badges hidden
- [ ] Non-admin with `update`: avatar「检查更新」and version badges visible / clickable
- [ ] Admin: unchanged update entry points
- [ ] `/compact` with offload under `.octop/conversation_history/` shows short relative path
- [ ] `make test-fast` skips `slow` / integration; `make test` still runs full suite with `-n`


Made with [Cursor](https://cursor.com)