### PR TITLE
feat(connectors): add WeKnora and Dify integrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 ### 新增
 
 - 自定义 MCP 连接器支持 OAuth：从 MCP URL 自动发现授权端点，统一 `POST /connectors/oauth/start` 启动授权；保存后可探测、一键授权，Bearer 注入 harness spec；Custom Connectors UI 支持启用与「对话默认选中」分离、保存后可选探测
+- 连接器新增 WeKnora 与 Dify：WeKnora 提供只读知识库列表、检索和文档阅读工具；Dify 直接接入应用发布的 Streamable HTTP MCP。连接器目录支持声明式凭证字段，Dashboard、IM 与 Cron 复用现有 MCP 注入链路
+- WeKnora / Dify 增加引导式接入：控制台入口、智能剪贴板粘贴、Dify MCP URL 即时校验，以及 WeKnora 默认本机部署只读检测
 
 ### 变更
 

--- a/dashboard/src/api/modules/connectors.ts
+++ b/dashboard/src/api/modules/connectors.ts
@@ -18,6 +18,17 @@ export interface ConnectorCatalogEntry {
   supports_quick_auth?: boolean;
   oauth_mode?: "dynamic" | "configured" | null;
   oauth_ready?: boolean;
+  credential_fields?: ConnectorCredentialField[];
+}
+
+export interface ConnectorCredentialField {
+  key: string;
+  label: string;
+  field_type: "text" | "password" | "url" | "tags";
+  required: boolean;
+  placeholder?: string | null;
+  help?: string | null;
+  secret: boolean;
 }
 
 export interface ConnectorAuthInfo {
@@ -42,6 +53,7 @@ export interface ConnectorInstance {
 }
 
 export interface ConnectorCredentialsPreview {
+  [key: string]: unknown;
   token_configured?: boolean;
   oauth_configured?: boolean;
   expires_at?: number;
@@ -89,6 +101,12 @@ export interface ConnectorProbeResult {
     issuer?: string;
     resource?: string;
   };
+}
+
+export interface WeKnoraLocalDetection {
+  found: boolean;
+  base_url?: string;
+  console_url?: string;
 }
 
 export type CustomMcpTransport = "streamable_http" | "stdio";
@@ -157,6 +175,9 @@ export interface FeishuUserAuthCompleteResult {
 
 export const connectorsApi = {
   catalog: () => request<ConnectorCatalogEntry[]>("/connectors/catalog"),
+
+  detectLocalWeKnora: () =>
+    request<WeKnoraLocalDetection>("/connectors/weknora/detect-local"),
 
   listInstances: () => request<ConnectorInstance[]>("/connector-instances"),
 

--- a/dashboard/src/assets/connectors/dify.svg
+++ b/dashboard/src/assets/connectors/dify.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="15" fill="#1c64f2"/>
+  <path d="M16 14h15c11 0 18 7 18 18s-7 18-18 18H16zm9 8v20h6c6 0 10-4 10-10s-4-10-10-10z" fill="#fff"/>
+</svg>

--- a/dashboard/src/assets/connectors/index.ts
+++ b/dashboard/src/assets/connectors/index.ts
@@ -2,6 +2,7 @@ import tencentArdot from "./tencent-ardot.png";
 import baiduMap from "./baidu-map.png";
 import ctripWendao from "./ctrip-wendao.png";
 import dida365 from "./dida365.png";
+import dify from "./dify.svg";
 import feishuCli from "./feishu-cli.png";
 import fliggy from "./fliggy.png";
 import meituanTravel from "./meituan-travel.png";
@@ -16,6 +17,7 @@ import tencentLexiang from "./tencent-lexiang.png";
 import tencentWeiyun from "./tencent-weiyun.png";
 import wechatReading from "./wechat-reading.png";
 import wecomCli from "./wecom-cli.png";
+import weknora from "./weknora.svg";
 import youdaoNote from "./youdao-note.png";
 import yuandian from "./yuandian.png";
 
@@ -36,10 +38,12 @@ export const CONNECTOR_LOGOS: Record<string, string> = {
   "tencent-meeting": tencentMeeting,
   notion,
   dida365: dida365,
+  dify,
   "tencent-news": tencentNews,
   "wechat-reading": wechatReading,
   "youdao-note": youdaoNote,
   "tencent-weiyun": tencentWeiyun,
+  weknora,
 };
 
 export function getConnectorLogo(kind: string): string | undefined {

--- a/dashboard/src/assets/connectors/weknora.svg
+++ b/dashboard/src/assets/connectors/weknora.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="15" fill="#0052d9"/>
+  <path d="M13 17h8l5 24 6-18h6l6 18 5-24h8L48 49h-8l-5-15-6 15h-8z" fill="#fff"/>
+</svg>

--- a/dashboard/src/pages/Agent/Connectors/guidedConnectorUtils.test.ts
+++ b/dashboard/src/pages/Agent/Connectors/guidedConnectorUtils.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  consoleUrlFromServiceUrl,
+  extractHttpUrl,
+  isDifyMcpServerUrl,
+  isGuidedConnector,
+} from "./guidedConnectorUtils";
+
+describe("guided connector helpers", () => {
+  it("extracts a pasted URL without surrounding prose", () => {
+    expect(
+      extractHttpUrl(
+        "MCP Server URL: https://dify.example.com/mcp/server/code/mcp。",
+      ),
+    ).toBe("https://dify.example.com/mcp/server/code/mcp");
+    expect(extractHttpUrl("sk-secret")).toBeNull();
+  });
+
+  it("recognizes only Dify app MCP server routes", () => {
+    expect(
+      isDifyMcpServerUrl("https://dify.example.com/mcp/server/server-code/mcp"),
+    ).toBe(true);
+    expect(isDifyMcpServerUrl("https://dify.example.com/v1/chat")).toBe(false);
+  });
+
+  it("derives safe console origins", () => {
+    expect(
+      consoleUrlFromServiceUrl("weknora", "http://127.0.0.1:8080/api/v1"),
+    ).toBe("http://127.0.0.1");
+    expect(
+      consoleUrlFromServiceUrl(
+        "dify",
+        "https://dify.example.com/mcp/server/code/mcp",
+      ),
+    ).toBe("https://dify.example.com");
+    expect(isGuidedConnector("weknora")).toBe(true);
+    expect(isGuidedConnector("notion")).toBe(false);
+  });
+});

--- a/dashboard/src/pages/Agent/Connectors/guidedConnectorUtils.ts
+++ b/dashboard/src/pages/Agent/Connectors/guidedConnectorUtils.ts
@@ -1,0 +1,45 @@
+export type GuidedConnectorKind = "weknora" | "dify";
+
+export function isGuidedConnector(
+  kind: string | undefined,
+): kind is GuidedConnectorKind {
+  return kind === "weknora" || kind === "dify";
+}
+
+export function extractHttpUrl(text: string): string | null {
+  const match = text.trim().match(/https?:\/\/[^\s<>"']+/i);
+  if (!match) return null;
+  return match[0].replace(/[),.;，。；）]+$/u, "");
+}
+
+export function isDifyMcpServerUrl(value: string): boolean {
+  try {
+    const url = new URL(value.trim());
+    return (
+      ["http:", "https:"].includes(url.protocol) &&
+      /^\/mcp\/server\/[^/]+\/mcp\/?$/.test(url.pathname)
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function consoleUrlFromServiceUrl(
+  kind: GuidedConnectorKind,
+  value: string,
+): string | null {
+  try {
+    const url = new URL(value.trim());
+    if (!["http:", "https:"].includes(url.protocol)) return null;
+    if (
+      kind === "weknora" &&
+      ["127.0.0.1", "localhost"].includes(url.hostname) &&
+      url.port === "8080"
+    ) {
+      return `${url.protocol}//${url.hostname}`;
+    }
+    return url.origin;
+  } catch {
+    return null;
+  }
+}

--- a/dashboard/src/pages/Agent/Connectors/index.module.less
+++ b/dashboard/src/pages/Agent/Connectors/index.module.less
@@ -487,6 +487,31 @@
   border-radius: var(--fn-radius-md);
 }
 
+.guidedSetup {
+  margin-bottom: 12px;
+  padding: 10px 12px;
+  border: 1px solid var(--fn-card-border-normal);
+  border-radius: var(--fn-radius-md);
+  background: color-mix(
+    in srgb,
+    var(--connector-accent, var(--fn-color-brand)) 4%,
+    var(--fn-bg-primary)
+  );
+  font-size: 13px;
+  color: var(--fn-text-secondary);
+
+  ol {
+    margin: 6px 0 0;
+    padding-left: 20px;
+    line-height: 1.65;
+  }
+}
+
+.guidedSetupTitle {
+  color: var(--fn-text-primary);
+  font-weight: 600;
+}
+
 .guideLinks {
   display: flex;
   flex-wrap: wrap;

--- a/dashboard/src/pages/Agent/Connectors/index.tsx
+++ b/dashboard/src/pages/Agent/Connectors/index.tsx
@@ -44,6 +44,12 @@ import {
   mailProviderById,
 } from "./connectorDefs";
 import { notifyConnectorsChanged } from "./customMcpUtils";
+import {
+  consoleUrlFromServiceUrl,
+  extractHttpUrl,
+  isDifyMcpServerUrl,
+  isGuidedConnector,
+} from "./guidedConnectorUtils";
 import { useConnectorInstances } from "./useConnectors";
 import styles from "./index.module.less";
 
@@ -109,6 +115,18 @@ function buildCredentials(
     credentials.sdk_id = values.sdk_id;
     const secret_key = String(values.secret_key ?? "").trim();
     if (secret_key) credentials.secret_key = secret_key;
+  } else if (entry.auth_kind === "custom_fields") {
+    for (const field of entry.credential_fields ?? []) {
+      const text = String(values[field.key] ?? "").trim();
+      if (!text) continue;
+      credentials[field.key] =
+        field.field_type === "tags"
+          ? text
+              .split(",")
+              .map((item) => item.trim())
+              .filter(Boolean)
+          : text;
+    }
   }
   return credentials;
 }
@@ -146,6 +164,17 @@ function previewToFormValues(
   if (entry.auth_kind === "oauth2" && preview.oauth_configured) {
     values.access_token = "__configured__";
   }
+  if (entry.auth_kind === "custom_fields") {
+    for (const field of entry.credential_fields ?? []) {
+      if (field.secret) continue;
+      const value = preview[field.key];
+      if (Array.isArray(value)) {
+        values[field.key] = value.join(", ");
+      } else if (value !== undefined && value !== null) {
+        values[field.key] = value;
+      }
+    }
+  }
   return values;
 }
 
@@ -178,7 +207,30 @@ function hasFreshCredentialInput(
   if (entry.auth_kind === "api_credentials") {
     return Boolean(String(values.secret_key ?? "").trim());
   }
+  if (entry.auth_kind === "custom_fields") {
+    return (entry.credential_fields ?? []).some(
+      (field) =>
+        field.secret && Boolean(String(values[field.key] ?? "").trim()),
+    );
+  }
   return false;
+}
+
+function customCredentialConfigChanged(
+  entry: ConnectorCatalogEntry,
+  values: Record<string, unknown>,
+  preview: ConnectorCredentialsPreview,
+): boolean {
+  if (entry.auth_kind !== "custom_fields") return false;
+  return (entry.credential_fields ?? []).some((field) => {
+    if (field.secret) return false;
+    const current = String(values[field.key] ?? "").trim();
+    const storedValue = preview[field.key];
+    const stored = Array.isArray(storedValue)
+      ? storedValue.join(", ")
+      : String(storedValue ?? "").trim();
+    return current !== stored;
+  });
 }
 
 function openAuthorizeLabel(
@@ -216,7 +268,7 @@ function secretFieldRules(required: boolean) {
 
 function configuredExtra(
   preview: ConnectorCredentialsPreview | undefined,
-  key: keyof ConnectorCredentialsPreview,
+  key: string,
   t: (key: string, fallback: string) => string,
 ) {
   if (!preview?.[key]) return undefined;
@@ -260,6 +312,10 @@ function ConnectorConfigDrawer({
     null,
   );
   const [installingCli, setInstallingCli] = useState(false);
+  const [detectingLocalWeKnora, setDetectingLocalWeKnora] = useState(false);
+  const [detectedWeKnoraConsole, setDetectedWeKnoraConsole] = useState<
+    string | null
+  >(null);
   const [feishuUserAuth, setFeishuUserAuth] =
     useState<FeishuUserAuthStartResult | null>(null);
   const [feishuUserAuthBusy, setFeishuUserAuthBusy] = useState(false);
@@ -272,6 +328,8 @@ function ConnectorConfigDrawer({
   const hasStoredCredentials = Boolean(instance?.has_credentials);
   const mailProvider = Form.useWatch("mail_provider", form) ?? "qq";
   const defaultOpen = Form.useWatch("default_open", form) === true;
+  const weknoraBaseUrl = String(Form.useWatch("base_url", form) ?? "");
+  const difyMcpUrl = String(Form.useWatch("mcp_url", form) ?? "");
   const selectedMailProvider = mailProviderById(String(mailProvider));
   const draftScope = entry
     ? instance
@@ -296,6 +354,7 @@ function ConnectorConfigDrawer({
     setInstanceDetail(null);
     setProbeResult(null);
     setCliInfo(null);
+    setDetectedWeKnoraConsole(null);
     setFeishuUserAuth(null);
     setFeishuUserReady(false);
     setFeishuAuthNeedsReauth(false);
@@ -685,6 +744,87 @@ function ConnectorConfigDrawer({
     }
   };
 
+  const handleGuidedPaste = async () => {
+    if (!entry || !isGuidedConnector(entry.kind)) return;
+    try {
+      const text = (await navigator.clipboard.readText()).trim();
+      if (!text) {
+        message.warning(t("connectors.clipboardEmpty", "剪贴板为空"));
+        return;
+      }
+      const pastedUrl = extractHttpUrl(text);
+      if (entry.kind === "dify") {
+        if (!pastedUrl) {
+          message.warning(
+            t("connectors.difyPasteUrlRequired", "剪贴板中没有 MCP URL"),
+          );
+          return;
+        }
+        form.setFieldValue("mcp_url", pastedUrl);
+        await form.validateFields(["mcp_url"]);
+      } else if (pastedUrl) {
+        form.setFieldValue("base_url", pastedUrl);
+      } else {
+        form.setFieldValue("api_key", text);
+      }
+      saveFormDraft(
+        draftScope,
+        form.getFieldsValue() as Record<string, unknown>,
+      );
+      message.success(t("connectors.pasteSuccess", "已粘贴"));
+    } catch (error) {
+      if (error && typeof error === "object" && "errorFields" in error) {
+        message.warning(
+          t(
+            "connectors.difyMcpUrlInvalid",
+            "请粘贴 Dify 访问点提供的完整 MCP Server URL",
+          ),
+        );
+        return;
+      }
+      message.error(
+        t("connectors.clipboardDenied", "无法读取剪贴板，请手动粘贴"),
+      );
+    }
+  };
+
+  const handleDetectLocalWeKnora = async () => {
+    if (detectingLocalWeKnora) return;
+    setDetectingLocalWeKnora(true);
+    try {
+      const result = await connectorsApi.detectLocalWeKnora();
+      if (!result.found || !result.base_url) {
+        message.warning(
+          t(
+            "connectors.weknoraNotFound",
+            "未在 OCTOP 主机的 127.0.0.1:8080 检测到 WeKnora",
+          ),
+        );
+        return;
+      }
+      form.setFieldValue("base_url", result.base_url);
+      setDetectedWeKnoraConsole(result.console_url ?? null);
+      saveFormDraft(
+        draftScope,
+        form.getFieldsValue() as Record<string, unknown>,
+      );
+      message.success(
+        t("connectors.weknoraFound", "已检测到本机 WeKnora 并填入地址"),
+      );
+    } catch (error) {
+      console.error(error);
+      message.error(
+        apiErrorMessage(
+          error,
+          t("connectors.weknoraDetectFailed", "检测本机 WeKnora 失败"),
+          t,
+        ),
+      );
+    } finally {
+      setDetectingLocalWeKnora(false);
+    }
+  };
+
   const handleOAuth = async () => {
     if (!entry || authorizing) return;
     const popup = window.open("", "octop-oauth", "width=520,height=720");
@@ -843,17 +983,35 @@ function ConnectorConfigDrawer({
       Boolean(preview.bot_id) &&
       String(values.bot_id ?? "").trim() !==
         String(preview.bot_id ?? "").trim();
-    const identityChanged = feishuAppIdChanged || wecomBotIdChanged;
-    if (identityChanged && !freshSecret) {
+    const customConfigChanged = customCredentialConfigChanged(
+      entry,
+      values,
+      preview,
+    );
+    const customHasStoredSecret = (entry.credential_fields ?? []).some(
+      (field) => field.secret && preview[`${field.key}_configured`] === true,
+    );
+    const identityChanged =
+      feishuAppIdChanged || wecomBotIdChanged || customConfigChanged;
+    if (
+      identityChanged &&
+      !freshSecret &&
+      (entry.auth_kind !== "custom_fields" || customHasStoredSecret)
+    ) {
       message.warning(
         entry.kind === "feishu-cli"
           ? t(
               "connectors.probeNeedSecretAfterAppIdChange",
               "App ID 已修改，请填写 App Secret 后再探测",
             )
-          : t(
+          : entry.kind === "wecom-cli"
+          ? t(
               "connectors.probeNeedSecretAfterBotIdChange",
               "Bot ID 已修改，请填写 Secret 后再探测",
+            )
+          : t(
+              "connectors.probeNeedSecretAfterConfigChange",
+              "连接配置已修改，请重新填写密钥后再探测",
             ),
       );
       return;
@@ -959,6 +1117,15 @@ function ConnectorConfigDrawer({
   const guideUrl = authInfo?.guide_url ?? entry.guide_url ?? entry.doc_url;
   const manualUrl = authInfo?.manual_url ?? entry.manual_url ?? guideUrl;
   const authHint = authInfo?.auth_hint ?? entry.auth_hint;
+  const guidedKind = isGuidedConnector(entry.kind) ? entry.kind : null;
+  const guidedServiceUrl =
+    guidedKind === "weknora" ? weknoraBaseUrl : difyMcpUrl;
+  const guidedConsoleUrl =
+    detectedWeKnoraConsole ??
+    (guidedKind
+      ? consoleUrlFromServiceUrl(guidedKind, guidedServiceUrl)
+      : null) ??
+    guideUrl;
 
   const preview = instanceDetail?.credentials_preview;
   const secretRequired = !hasStoredCredentials;
@@ -1018,6 +1185,45 @@ function ConnectorConfigDrawer({
 
         {authHint && <div className={styles.authHint}>{authHint}</div>}
 
+        {guidedKind && (
+          <div className={styles.guidedSetup}>
+            <div className={styles.guidedSetupTitle}>
+              {t("connectors.guidedSetup", "快速接入")}
+            </div>
+            {guidedKind === "weknora" ? (
+              <ol>
+                <li>
+                  {t("connectors.weknoraStep1", "打开 WeKnora 并创建 API Key")}
+                </li>
+                <li>
+                  {t(
+                    "connectors.weknoraStep2",
+                    "检测本机服务，或手动填写部署地址",
+                  )}
+                </li>
+                <li>
+                  {t("connectors.guidedStepProbe", "粘贴凭证后探测并保存")}
+                </li>
+              </ol>
+            ) : (
+              <ol>
+                <li>
+                  {t("connectors.difyStep1", "在 Dify 中发布应用或工作流")}
+                </li>
+                <li>
+                  {t(
+                    "connectors.difyStep2",
+                    "在访问点启用 MCP 并复制完整 Server URL",
+                  )}
+                </li>
+                <li>
+                  {t("connectors.guidedStepProbe", "粘贴凭证后探测并保存")}
+                </li>
+              </ol>
+            )}
+          </div>
+        )}
+
         {guideUrl && !hideGuideLink && (
           <div className={styles.guideLinks}>
             <a href={guideUrl} target="_blank" rel="noreferrer">
@@ -1027,6 +1233,35 @@ function ConnectorConfigDrawer({
         )}
 
         <div className={styles.quickAuthBar}>
+          {guidedKind && (
+            <>
+              <Button
+                icon={<ExternalLink size={14} />}
+                onClick={() => openUrl(guidedConsoleUrl)}
+              >
+                {guidedKind === "weknora"
+                  ? t("connectors.openWeKnora", "打开 WeKnora")
+                  : t("connectors.openDify", "打开 Dify")}
+              </Button>
+              {guidedKind === "weknora" && (
+                <Button
+                  icon={<RefreshCw size={14} />}
+                  loading={detectingLocalWeKnora}
+                  onClick={() => void handleDetectLocalWeKnora()}
+                >
+                  {t("connectors.detectLocal", "检测本机服务")}
+                </Button>
+              )}
+              <Button
+                icon={<ClipboardPaste size={14} />}
+                onClick={() => void handleGuidedPaste()}
+              >
+                {guidedKind === "dify"
+                  ? t("connectors.pasteMcpUrl", "粘贴 MCP 地址")
+                  : t("connectors.smartPaste", "智能粘贴")}
+              </Button>
+            </>
+          )}
           {entry && isHostCliConnector(entry.kind) && (
             <>
               {canInstallCli && (
@@ -1234,6 +1469,57 @@ function ConnectorConfigDrawer({
           >
             <Input placeholder={entry.name} />
           </Form.Item>
+
+          {entry.auth_kind === "custom_fields" &&
+            (entry.credential_fields ?? []).map((field) => {
+              const isSecret = field.secret || field.field_type === "password";
+              const input = isSecret ? (
+                <Input.Password
+                  placeholder={
+                    hasStoredCredentials && field.secret
+                      ? t("connectors.secretPlaceholder", "留空表示不修改")
+                      : field.placeholder ?? undefined
+                  }
+                />
+              ) : (
+                <Input placeholder={field.placeholder ?? undefined} />
+              );
+              return (
+                <Form.Item
+                  key={field.key}
+                  name={field.key}
+                  label={field.label}
+                  rules={[
+                    ...(isSecret
+                      ? secretFieldRules(field.required && secretRequired)
+                      : [{ required: field.required }]),
+                    ...(entry.kind === "dify" && field.key === "mcp_url"
+                      ? [
+                          {
+                            validator: (_: unknown, value: unknown) =>
+                              !value || isDifyMcpServerUrl(String(value))
+                                ? Promise.resolve()
+                                : Promise.reject(
+                                    new Error(
+                                      t(
+                                        "connectors.difyMcpUrlInvalid",
+                                        "请粘贴 Dify 访问点提供的完整 MCP Server URL",
+                                      ),
+                                    ),
+                                  ),
+                          },
+                        ]
+                      : []),
+                  ]}
+                  extra={
+                    configuredExtra(preview, `${field.key}_configured`, t) ??
+                    field.help
+                  }
+                >
+                  {input}
+                </Form.Item>
+              );
+            })}
 
           {entry.auth_kind === "personal_token" && (
             <Form.Item

--- a/src/octop/api/routers/connectors.py
+++ b/src/octop/api/routers/connectors.py
@@ -58,6 +58,7 @@ from octop.infra.connectors.oauth.registry import (
     oauth_target_requires_https,
 )
 from octop.infra.connectors.probe import (
+    detect_local_weknora,
     prepare_probe_credentials,
     probe_connector,
     probe_custom_mcp_server,
@@ -381,6 +382,14 @@ def _credentials_preview(kind: str, creds: dict[str, Any]) -> dict[str, Any]:
             preview["sdk_id"] = str(creds["sdk_id"])
         if str(creds.get("secret_key") or "").strip():
             preview["secret_key_configured"] = True
+    elif entry.auth_kind == "custom_fields":
+        for field in entry.credential_fields:
+            value = creds.get(field.key)
+            if field.secret:
+                if str(value or "").strip():
+                    preview[f"{field.key}_configured"] = True
+            elif value not in (None, "", []):
+                preview[field.key] = value
     return preview
 
 
@@ -414,6 +423,15 @@ async def get_catalog(
         catalog_entry_to_dict(e, oauth_ready=oauth_ready_for_kind(e.kind, settings))
         for e in list_catalog()
     ]
+
+
+@router.get("/connectors/weknora/detect-local", summary="Detect local WeKnora")
+async def detect_weknora_on_octop_host(
+    user: Any = Depends(current_user),
+) -> dict[str, Any]:
+    """Check WeKnora's fixed default loopback health endpoint (no persistence)."""
+    del user
+    return await detect_local_weknora()
 
 
 @router.get("/connector-instances", summary="List connector instances")

--- a/src/octop/infra/connectors/builder.py
+++ b/src/octop/infra/connectors/builder.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import re
 import secrets
 from typing import Any
-from urllib.parse import quote
+from urllib.parse import quote, urlsplit, urlunsplit
 
 from octop.config import OctopConfig
 from octop.infra.connectors.catalog import (
@@ -13,6 +13,7 @@ from octop.infra.connectors.catalog import (
     get_catalog_entry,
     is_mcp_oauth_remote,
 )
+from octop.infra.connectors.custom_mcp import validate_mcp_http_url
 from octop.infra.connectors.mail_servers import resolve_mail_servers
 from octop.infra.utils.ulid import new_ulid
 
@@ -36,6 +37,18 @@ def normalize_weiyun_mcp_token(raw: str) -> str:
     if match:
         return match.group(1).strip()
     return text
+
+
+def normalize_weknora_base_url(raw: str) -> str:
+    """Normalize a WeKnora origin or API base to its `/api/v1` root."""
+    url = validate_mcp_http_url(raw)
+    parsed = urlsplit(url)
+    if parsed.query or parsed.fragment:
+        raise ValueError("base_url must not contain a query string or fragment")
+    path = parsed.path.rstrip("/")
+    if not path.endswith("/api/v1"):
+        path = f"{path}/api/v1"
+    return urlunsplit((parsed.scheme, parsed.netloc, path, "", ""))
 
 
 def mcp_server_name(kind: str, instance_id: str) -> str:
@@ -73,6 +86,13 @@ def build_http_mcp_spec(
 
 
 def _build_remote_spec(entry: ConnectorCatalogEntry, creds: dict[str, Any]) -> dict[str, Any]:
+    if entry.kind == "dify":
+        url = validate_mcp_http_url(str(creds.get("mcp_url") or ""))
+        return {
+            "transport": "http",
+            "url": url,
+            "headers": _mcp_http_headers(),
+        }
     if entry.kind == "tencent-docs":
         token = str(creds.get("token") or "")
         spec: dict[str, Any] = {
@@ -362,6 +382,34 @@ def validate_create_credentials(
             "internal_token": internal_token,
         }
 
+    if entry.auth_kind == "custom_fields":
+        if entry.kind == "weknora":
+            base_url = normalize_weknora_base_url(str(credentials.get("base_url") or ""))
+            out = {
+                "base_url": base_url,
+                "internal_token": new_internal_token(),
+            }
+            api_key = str(credentials.get("api_key") or "").strip()
+            tenant_id = str(credentials.get("tenant_id") or "").strip()
+            raw_ids = credentials.get("knowledge_base_ids")
+            if api_key:
+                out["api_key"] = api_key
+            if tenant_id:
+                out["tenant_id"] = tenant_id
+            if isinstance(raw_ids, list):
+                ids = [str(item).strip() for item in raw_ids if str(item).strip()]
+            else:
+                ids = [part.strip() for part in str(raw_ids or "").split(",") if part.strip()]
+            if ids:
+                out["knowledge_base_ids"] = list(dict.fromkeys(ids))
+            return out
+        if entry.kind == "dify":
+            mcp_url = validate_mcp_http_url(str(credentials.get("mcp_url") or ""))
+            if "/mcp/server/" not in mcp_url or not mcp_url.rstrip("/").endswith("/mcp"):
+                raise ValueError("mcp_url must be a Dify MCP Server URL ending in /mcp")
+            return {"mcp_url": mcp_url}
+        raise ValueError(f"unsupported custom_fields connector kind: {kind}")
+
     raise ValueError(f"unsupported auth_kind: {entry.auth_kind}")
 
 
@@ -375,6 +423,8 @@ def _redact_mcp_configs_for_log(configs: dict[str, Any]) -> dict[str, Any]:
         url = str(entry.get("url") or "")
         if "token=" in url:
             entry["url"] = url.split("token=", 1)[0] + "token=***"
+        elif "/mcp/server/" in url:
+            entry["url"] = re.sub(r"(/mcp/server/)[^/?#]+", r"\1***", url)
         headers = entry.get("headers")
         if isinstance(headers, dict):
             redacted = dict(headers)

--- a/src/octop/infra/connectors/catalog.py
+++ b/src/octop/infra/connectors/catalog.py
@@ -13,7 +13,22 @@ AuthKind = Literal[
     "imap_app_password",
     "session_cookie",
     "api_credentials",
+    "custom_fields",
 ]
+
+CredentialFieldType = Literal["text", "password", "url", "tags"]
+RemoteTransport = Literal["raw_http", "streamable_http", "sse"]
+
+
+@dataclass(frozen=True)
+class ConnectorCredentialField:
+    key: str
+    label: str
+    field_type: CredentialFieldType = "text"
+    required: bool = True
+    placeholder: str | None = None
+    help: str | None = None
+    secret: bool = False
 
 
 @dataclass(frozen=True)
@@ -43,6 +58,8 @@ class ConnectorCatalogEntry:
     oauth_resource: str | None = None
     oauth_scopes: str | None = None
     mcp_user_agent: str | None = None
+    credential_fields: tuple[ConnectorCredentialField, ...] = ()
+    remote_transport: RemoteTransport = "raw_http"
 
 
 def is_mcp_oauth_remote(entry: ConnectorCatalogEntry) -> bool:
@@ -67,6 +84,73 @@ def get_mcp_oauth_remote(kind: str) -> ConnectorCatalogEntry | None:
 
 
 _CATALOG: tuple[ConnectorCatalogEntry, ...] = (
+    ConnectorCatalogEntry(
+        kind="weknora",
+        name="WeKnora",
+        description="连接 WeKnora 私有知识库，提供只读检索与文档阅读",
+        auth_kind="custom_fields",
+        doc_url="https://github.com/Tencent/WeKnora",
+        icon="weknora",
+        color="#0052d9",
+        phase="available",
+        mcp_mode="gateway",
+        guide_url="https://github.com/Tencent/WeKnora/blob/main/docs/api/README.md",
+        auth_hint="填写 WeKnora 服务地址；API Key 与 Tenant ID 按部署的鉴权设置填写。",
+        credential_fields=(
+            ConnectorCredentialField(
+                key="base_url",
+                label="服务地址",
+                field_type="url",
+                placeholder="http://127.0.0.1:8080 或 https://weknora.example.com",
+                help="未包含 /api/v1 时会自动补齐",
+            ),
+            ConnectorCredentialField(
+                key="api_key",
+                label="API Key",
+                field_type="password",
+                required=False,
+                placeholder="sk-...（无鉴权部署可留空）",
+                secret=True,
+            ),
+            ConnectorCredentialField(
+                key="tenant_id",
+                label="Tenant ID",
+                required=False,
+                help="平台级 API Key 需要指定工作空间时填写",
+            ),
+            ConnectorCredentialField(
+                key="knowledge_base_ids",
+                label="默认知识库 ID",
+                field_type="tags",
+                required=False,
+                placeholder="kb-123, kb-456",
+                help="留空时检索当前凭证可见的全部知识库",
+            ),
+        ),
+    ),
+    ConnectorCatalogEntry(
+        kind="dify",
+        name="Dify",
+        description="连接 Dify 已发布应用或工作流的 MCP 服务",
+        auth_kind="custom_fields",
+        doc_url="https://docs.dify.ai/",
+        icon="dify",
+        color="#1c64f2",
+        phase="available",
+        mcp_mode="remote",
+        auth_hint="在 Dify 应用的访问点中启用 MCP，然后粘贴完整的 MCP Server URL。",
+        credential_fields=(
+            ConnectorCredentialField(
+                key="mcp_url",
+                label="MCP Server URL",
+                field_type="url",
+                placeholder="https://dify.example.com/mcp/server/<server_code>/mcp",
+                help="完整 URL 含访问标识，将按密钥加密保存",
+                secret=True,
+            ),
+        ),
+        remote_transport="streamable_http",
+    ),
     ConnectorCatalogEntry(
         kind="tencent-docs",
         name="腾讯文档",
@@ -432,5 +516,17 @@ def catalog_entry_to_dict(
         "auth_hint": entry.auth_hint,
         "oauth_mode": oauth_mode,
         "oauth_ready": oauth_ready,
+        "credential_fields": [
+            {
+                "key": field.key,
+                "label": field.label,
+                "field_type": field.field_type,
+                "required": field.required,
+                "placeholder": field.placeholder,
+                "help": field.help,
+                "secret": field.secret,
+            }
+            for field in entry.credential_fields
+        ],
         "supports_quick_auth": entry.phase == "available" and entry.auth_kind != "api_credentials",
     }

--- a/src/octop/infra/connectors/custom_mcp.py
+++ b/src/octop/infra/connectors/custom_mcp.py
@@ -102,7 +102,12 @@ def _normalize_args(raw: Any) -> list[str]:
     return [str(item) for item in raw]
 
 
-def _validate_http_url(url: str) -> str:
+def validate_mcp_http_url(url: str) -> str:
+    """Validate a user-configured MCP/connector URL.
+
+    Local loopback deployments may use HTTP. Remote deployments must use
+    public HTTPS and pass the shared SSRF guard.
+    """
     text = url.strip()
     if not text:
         raise ValueError("url is required")
@@ -150,7 +155,7 @@ def normalize_server_spec(name: str, raw: Any) -> dict[str, Any]:
         spec["display_name"] = display_name
 
     if transport == "streamable_http":
-        url = _validate_http_url(str(raw.get("url") or ""))
+        url = validate_mcp_http_url(str(raw.get("url") or ""))
         spec["url"] = url
         headers = _normalize_headers(raw.get("headers"))
         if headers:

--- a/src/octop/infra/connectors/gateway/adapters/weknora.py
+++ b/src/octop/infra/connectors/gateway/adapters/weknora.py
@@ -1,0 +1,239 @@
+"""Read-only WeKnora knowledge-base gateway adapter."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from octop.infra.connectors.builder import normalize_weknora_base_url
+
+_MAX_RESULTS = 8
+_MAX_CHUNK_CHARS = 1200
+
+TOOLS: list[dict[str, Any]] = [
+    {
+        "name": "list_knowledge_bases",
+        "description": "List WeKnora knowledge bases visible to the configured credential.",
+        "inputSchema": {"type": "object", "properties": {}},
+    },
+    {
+        "name": "search",
+        "description": (
+            "Search WeKnora knowledge bases and return ranked source passages. "
+            "Use the returned knowledge_id with read_document for surrounding context."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "query": {"type": "string", "description": "Search query"},
+                "knowledge_base_ids": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Optional knowledge-base scope; defaults to connector config",
+                },
+                "max_results": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": _MAX_RESULTS,
+                    "description": f"Maximum passages (1-{_MAX_RESULTS})",
+                },
+            },
+            "required": ["query"],
+        },
+    },
+    {
+        "name": "read_document",
+        "description": "Read one WeKnora document and its ordered chunks by knowledge_id.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "knowledge_id": {"type": "string", "description": "Document knowledge ID"},
+                "page": {"type": "integer", "minimum": 1, "description": "Page, default 1"},
+                "page_size": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 50,
+                    "description": "Chunks per page, default 20",
+                },
+            },
+            "required": ["knowledge_id"],
+        },
+    },
+]
+
+
+def list_tools() -> list[dict[str, Any]]:
+    return TOOLS
+
+
+def _headers(creds: dict[str, Any]) -> dict[str, str]:
+    headers = {"Accept": "application/json"}
+    api_key = str(creds.get("api_key") or "").strip()
+    tenant_id = str(creds.get("tenant_id") or "").strip()
+    if api_key:
+        headers["X-API-Key"] = api_key
+    if tenant_id:
+        headers["X-Tenant-ID"] = tenant_id
+    return headers
+
+
+def _request(
+    creds: dict[str, Any],
+    method: str,
+    path: str,
+    *,
+    params: dict[str, Any] | None = None,
+    body: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    base_url = normalize_weknora_base_url(str(creds.get("base_url") or ""))
+    try:
+        with httpx.Client(timeout=30.0, follow_redirects=False) as client:
+            response = client.request(
+                method,
+                f"{base_url}{path}",
+                headers=_headers(creds),
+                params=params,
+                json=body,
+            )
+        response.raise_for_status()
+        payload = response.json()
+    except httpx.HTTPStatusError as exc:
+        status = exc.response.status_code
+        raise ValueError(f"WeKnora request failed: HTTP {status}") from exc
+    except (httpx.HTTPError, ValueError) as exc:
+        if isinstance(exc, ValueError) and str(exc).startswith("WeKnora request failed"):
+            raise
+        raise ValueError(f"WeKnora request failed: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise ValueError("WeKnora returned an invalid JSON response")
+    if payload.get("success") is False:
+        reason = payload.get("message") or payload.get("error") or "request rejected"
+        raise ValueError(f"WeKnora request failed: {reason}")
+    return payload
+
+
+def _data_list(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    data = payload.get("data")
+    if isinstance(data, list):
+        return [item for item in data if isinstance(item, dict)]
+    return []
+
+
+def _configured_ids(creds: dict[str, Any], raw: Any = None) -> list[str]:
+    value = raw if raw is not None else creds.get("knowledge_base_ids")
+    if isinstance(value, list):
+        ids = [str(item).strip() for item in value if str(item).strip()]
+    else:
+        ids = [part.strip() for part in str(value or "").split(",") if part.strip()]
+    return list(dict.fromkeys(ids))
+
+
+def _visible_knowledge_base_ids(creds: dict[str, Any]) -> list[str]:
+    ids: list[str] = []
+    for item in _data_list(_request(creds, "GET", "/knowledge-bases")):
+        kb_id = str(item.get("id") or "").strip()
+        if kb_id:
+            ids.append(kb_id)
+    return ids
+
+
+def _clip_passage(item: dict[str, Any]) -> dict[str, Any]:
+    content = str(item.get("content") or "")
+    clipped = content[:_MAX_CHUNK_CHARS]
+    return {
+        "knowledge_id": item.get("knowledge_id"),
+        "knowledge_title": item.get("knowledge_title") or item.get("knowledge_filename"),
+        "chunk_index": item.get("chunk_index"),
+        "score": item.get("score"),
+        "content": clipped,
+        "truncated": len(content) > len(clipped),
+    }
+
+
+def _list_knowledge_bases(creds: dict[str, Any]) -> dict[str, Any]:
+    rows = _data_list(_request(creds, "GET", "/knowledge-bases"))
+    return {
+        "knowledge_bases": [
+            {
+                "id": item.get("id"),
+                "name": item.get("name"),
+                "description": item.get("description"),
+                "knowledge_count": item.get("knowledge_count"),
+                "chunk_count": item.get("chunk_count"),
+            }
+            for item in rows
+        ]
+    }
+
+
+def _search(creds: dict[str, Any], args: dict[str, Any]) -> dict[str, Any]:
+    query = str(args.get("query") or "").strip()
+    if not query:
+        raise ValueError("query is required")
+    ids = _configured_ids(creds, args.get("knowledge_base_ids"))
+    if not ids:
+        ids = _visible_knowledge_base_ids(creds)
+    if not ids:
+        raise ValueError("no visible WeKnora knowledge bases")
+    max_results = max(1, min(int(args.get("max_results") or _MAX_RESULTS), _MAX_RESULTS))
+    payload = _request(
+        creds,
+        "POST",
+        "/knowledge-search",
+        params={"resource_urls": "handle"},
+        body={"query": query, "knowledge_base_ids": ids},
+    )
+    passages = [_clip_passage(item) for item in _data_list(payload)[:max_results]]
+    return {"query": query, "knowledge_base_ids": ids, "passages": passages}
+
+
+def _read_document(creds: dict[str, Any], args: dict[str, Any]) -> dict[str, Any]:
+    knowledge_id = str(args.get("knowledge_id") or "").strip()
+    if not knowledge_id:
+        raise ValueError("knowledge_id is required")
+    page = max(1, int(args.get("page") or 1))
+    page_size = max(1, min(int(args.get("page_size") or 20), 50))
+    escaped_id = quote(knowledge_id, safe="")
+    detail_payload = _request(creds, "GET", f"/knowledge/{escaped_id}")
+    chunks_payload = _request(
+        creds,
+        "GET",
+        f"/chunks/{escaped_id}",
+        params={"page": page, "page_size": page_size},
+    )
+    detail = detail_payload.get("data")
+    if not isinstance(detail, dict):
+        detail = {}
+    chunks = sorted(
+        _data_list(chunks_payload),
+        key=lambda item: int(item.get("chunk_index") or 0),
+    )
+    return {
+        "knowledge_id": knowledge_id,
+        "title": detail.get("title") or detail.get("file_name"),
+        "description": detail.get("description"),
+        "summary": detail.get("summary"),
+        "page": chunks_payload.get("page", page),
+        "page_size": chunks_payload.get("page_size", page_size),
+        "total": chunks_payload.get("total"),
+        "chunks": [_clip_passage(item) for item in chunks],
+    }
+
+
+def call_tool(creds: dict[str, Any], name: str, args: dict[str, Any]) -> str:
+    if name == "list_knowledge_bases":
+        result = _list_knowledge_bases(creds)
+    elif name == "search":
+        result = _search(creds, args)
+    elif name == "read_document":
+        result = _read_document(creds, args)
+    else:
+        raise ValueError(f"unknown tool: {name}")
+    return json.dumps(result, ensure_ascii=False)
+
+
+def probe_credentials(creds: dict[str, Any]) -> None:
+    _request(creds, "GET", "/knowledge-bases")

--- a/src/octop/infra/connectors/gateway/registry.py
+++ b/src/octop/infra/connectors/gateway/registry.py
@@ -16,6 +16,7 @@ from octop.infra.connectors.gateway.adapters import (
     tencent_news,
     wechat_reading,
     wecom_cli,
+    weknora,
     yuandian,
 )
 
@@ -41,6 +42,7 @@ _ADAPTERS: dict[str, GatewayAdapter] = {
     "wechat-reading": wechat_reading,
     "feishu-cli": feishu_cli,
     "wecom-cli": wecom_cli,
+    "weknora": weknora,
 }
 
 

--- a/src/octop/infra/connectors/probe.py
+++ b/src/octop/infra/connectors/probe.py
@@ -28,6 +28,34 @@ from octop.infra.utils.ssrf_guard import UnsafeOutboundUrl, safe_request
 
 logger = logging.getLogger(__name__)
 
+_LOCAL_WEKNORA_API_URL = "http://127.0.0.1:8080"
+_LOCAL_WEKNORA_CONSOLE_URL = "http://127.0.0.1"
+
+
+async def detect_local_weknora() -> dict[str, Any]:
+    """Detect a default host-side WeKnora deployment without persisting data.
+
+    The target is deliberately fixed to loopback.  This keeps the convenience
+    endpoint from becoming an arbitrary server-side URL fetch while matching
+    WeKnora's default Docker ports (UI 80, API 8080).
+    """
+    try:
+        async with httpx.AsyncClient(
+            timeout=httpx.Timeout(2.0),
+            follow_redirects=False,
+            trust_env=False,
+        ) as client:
+            response = await client.get(f"{_LOCAL_WEKNORA_API_URL}/health")
+    except httpx.HTTPError:
+        return {"found": False}
+    if not response.is_success:
+        return {"found": False}
+    return {
+        "found": True,
+        "base_url": f"{_LOCAL_WEKNORA_API_URL}/api/v1",
+        "console_url": _LOCAL_WEKNORA_CONSOLE_URL,
+    }
+
 
 def normalize_tools(raw: list[Any] | None) -> list[dict[str, str]]:
     out: list[dict[str, str]] = []
@@ -384,7 +412,7 @@ async def probe_connector(
     headers = dict(spec.get("headers") or {})
     url = str(spec["url"])
 
-    if is_mcp_oauth_remote(entry):
+    if is_mcp_oauth_remote(entry) or entry.remote_transport == "streamable_http":
         return await probe_streamable_http_mcp(url, headers, kind=entry.kind)
 
     try:

--- a/tests/unit/test_connectors.py
+++ b/tests/unit/test_connectors.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 from pathlib import Path
 
 import pytest
@@ -168,6 +169,241 @@ def test_build_dida365_remote_spec():
     assert spec["url"] == "https://mcp.dida365.com"
     assert spec["headers"]["Authorization"] == "Bearer dida-tok"
     assert spec["headers"]["Accept"] == "application/json, text/event-stream"
+
+
+def test_weknora_catalog_and_credentials():
+    from octop.infra.connectors.catalog import catalog_entry_to_dict
+
+    entry = get_catalog_entry("weknora")
+    assert entry is not None
+    assert entry.mcp_mode == "gateway"
+    data = catalog_entry_to_dict(entry)
+    fields = {item["key"]: item for item in data["credential_fields"]}
+    assert fields["base_url"]["field_type"] == "url"
+    assert fields["api_key"]["secret"] is True
+
+    payload = validate_create_credentials(
+        "weknora",
+        {
+            "base_url": "http://127.0.0.1:8080/",
+            "api_key": "sk-secret",
+            "tenant_id": "tenant-1",
+            "knowledge_base_ids": "kb-1, kb-2, kb-1",
+        },
+    )
+    assert payload["base_url"] == "http://127.0.0.1:8080/api/v1"
+    assert payload["api_key"] == "sk-secret"
+    assert payload["tenant_id"] == "tenant-1"
+    assert payload["knowledge_base_ids"] == ["kb-1", "kb-2"]
+    assert payload["internal_token"]
+
+
+def test_weknora_rejects_non_https_remote_url():
+    with pytest.raises(ValueError, match="non-local url must use https"):
+        validate_create_credentials(
+            "weknora",
+            {"base_url": "http://weknora.example.com", "api_key": "sk-secret"},
+        )
+    with pytest.raises(ValueError, match="query string or fragment"):
+        validate_create_credentials(
+            "weknora",
+            {"base_url": "https://weknora.example.com?token=secret"},
+        )
+
+
+def test_dify_builds_streamable_http_spec():
+    entry = get_catalog_entry("dify")
+    assert entry is not None
+    assert entry.remote_transport == "streamable_http"
+    creds = validate_create_credentials(
+        "dify",
+        {"mcp_url": "https://dify.example.com/mcp/server/server-code/mcp"},
+    )
+    spec = build_http_mcp_spec(
+        entry=entry,
+        instance_id="x",
+        creds=creds,
+        config=OctopConfig(),
+    )
+    assert spec == {
+        "transport": "http",
+        "url": "https://dify.example.com/mcp/server/server-code/mcp",
+        "headers": {"Accept": "application/json, text/event-stream"},
+    }
+
+
+def test_dify_rejects_non_server_url():
+    with pytest.raises(ValueError, match="Dify MCP Server URL"):
+        validate_create_credentials("dify", {"mcp_url": "https://dify.example.com/v1/chat"})
+
+
+def test_dify_server_code_is_redacted_from_logs():
+    from octop.infra.connectors.builder import _redact_mcp_configs_for_log
+
+    redacted = _redact_mcp_configs_for_log(
+        {
+            "dify__x": {
+                "transport": "http",
+                "url": "https://dify.example.com/mcp/server/secret-code/mcp",
+            }
+        }
+    )
+    assert redacted["dify__x"]["url"] == "https://dify.example.com/mcp/server/***/mcp"
+
+
+def test_custom_field_preview_redacts_secrets():
+    from octop.api.routers.connectors import _credentials_preview
+
+    weknora = _credentials_preview(
+        "weknora",
+        {
+            "base_url": "https://weknora.example.com/api/v1",
+            "api_key": "sk-secret",
+            "tenant_id": "tenant-1",
+            "knowledge_base_ids": ["kb-1"],
+        },
+    )
+    assert weknora == {
+        "base_url": "https://weknora.example.com/api/v1",
+        "api_key_configured": True,
+        "tenant_id": "tenant-1",
+        "knowledge_base_ids": ["kb-1"],
+    }
+    dify = _credentials_preview(
+        "dify",
+        {"mcp_url": "https://dify.example.com/mcp/server/secret-code/mcp"},
+    )
+    assert dify == {"mcp_url_configured": True}
+
+
+def test_gateway_weknora_tools_and_search(monkeypatch: pytest.MonkeyPatch):
+    from octop.infra.connectors.gateway.adapters import weknora
+
+    calls: list[tuple[str, str, dict[str, object] | None]] = []
+
+    def _fake_request(
+        _creds: dict[str, object],
+        method: str,
+        path: str,
+        *,
+        params: dict[str, object] | None = None,
+        body: dict[str, object] | None = None,
+    ) -> dict[str, object]:
+        calls.append((method, path, body))
+        if path == "/knowledge-bases":
+            return {"success": True, "data": [{"id": "kb-1", "name": "Docs"}]}
+        assert params == {"resource_urls": "handle"}
+        return {
+            "success": True,
+            "data": [
+                {
+                    "knowledge_id": "doc-1",
+                    "knowledge_title": "Guide",
+                    "chunk_index": 2,
+                    "score": 0.9,
+                    "content": "x" * 1300,
+                }
+            ],
+        }
+
+    monkeypatch.setattr(weknora, "_request", _fake_request)
+    listed = handle_mcp_request(
+        kind="weknora",
+        creds={"base_url": "http://127.0.0.1:8080/api/v1"},
+        body={"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {}},
+    )
+    assert [tool["name"] for tool in listed["result"]["tools"]] == [
+        "list_knowledge_bases",
+        "search",
+        "read_document",
+    ]
+    result = json.loads(
+        weknora.call_tool(
+            {"base_url": "http://127.0.0.1:8080/api/v1"},
+            "search",
+            {"query": "install"},
+        )
+    )
+    assert result["knowledge_base_ids"] == ["kb-1"]
+    assert len(result["passages"][0]["content"]) == 1200
+    assert result["passages"][0]["truncated"] is True
+    assert calls[-1][2] == {"query": "install", "knowledge_base_ids": ["kb-1"]}
+
+
+@pytest.mark.asyncio
+async def test_dify_probe_uses_streamable_http(monkeypatch: pytest.MonkeyPatch):
+    from octop.infra.connectors.probe import probe_connector
+
+    seen: dict[str, object] = {}
+
+    async def _probe(url: str, headers: dict[str, str], *, kind: str) -> dict[str, object]:
+        seen.update(url=url, headers=headers, kind=kind)
+        return {"ok": True, "tool_count": 1, "tools": [{"name": "run", "description": ""}]}
+
+    monkeypatch.setattr("octop.infra.connectors.probe.probe_streamable_http_mcp", _probe)
+    entry = get_catalog_entry("dify")
+    assert entry is not None
+    result = await probe_connector(
+        entry,
+        {"mcp_url": "https://dify.example.com/mcp/server/code/mcp"},
+        instance_id="probe",
+        config=OctopConfig(),
+    )
+    assert result["ok"] is True
+    assert seen == {
+        "url": "https://dify.example.com/mcp/server/code/mcp",
+        "headers": {"Accept": "application/json, text/event-stream"},
+        "kind": "dify",
+    }
+
+
+@pytest.mark.asyncio
+async def test_detect_local_weknora_uses_fixed_loopback(monkeypatch: pytest.MonkeyPatch):
+    import httpx
+
+    from octop.infra.connectors import probe
+
+    seen: list[str] = []
+    real_client = httpx.AsyncClient
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(str(request.url))
+        return httpx.Response(200, json={"status": "ok"})
+
+    def client_factory(**kwargs: object) -> httpx.AsyncClient:
+        kwargs.pop("trust_env", None)
+        return real_client(transport=httpx.MockTransport(handler), **kwargs)
+
+    monkeypatch.setattr(probe.httpx, "AsyncClient", client_factory)
+    result = await probe.detect_local_weknora()
+
+    assert result == {
+        "found": True,
+        "base_url": "http://127.0.0.1:8080/api/v1",
+        "console_url": "http://127.0.0.1",
+    }
+    assert seen == ["http://127.0.0.1:8080/health"]
+
+
+@pytest.mark.asyncio
+async def test_detect_local_weknora_returns_not_found_on_unhealthy_host(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    import httpx
+
+    from octop.infra.connectors import probe
+
+    real_client = httpx.AsyncClient
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(503, request=request)
+
+    def client_factory(**kwargs: object) -> httpx.AsyncClient:
+        kwargs.pop("trust_env", None)
+        return real_client(transport=httpx.MockTransport(handler), **kwargs)
+
+    monkeypatch.setattr(probe.httpx, "AsyncClient", client_factory)
+    assert await probe.detect_local_weknora() == {"found": False}
 
 
 def test_gateway_tools_list():


### PR DESCRIPTION
## 变更内容

- 新增 WeKnora 只读知识库连接器，提供知识库列表、检索与文档分块阅读工具。
- 新增 Dify Streamable HTTP MCP 接入，支持直接粘贴应用发布的 MCP Server URL。
- 增加声明式凭证字段、引导式接入、本机 WeKnora 检测、凭证脱敏与连接探测。
- Dashboard、普通对话、IM 与 Cron 复用现有连接器/MCP 注入链路。

## 安全边界

- WeKnora 工具保持只读，不包含上传、修改或删除操作。
- 仅允许 loopback 使用 HTTP；远程地址必须通过现有 SSRF/HTTPS 校验。
- API Key、Dify server code 等敏感信息不会进入日志预览。

## 验证

- 仓库 pre-commit 全部通过。
- 受影响测试：311 passed，188 deselected。
- Ruff、mypy、TypeScript、Prettier 与 Dashboard production build 通过。
- 使用本地 WeKnora Lite 私有知识库完成真实 probe 与知识库枚举验证。