### PR TITLE
fix(dashboard): hide bubblewrap skipped toast on non-Linux

### DIFF
--- a/dashboard/src/pages/Experts/components/agentBackendForm.ensureBwrap.test.ts
+++ b/dashboard/src/pages/Experts/components/agentBackendForm.ensureBwrap.test.ts
@@ -5,7 +5,7 @@ describe("ensureBwrap helpers", () => {
   it("maps status to toast kind", () => {
     expect(ensureBwrapToastKind("ready")).toBe("none");
     expect(ensureBwrapToastKind("installed")).toBe("success");
-    expect(ensureBwrapToastKind("skipped")).toBe("warning");
+    expect(ensureBwrapToastKind("skipped")).toBe("none");
     expect(ensureBwrapToastKind("degraded")).toBe("warning");
   });
 

--- a/dashboard/src/pages/Experts/components/agentBackendForm.ts
+++ b/dashboard/src/pages/Experts/components/agentBackendForm.ts
@@ -168,7 +168,7 @@ export async function ensureBubblewrapAfterProbe(): Promise<EnsureBwrapResult> {
 export function ensureBwrapToastKind(
   status: EnsureBwrapStatus,
 ): "none" | "success" | "warning" {
-  if (status === "ready") return "none";
+  if (status === "ready" || status === "skipped") return "none";
   if (status === "installed") return "success";
   return "warning";
 }


### PR DESCRIPTION
## Summary
- Treat `ensure-bwrap` `skipped` (macOS/Windows and other non-Linux) as silent instead of a warning toast.
- Saving a scoped `root_dir` no longer shows “bubblewrap jail is not used…” on platforms that cannot use bubblewrap.
- Linux install success (`installed`) and install failure (`degraded`) toasts are unchanged.

## Test plan
- [ ] On macOS or Windows: save an agent backend with a non-root `root_dir` and confirm no bubblewrap warning toast appears.
- [ ] On Linux without `bwrap` where install fails: confirm the degraded warning still appears.
- [ ] On Linux where `bwrap` is already present: confirm save stays silent (`ready`).
- [ ] `cd dashboard && npm run test -- --run src/pages/Experts/components/agentBackendForm.ensureBwrap.test.ts`


Made with [Cursor](https://cursor.com)