### PR TITLE
ci: cascade desktop package with release and tighten triggers

### DIFF
--- a/.github/workflows/auto-tag-on-release.yml
+++ b/.github/workflows/auto-tag-on-release.yml
@@ -64,8 +64,10 @@ jobs:
           git push origin "$tag"
 
       # GITHUB_TOKEN tag pushes do not cascade to other workflows. Explicitly
-      # dispatch Release / Docker Publish (workflow_dispatch is exempt).
-      - name: Trigger Release and Docker Publish
+      # dispatch Release / Docker Publish / Desktop Package (workflow_dispatch
+      # is exempt). Desktop builds in parallel; its release job upserts zips
+      # onto the same v* GitHub Release.
+      - name: Trigger Release, Docker Publish, and Desktop Package
         if: steps.check_tag.outputs.should_publish == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -73,3 +75,6 @@ jobs:
           tag="${{ steps.version.outputs.tag }}"
           gh workflow run release.yml --ref "$tag"
           gh workflow run docker-publish.yml --ref "$tag"
+          gh workflow run octop-desktop.yml --ref "$tag" \
+            -f platforms=all \
+            -f attach_release=true

--- a/.github/workflows/octop-desktop.yml
+++ b/.github/workflows/octop-desktop.yml
@@ -1,11 +1,14 @@
 name: Octop Desktop Package
 
+# 正式发版：Auto Tag 在打 v* 后与 Release / Docker Publish 一并 dispatch（GITHUB_TOKEN
+# 打的 tag 不会触发 push workflow）。产物由本 workflow 的 release job upsert 到同一
+# GitHub Release。workflow_dispatch 保留给手工补包 / 按平台重跑。
+# 不要对任意分支 push 跑六平台矩阵。
+
 on:
   push:
     tags:
-      - "*"
-    branches:
-      - "*"
+      - "v*"
   workflow_dispatch:
     inputs:
       platforms:


### PR DESCRIPTION
## Summary
- Restrict `octop-desktop.yml` to `v*` tags + `workflow_dispatch` (stop six-platform matrix on every branch push).
- Auto Tag now dispatches Desktop alongside Release / Docker so installers attach to the same `v*` GitHub Release.

## Why target main
`pull_request_target` Auto Tag and the live desktop workflow run from **main**. #459 carries the same change into `develop` with the GHCR/FnOS work; this PR makes the cascade effective before the next release.

## Test plan
- [ ] Confirm Actions no longer start Octop Desktop Package on ordinary `main`/`develop` pushes
- [ ] Manual: `gh workflow run octop-desktop.yml --ref main -f platforms=linux-amd64 -f attach_release=false` still works
- [ ] Next `release/*` → main merge: Auto Tag logs show three dispatches (release, docker-publish, octop-desktop)


Made with [Cursor](https://cursor.com)