### PR TITLE
fix(connectors): 自定义 MCP OAuth 刷新失败后标记重新授权

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### 变更
 
+- 自定义 MCP OAuth：token 刷新失败且已过期时自动标记需重新授权；OAuth 发现结果进程内缓存；callback 页与 OAuth 启动错误 i18n 化
 - Docker / FnOS 镜像对外统一为 `ghcr.io/tencentcloud/octop`（仍同步推送 Docker Hub；移除 vanilla 镜像标签）
 - FnOS FPK 在 Release 成功后自动构建：复用 GHCR 镜像与 Release wheel，不再重复编镜像
 - 正式发版时 Auto Tag 同步触发桌面客户端打包，产物挂到同一 `v*` GitHub Release（不再对任意分支 push 跑六平台矩阵）

--- a/docs/api.md
+++ b/docs/api.md
@@ -314,9 +314,18 @@ for non-`/` paths.
 | `GET`    | `/connectors/auth/{kind}/info` | user | auth flow info |
 | `GET`    | `/connectors/auth/{kind}/authorize-url` | user | build the authorize URL |
 | `POST`   | `/connectors/auth/{kind}/exchange-code` | user | exchange auth code |
-| `POST`   | `/connectors/oauth/{kind}/start` | user | start an OAuth flow |
+| `POST`   | `/connectors/oauth/start` | user | start OAuth (catalog or custom MCP via `target`) |
+| `POST`   | `/connectors/oauth/{kind}/start` | user | legacy catalog OAuth start |
+| `PUT`    | `/connectors/custom-mcp` | user | save custom MCP server map |
+| `PATCH`  | `/connectors/custom-mcp/servers/{name}` | user | patch `enabled` / `default_open` on one server |
+| `POST`   | `/connectors/custom-mcp/test` | user | probe a custom MCP server (inline spec or saved name) |
 | `GET`    | `/connectors/oauth/callback` | public | OAuth redirect target |
 | `GET`    | `/connectors/oauth/pending/{state_id}` | user | poll the OAuth result |
+
+Custom MCP OAuth (streamable HTTP, public HTTPS URL only): Octop discovers the authorization
+server from the MCP URL (401 / RFC 9728 protected-resource metadata), requires dynamic client
+registration (DCR), stores encrypted tokens in the custom MCP spec, and injects `Authorization:
+Bearer` when loading tools. Loopback MCP URLs do not use remote OAuth discovery.
 
 ## Internal MCP (harness agents)
 

--- a/src/octop/api/routers/connectors.py
+++ b/src/octop/api/routers/connectors.py
@@ -15,6 +15,7 @@ from pydantic import BaseModel, Field, model_validator
 
 from octop.api.common.public_base import resolve_public_base
 from octop.api.deps import current_user, get_server, require_permission
+from octop.i18n import tr
 from octop.infra.connectors.builder import (
     mcp_server_name,
     normalize_weiyun_mcp_token,
@@ -65,6 +66,7 @@ from octop.infra.connectors.probe import (
 from octop.infra.connectors.service import ConnectorService
 from octop.infra.db.repos.connectors import ConnectorRepo
 from octop.infra.errors import ErrorCode, OctopError
+from octop.infra.utils.locale import resolve_request_locale
 from octop.infra.utils.ulid import new_ulid
 
 logger = logging.getLogger(__name__)
@@ -158,6 +160,18 @@ class CustomMcpTestBody(BaseModel):
     server: dict[str, Any] | None = None
 
 
+def _oauth_callback_html(
+    request: Request,
+    message_key: str,
+    *,
+    status_code: int = 200,
+    **fmt: Any,
+) -> HTMLResponse:
+    locale = resolve_request_locale(request)
+    message = tr(f"connector.oauth.{message_key}", locale, **fmt)
+    return HTMLResponse(f"<html><body>{message}</body></html>", status_code=status_code)
+
+
 def _resolve_custom_mcp_url(svc: ConnectorService, user_id: int, server_name: str) -> str:
     saved = svc.get_custom_servers(user_id)
     raw = saved.get(server_name)
@@ -229,10 +243,7 @@ async def _begin_oauth_flow(
         raise OctopError(ErrorCode.CONNECTOR_INVALID_CREDENTIALS, str(exc)) from exc
     except Exception as exc:
         logger.exception("oauth start failed for target %s", target)
-        raise OctopError(
-            ErrorCode.CONNECTOR_INVALID_CREDENTIALS,
-            f"无法启动 OAuth: {exc}",
-        ) from exc
+        raise OctopError(ErrorCode.CONNECTOR_INVALID_CREDENTIALS, str(exc)) from exc
 
     server.services.repos.connector_repo.create_oauth_state(
         state_id=state_id,
@@ -1116,14 +1127,27 @@ async def oauth_callback(
 ) -> HTMLResponse:
     """OAuth redirect target. Exchanges the code and stores credentials. No JWT required."""
     if error:
-        return HTMLResponse(f"<html><body>授权失败: {error}</body></html>", status_code=400)
+        return _oauth_callback_html(
+            request,
+            "callback_auth_failed",
+            status_code=400,
+            error=error,
+        )
     if not code or not state:
-        return HTMLResponse("<html><body>缺少 code 或 state</body></html>", status_code=400)
+        return _oauth_callback_html(
+            request,
+            "callback_missing_params",
+            status_code=400,
+        )
 
     repo = server.services.repos.connector_repo
     row = repo.consume_oauth_state(state)
     if row is None:
-        return HTMLResponse("<html><body>无效或过期的 state</body></html>", status_code=400)
+        return _oauth_callback_html(
+            request,
+            "callback_invalid_state",
+            status_code=400,
+        )
 
     base = resolve_public_base(request)
     redirect_uri = f"{base}/api/connectors/oauth/callback"
@@ -1145,7 +1169,12 @@ async def oauth_callback(
         delete_oauth_ctx(server.services.settings_repo, row.state_id)
     except Exception as exc:
         logger.exception("oauth callback failed for %s", row.kind)
-        return HTMLResponse(f"<html><body>Token 交换失败: {exc}</body></html>", status_code=400)
+        return _oauth_callback_html(
+            request,
+            "callback_token_exchange_failed",
+            status_code=400,
+            detail=str(exc),
+        )
 
     pending_payload: dict[str, Any] = {
         "user_id": row.user_id,
@@ -1170,9 +1199,11 @@ async def oauth_callback(
             pending_payload["applied"] = True
         except Exception as exc:
             logger.exception("custom MCP oauth apply failed for %s", server_name)
-            return HTMLResponse(
-                f"<html><body>保存授权失败: {exc}</body></html>",
+            return _oauth_callback_html(
+                request,
+                "callback_save_failed",
                 status_code=400,
+                detail=str(exc),
             )
 
     # Store tokens in a short-lived settings key for frontend pickup, or auto-create instance.
@@ -1182,6 +1213,8 @@ async def oauth_callback(
         json.dumps(pending_payload),
     )
     redirect = row.redirect_after or "/connectors"
+    locale = resolve_request_locale(request)
+    success_message = tr("connector.oauth.callback_success", locale)
     html = f"""<!DOCTYPE html><html><body>
 <script>
   if (window.opener) {{
@@ -1191,7 +1224,7 @@ async def oauth_callback(
     window.location.href = '{redirect}?oauth_state={row.state_id}';
   }}
 </script>
-<p>授权完成，可关闭此窗口。</p>
+<p>{success_message}</p>
 </body></html>"""
     return HTMLResponse(html)
 

--- a/src/octop/i18n/en.json
+++ b/src/octop/i18n/en.json
@@ -280,6 +280,16 @@
       }
     }
   },
+  "connector": {
+    "oauth": {
+      "callback_auth_failed": "Authorization failed: {error}",
+      "callback_missing_params": "Missing authorization code or state.",
+      "callback_invalid_state": "Invalid or expired authorization state.",
+      "callback_token_exchange_failed": "Token exchange failed: {detail}",
+      "callback_save_failed": "Failed to save authorization: {detail}",
+      "callback_success": "Authorization complete. You may close this window."
+    }
+  },
   "errors": {
     "AUTH_FAILED": "Authentication failed.",
     "TOKEN_EXPIRED": "Session expired. Please sign in again.",

--- a/src/octop/i18n/zh.json
+++ b/src/octop/i18n/zh.json
@@ -280,6 +280,16 @@
       }
     }
   },
+  "connector": {
+    "oauth": {
+      "callback_auth_failed": "授权失败：{error}",
+      "callback_missing_params": "缺少 code 或 state。",
+      "callback_invalid_state": "无效或过期的 state。",
+      "callback_token_exchange_failed": "Token 交换失败：{detail}",
+      "callback_save_failed": "保存授权失败：{detail}",
+      "callback_success": "授权完成，可关闭此窗口。"
+    }
+  },
   "errors": {
     "AUTH_FAILED": "认证失败。",
     "TOKEN_EXPIRED": "登录已过期，请重新登录。",

--- a/src/octop/infra/connectors/custom_mcp.py
+++ b/src/octop/infra/connectors/custom_mcp.py
@@ -168,8 +168,11 @@ def normalize_server_spec(name: str, raw: Any) -> dict[str, Any]:
             spec["env"] = env
 
     oauth = raw.get(_OAUTH_KEY)
-    if isinstance(oauth, dict) and str(oauth.get("access_token") or "").strip():
-        spec[_OAUTH_KEY] = dict(oauth)
+    if isinstance(oauth, dict):
+        if str(oauth.get("access_token") or "").strip():
+            spec[_OAUTH_KEY] = dict(oauth)
+        elif oauth.get("required") is True:
+            spec[_OAUTH_KEY] = {"required": True}
 
     return spec
 
@@ -221,6 +224,13 @@ def oauth_required(spec: dict[str, Any]) -> bool:
         return False
     oauth = oauth_tokens_from_spec(spec)
     return oauth.get("required") is True
+
+
+def mark_oauth_reauth_required(spec: dict[str, Any]) -> dict[str, Any]:
+    """Drop stale OAuth tokens and flag the dashboard to prompt re-authorization."""
+    out = {k: v for k, v in spec.items() if k != _OAUTH_KEY}
+    out[_OAUTH_KEY] = {"required": True}
+    return out
 
 
 def set_oauth_required_in_spec(spec: dict[str, Any], *, required: bool) -> dict[str, Any]:

--- a/src/octop/infra/connectors/oauth/discovery.py
+++ b/src/octop/infra/connectors/oauth/discovery.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+import time
 from typing import Any
 from urllib.parse import urljoin, urlparse
 
@@ -13,6 +14,14 @@ _RESOURCE_METADATA_PARAM = re.compile(
     r'resource_metadata\s*=\s*"([^"]+)"',
     re.IGNORECASE,
 )
+
+_DISCOVERY_CACHE_TTL_SEC = 3600.0
+_discovery_cache: dict[str, tuple[float, dict[str, Any]]] = {}
+
+
+def clear_oauth_discovery_cache() -> None:
+    """Clear the in-process OAuth discovery cache (tests only)."""
+    _discovery_cache.clear()
 
 
 def _mcp_url_host(url: str) -> str:
@@ -126,7 +135,11 @@ def _normalize_issuer(raw: str, *, mcp_url: str) -> str:
     return urljoin(base, text).rstrip("/")
 
 
-async def discover_oauth_from_mcp_url(mcp_url: str) -> dict[str, Any]:
+async def discover_oauth_from_mcp_url(
+    mcp_url: str,
+    *,
+    use_cache: bool = True,
+) -> dict[str, Any]:
     """Return OAuth discovery details for a remote MCP HTTP endpoint.
 
     Result shape::
@@ -141,6 +154,17 @@ async def discover_oauth_from_mcp_url(mcp_url: str) -> dict[str, Any]:
         }
     """
     url = mcp_url.strip()
+    if use_cache:
+        cached = _discovery_cache.get(url)
+        if cached is not None and cached[0] > time.time():
+            return cached[1]
+    result = await _discover_oauth_from_mcp_url_uncached(url)
+    if use_cache and result.get("available"):
+        _discovery_cache[url] = (time.time() + _DISCOVERY_CACHE_TTL_SEC, result)
+    return result
+
+
+async def _discover_oauth_from_mcp_url_uncached(url: str) -> dict[str, Any]:
     if not url:
         return {"available": False, "error": "empty mcp url"}
     if _is_loopback_mcp_url(url):

--- a/src/octop/infra/connectors/service.py
+++ b/src/octop/infra/connectors/service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import time
 from pathlib import Path
 from typing import Any
@@ -19,6 +20,7 @@ from octop.infra.connectors.custom_mcp import (
     expand_custom_instances,
     extract_servers,
     is_custom_mcp_kind,
+    mark_oauth_reauth_required,
     merge_preserved_oauth,
     oauth_configured,
     oauth_tokens_from_spec,
@@ -41,6 +43,10 @@ from octop.infra.db.repos.secrets import SecretRepo
 from octop.infra.errors import ErrorCode, OctopError
 from octop.infra.utils.paths import PathLayout
 from octop.infra.utils.ulid import new_ulid
+
+logger = logging.getLogger(__name__)
+
+_OAUTH_REFRESH_SKEW_SEC = 120
 
 
 def list_user_connector_instances(
@@ -213,15 +219,29 @@ class ConnectorService:
             oauth = oauth_tokens_from_spec(raw)
             if not oauth_configured(raw):
                 continue
-            expires_at = oauth.get("expires_at")
+            expires_at_raw = oauth.get("expires_at")
+            expires_at = int(expires_at_raw) if expires_at_raw is not None else None
             refresh = str(oauth.get("refresh_token") or "").strip()
+            if expires_at is not None and expires_at <= now and not refresh:
+                servers[name] = mark_oauth_reauth_required(dict(raw))
+                changed = True
+                continue
             if not refresh:
                 continue
-            if expires_at and int(expires_at) > now + 120:
+            if expires_at is not None and expires_at > now + _OAUTH_REFRESH_SKEW_SEC:
                 continue
             try:
                 refreshed = await refresh_custom_mcp_oauth(oauth)
             except Exception:
+                logger.warning(
+                    "custom MCP oauth refresh failed for %r (user_id=%s)",
+                    name,
+                    user_id,
+                    exc_info=True,
+                )
+                if expires_at is not None and expires_at <= now:
+                    servers[name] = mark_oauth_reauth_required(dict(raw))
+                    changed = True
                 continue
             spec = dict(raw)
             spec["oauth"] = refreshed

--- a/tests/integration/test_connectors_api.py
+++ b/tests/integration/test_connectors_api.py
@@ -7,8 +7,11 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from octop.infra.connectors.custom_mcp import CUSTOM_MCP_KIND
+from octop.infra.connectors.oauth.registry import save_oauth_ctx
+from octop.infra.utils.ulid import new_ulid
 from tests.support.app import octop_client, write_octop_config
-from tests.support.auth import auth_header, bootstrap_admin, create_user
+from tests.support.auth import auth_header, bootstrap_admin, create_user, resolve_user_id
 from tests.support.http import ws_chat_turn
 
 
@@ -341,3 +344,123 @@ async def test_patch_custom_mcp_server_default_open_only(env):
     )
     assert patch_off.status_code == 200
     assert "default_open" not in patch_off.json()["servers"]["linear"]
+
+
+async def test_custom_mcp_oauth_callback_applies_tokens(env):
+    c, srv, auth, _ = env
+    user_id = await resolve_user_id(c, auth, "admin")
+
+    put = await c.put(
+        "/api/connectors/custom-mcp",
+        headers=auth,
+        json={
+            "servers": {
+                "my-oauth-mcp": {
+                    "transport": "streamable_http",
+                    "url": "https://mcp.example.com/mcp",
+                    "enabled": False,
+                }
+            }
+        },
+    )
+    assert put.status_code == 200
+
+    oauth_state = "test-oauth-state-xyz"
+    state_id = new_ulid()
+    srv.services.repos.connector_repo.create_oauth_state(
+        state_id=state_id,
+        state=oauth_state,
+        user_id=user_id,
+        kind=CUSTOM_MCP_KIND,
+        code_verifier="verifier123",
+        redirect_after="/connectors",
+    )
+    save_oauth_ctx(
+        srv.services.settings_repo,
+        state_id,
+        {
+            "flow": "custom_mcp",
+            "kind": CUSTOM_MCP_KIND,
+            "server_name": "my-oauth-mcp",
+            "issuer": "https://auth.example.com",
+            "resource": "https://mcp.example.com/mcp",
+            "client_id": "cid",
+            "client_secret": None,
+            "redirect_uri": "http://testserver/api/connectors/oauth/callback",
+            "metadata": {
+                "authorization_endpoint": "https://auth.example.com/authorize",
+                "token_endpoint": "https://auth.example.com/token",
+            },
+        },
+    )
+
+    with patch(
+        "octop.api.routers.connectors.exchange_oauth_code",
+        new_callable=AsyncMock,
+        return_value={
+            "access_token": "new-access-token",
+            "refresh_token": "refresh-tok",
+            "expires_at": 9_999_999_999,
+        },
+    ):
+        callback = await c.get(
+            f"/api/connectors/oauth/callback?code=authcode&state={oauth_state}",
+            follow_redirects=False,
+        )
+    assert callback.status_code == 200
+    assert "octop:connector-oauth" in callback.text
+
+    stored = await c.get("/api/connectors/custom-mcp", headers=auth)
+    assert stored.status_code == 200
+    assert stored.json()["servers"]["my-oauth-mcp"]["oauth"]["configured"] is True
+
+    pending = await c.get(f"/api/connectors/oauth/pending/{state_id}", headers=auth)
+    assert pending.status_code == 200
+    body = pending.json()
+    assert body["applied"] is True
+    assert body["server_name"] == "my-oauth-mcp"
+
+
+async def test_custom_mcp_oauth_start_unified(env):
+    c, _, auth, _ = env
+    put = await c.put(
+        "/api/connectors/custom-mcp",
+        headers=auth,
+        json={
+            "servers": {
+                "oauth-srv": {
+                    "transport": "streamable_http",
+                    "url": "https://mcp.example.com/mcp",
+                }
+            }
+        },
+    )
+    assert put.status_code == 200
+
+    mocked_start = AsyncMock(
+        return_value=(
+            "https://auth.example.com/authorize?state=x",
+            "verifier",
+            {"flow": "custom_mcp"},
+        )
+    )
+    with (
+        patch("octop.api.routers.connectors._is_public_http_uri", return_value=False),
+        patch("octop.api.routers.connectors.start_oauth_for_target", mocked_start),
+    ):
+        r = await c.post(
+            "/api/connectors/oauth/start",
+            headers=auth,
+            json={
+                "target": {"type": "custom_mcp", "server_name": "oauth-srv"},
+                "redirect_after": "/connectors",
+            },
+        )
+    assert r.status_code == 200
+    data = r.json()
+    assert data["authorize_url"].startswith("https://auth.example.com/")
+    assert data["state_id"]
+    mocked_start.assert_awaited_once()
+    call_kwargs = mocked_start.await_args.kwargs
+    assert call_kwargs["target"] == {"type": "custom_mcp", "server_name": "oauth-srv"}
+    assert call_kwargs["mcp_url"] == "https://mcp.example.com/mcp"

--- a/tests/unit/connectors/test_custom_mcp.py
+++ b/tests/unit/connectors/test_custom_mcp.py
@@ -357,3 +357,90 @@ def test_list_default_open_mcp_server_names(svc: ConnectorService, db: SqlitePoo
     assert mcp_server_name("tencent-docs", iid) in names
     assert "always" in names
     assert "opt" not in names
+
+
+@pytest.mark.asyncio
+async def test_ensure_fresh_custom_servers_marks_reauth_when_refresh_fails_expired(
+    svc: ConnectorService,
+    db: SqlitePool,
+) -> None:
+    import time
+    from unittest.mock import AsyncMock, patch
+
+    uid = _ensure_user(db)
+    expired_at = int(time.time()) - 60
+    svc.put_custom_servers(
+        uid,
+        {
+            "srv": {
+                "transport": "streamable_http",
+                "url": "https://example.com/mcp",
+            }
+        },
+    )
+    svc.apply_custom_server_oauth(
+        uid,
+        "srv",
+        {
+            "access_token": "old",
+            "refresh_token": "refresh-me",
+            "expires_at": expired_at,
+            "oauth_client_id": "cid",
+        },
+        issuer="https://example.com",
+        resource="https://example.com/mcp",
+    )
+    with patch(
+        "octop.infra.connectors.service.refresh_custom_mcp_oauth",
+        new_callable=AsyncMock,
+        side_effect=ValueError("refresh failed"),
+    ):
+        await svc.ensure_fresh_custom_servers(uid)
+
+    preview = svc.get_custom_servers_for_api(uid)
+    assert preview["srv"]["oauth"] == {"configured": False, "required": True}
+    stored = svc.get_custom_servers(uid)["srv"]["oauth"]
+    assert stored == {"required": True}
+
+
+@pytest.mark.asyncio
+async def test_ensure_fresh_custom_servers_keeps_valid_token_when_refresh_fails(
+    svc: ConnectorService,
+    db: SqlitePool,
+) -> None:
+    import time
+    from unittest.mock import AsyncMock, patch
+
+    uid = _ensure_user(db)
+    expires_at = int(time.time()) + 60
+    svc.put_custom_servers(
+        uid,
+        {
+            "srv": {
+                "transport": "streamable_http",
+                "url": "https://example.com/mcp",
+            }
+        },
+    )
+    svc.apply_custom_server_oauth(
+        uid,
+        "srv",
+        {
+            "access_token": "still-valid",
+            "refresh_token": "refresh-me",
+            "expires_at": expires_at,
+            "oauth_client_id": "cid",
+        },
+        issuer="https://example.com",
+        resource="https://example.com/mcp",
+    )
+    with patch(
+        "octop.infra.connectors.service.refresh_custom_mcp_oauth",
+        new_callable=AsyncMock,
+        side_effect=ValueError("refresh failed"),
+    ):
+        await svc.ensure_fresh_custom_servers(uid)
+
+    preview = svc.get_custom_servers_for_api(uid)
+    assert preview["srv"]["oauth"]["configured"] is True
+    assert svc.get_custom_servers(uid)["srv"]["oauth"]["access_token"] == "still-valid"

--- a/tests/unit/connectors/test_oauth_discovery.py
+++ b/tests/unit/connectors/test_oauth_discovery.py
@@ -7,11 +7,14 @@ import pytest
 from octop.infra.connectors.custom_mcp import (
     build_oauth_storage,
     harness_spec_for_server,
+    mark_oauth_reauth_required,
     merge_preserved_oauth,
     redact_server_for_api,
 )
 from octop.infra.connectors.oauth.discovery import (
     build_protected_resource_metadata_urls,
+    clear_oauth_discovery_cache,
+    discover_oauth_from_mcp_url,
     parse_www_authenticate_resource_metadata,
 )
 from octop.infra.connectors.oauth.registry import (
@@ -104,3 +107,54 @@ def test_harness_spec_injects_oauth_bearer():
 def test_oauth_state_kind_invalid():
     with pytest.raises(ValueError, match="unsupported oauth target"):
         oauth_state_kind_for_target({"type": "unknown"})
+
+
+def test_mark_oauth_reauth_required_clears_tokens():
+    spec = {
+        "transport": "streamable_http",
+        "url": "https://example.com/mcp",
+        "oauth": build_oauth_storage(
+            {"access_token": "secret", "refresh_token": "r", "expires_at": 1},
+            issuer="https://example.com",
+            resource="https://example.com/mcp",
+        ),
+    }
+    marked = mark_oauth_reauth_required(spec)
+    assert marked["oauth"] == {"required": True}
+    preview = redact_server_for_api(marked)
+    assert preview["oauth"] == {"configured": False, "required": True}
+
+
+@pytest.mark.asyncio
+async def test_discover_oauth_from_mcp_url_uses_cache(monkeypatch: pytest.MonkeyPatch) -> None:
+    clear_oauth_discovery_cache()
+    calls = 0
+    cached_result = {
+        "available": True,
+        "issuer": "https://auth.example.com",
+        "resource": "https://example.com/mcp",
+        "metadata": {"registration_endpoint": "https://auth.example.com/reg"},
+        "scopes_supported": None,
+        "error": None,
+    }
+
+    async def fake_uncached(url: str) -> dict[str, object]:
+        nonlocal calls
+        calls += 1
+        assert url == "https://example.com/mcp"
+        return cached_result
+
+    monkeypatch.setattr(
+        "octop.infra.connectors.oauth.discovery._discover_oauth_from_mcp_url_uncached",
+        fake_uncached,
+    )
+
+    first = await discover_oauth_from_mcp_url("https://example.com/mcp")
+    second = await discover_oauth_from_mcp_url("https://example.com/mcp")
+    assert first == cached_result
+    assert second == cached_result
+    assert calls == 1
+
+    bypass = await discover_oauth_from_mcp_url("https://example.com/mcp", use_cache=False)
+    assert bypass == cached_result
+    assert calls == 2


### PR DESCRIPTION
## Summary
- Token 刷新失败且已过期时，丢弃失效凭证并标记 `oauth.required`，让 Dashboard 引导重新授权；未过期则保留现有 token。
- OAuth 发现结果进程内缓存 1 小时，减少对 MCP URL 的重复探测。
- OAuth callback 页与启动失败文案走 i18n（en/zh）；补充 callback 落库与统一 `POST /connectors/oauth/start` 的测试；文档同步自定义 MCP OAuth 约定。

## Test plan
- [ ] `uv run pytest tests/unit/connectors tests/integration/test_connectors_api.py tests/unit/i18n -q`
- [ ] 自定义 MCP：token 过期且 refresh 失败后，API 预览出现需重新授权，重新走 OAuth 可写回 token
- [ ] 自定义 MCP：token 仍有效时 refresh 失败，不误清凭证
- [ ] OAuth callback 成功/失败页按 `Accept-Language` 显示中英文


Made with [Cursor](https://cursor.com)