### PR TITLE
feat: let admins edit username on the users screen

### DIFF
--- a/dashboard/src/pages/Admin/Users/UsersListPanel.tsx
+++ b/dashboard/src/pages/Admin/Users/UsersListPanel.tsx
@@ -115,6 +115,7 @@ interface CreateValues {
 }
 
 interface EditValues {
+  username: string;
   display_name?: string;
   email?: string;
   role: "admin" | "user";
@@ -997,6 +998,7 @@ export default function UsersListPanel() {
   const openEdit = (row: UserRow) => {
     setEditTarget(row);
     editForm.setFieldsValue({
+      username: row.username,
       display_name: row.display_name ?? "",
       email: row.email ?? "",
       role: row.role,
@@ -1038,6 +1040,7 @@ export default function UsersListPanel() {
       await request(`/users/${editTarget.id}`, {
         method: "PATCH",
         body: JSON.stringify({
+          username: values.username.trim(),
           display_name: values.display_name?.trim() || null,
           email: values.email?.trim() || null,
           role: values.role,
@@ -1664,6 +1667,19 @@ export default function UsersListPanel() {
             <div className={styles.createSectionTitle}>
               {t("adminUsers.createSectionAccount")}
             </div>
+            <Form.Item
+              label={t("adminUsers.formUsername")}
+              name="username"
+              rules={[
+                { required: true, message: t("adminUsers.formUsername") },
+                {
+                  pattern: /^[a-zA-Z0-9_-]{1,64}$/,
+                  message: t("wizard.admin.usernameRule"),
+                },
+              ]}
+            >
+              <Input prefix={<User {...FIELD_ICON_PROPS} />} />
+            </Form.Item>
             <Form.Item
               label={t("adminUsers.formDisplayName")}
               name="display_name"

--- a/src/octop/api/routers/users.py
+++ b/src/octop/api/routers/users.py
@@ -28,6 +28,7 @@ class UserCreateBody(BaseModel):
 
 class UserPatchBody(BaseModel):
     role: str | None = None
+    username: str | None = None
     display_name: str | None = None
     email: str | None = Field(default=None, max_length=254)
     disabled: bool | None = None
@@ -187,20 +188,24 @@ async def patch_user(
             target_user_id=user_id,
             new_permissions=body.permissions,
         )
+    username = row.username
     if body.role is not None:
         if user_id == actor.id and Role(body.role) is not Role.ADMIN:
             raise OctopError(ErrorCode.FORBIDDEN, "cannot demote yourself")
-        await server.user_manager.set_role(row.username, Role(body.role))
+        await server.user_manager.set_role(username, Role(body.role))
     if body.display_name is not None:
-        await server.user_manager.set_display_name(row.username, body.display_name)
+        await server.user_manager.set_display_name(username, body.display_name)
+    if body.username is not None:
+        await server.user_manager.set_username(username, body.username)
+        username = body.username
     if "email" in body.model_fields_set:
-        await server.user_manager.set_email(row.username, body.email)
+        await server.user_manager.set_email(username, body.email)
     if body.disabled is True:
-        await server.user_manager.disable(row.username)
+        await server.user_manager.disable(username)
     elif body.disabled is False:
-        await server.user_manager.enable(row.username)
+        await server.user_manager.enable(username)
     if body.permissions is not None:
-        await server.user_manager.set_permissions(row.username, body.permissions)
+        await server.user_manager.set_permissions(username, body.permissions)
     updated = server.user_manager.get_row(user_id)
     assert updated is not None
     return _row_to_dict(updated)

--- a/src/octop/infra/db/repos/users.py
+++ b/src/octop/infra/db/repos/users.py
@@ -182,6 +182,13 @@ class UserRepo:
                 (display_name, user_id),
             )
 
+    def set_username(self, user_id: int, username: str) -> None:
+        with self._db.transaction() as conn:
+            conn.execute(
+                "UPDATE users SET username = ? WHERE id = ?",
+                (username, user_id),
+            )
+
     def set_email(self, user_id: int, email: str | None) -> None:
         with self._db.transaction() as conn:
             conn.execute("UPDATE users SET email = ? WHERE id = ?", (email, user_id))

--- a/src/octop/infra/users/manager.py
+++ b/src/octop/infra/users/manager.py
@@ -441,6 +441,25 @@ class UserManager:
             if current is not None:
                 current.display_name = display_name
 
+    async def set_username(self, username: str, new_username: str) -> None:
+        row = self._services.user_repo.get_by_username(username)
+        if row is None:
+            raise OctopError(ErrorCode.NOT_FOUND, "user not found")
+        if new_username == row.username:
+            return
+        self._services.user_repo.set_username(row.id, new_username)
+        async with self._lock:
+            current = self._users.pop(username, None)
+            if current is not None:
+                current.username = new_username
+                self._users[new_username] = current
+        self._services.audit_repo.write(
+            actor=ACTOR_ADMIN,
+            action="user.set_username",
+            target=username,
+            payload=new_username,
+        )
+
     async def set_email(self, username: str, email: str | None) -> None:
         row = self._services.user_repo.get_by_username(username)
         if row is None:


### PR DESCRIPTION
## Summary
- Admins can change a user's **username** (and existing display name) from the Users edit drawer.
- `PATCH /api/users/{id}` persists the new username and rekeys the in-memory user cache.
- Later fields in the same PATCH (email, permissions, etc.) use the new username so Save no longer returns 404 after a rename.

Fixes #317

## Test plan
- [ ] Open Admin → Users on the Vite dashboard (`localhost:5173` with local backend).
- [ ] Edit a user, change username and display name, Save — expect 200, list shows the new username.
- [ ] Confirm `PATCH /api/users/{id}` in the `octop run` terminal and no 404.
- [ ] Saving with an unchanged username still succeeds.
- [ ] Editing only display name still works.


Made with [Cursor](https://cursor.com)