### PR TITLE
fix(dashboard): 修复聊天页中文语音识别

### DIFF
--- a/dashboard/src/hooks/useVoiceInput.ts
+++ b/dashboard/src/hooks/useVoiceInput.ts
@@ -1,23 +1,41 @@
 import { useCallback, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { voiceApi, type ActiveVoice } from "../api/modules/voice";
+import { speechLocaleFromUi } from "../utils/localePrefs";
 import { cachedActiveVoice, fetchActiveVoice } from "./useVoiceConfig";
 
 import { message as antMessage } from "@/utils/antdMessage";
 
+interface BrowserSpeechRecognitionAlternative {
+  transcript?: string;
+}
+
+interface BrowserSpeechRecognitionResult {
+  isFinal: boolean;
+  length: number;
+  [index: number]: BrowserSpeechRecognitionAlternative;
+}
+
 interface BrowserSpeechRecognitionResultEvent {
-  results: ArrayLike<{ [index: number]: { transcript?: string } }>;
+  resultIndex: number;
+  results: ArrayLike<BrowserSpeechRecognitionResult> & { length: number };
+}
+
+interface BrowserSpeechRecognitionErrorEvent {
+  error?: string;
 }
 
 interface BrowserSpeechRecognition {
   lang: string;
+  continuous: boolean;
   interimResults: boolean;
   maxAlternatives: number;
   onresult: ((event: BrowserSpeechRecognitionResultEvent) => void) | null;
-  onerror: (() => void) | null;
+  onerror: ((event: BrowserSpeechRecognitionErrorEvent) => void) | null;
   onend: (() => void) | null;
   start: () => void;
   stop?: () => void;
+  abort?: () => void;
 }
 
 type SpeechRecognitionCtor = new () => BrowserSpeechRecognition;
@@ -49,6 +67,12 @@ function pickRecorderMimeType(): string {
   return "";
 }
 
+/**
+ * Native Web Speech API transcription.
+ *
+ * Important: settle only on `onend` / error / timeout. Resolving in `onresult`
+ * races Chrome's `onend` and often yields empty text for Chinese utterances.
+ */
 async function transcribeWithBrowser(language: string): Promise<string> {
   const Ctor = getSpeechRecognition();
   if (!Ctor) {
@@ -57,7 +81,11 @@ async function transcribeWithBrowser(language: string): Promise<string> {
   return new Promise((resolve, reject) => {
     const rec = new Ctor();
     let settled = false;
+    let finalText = "";
+    let interimText = "";
     let timer = 0;
+    let lastError: string | undefined;
+
     const settle = (fn: () => void) => {
       if (settled) return;
       settled = true;
@@ -67,23 +95,62 @@ async function transcribeWithBrowser(language: string): Promise<string> {
       rec.onend = null;
       fn();
     };
+
     rec.lang = language;
-    rec.interimResults = false;
+    rec.continuous = false;
+    rec.interimResults = true;
     rec.maxAlternatives = 1;
+
     rec.onresult = (event) => {
-      const text = event.results[0]?.[0]?.transcript?.trim() ?? "";
-      settle(() => resolve(text));
+      let finals = "";
+      let interim = "";
+      for (let i = event.resultIndex; i < event.results.length; i++) {
+        const result = event.results[i];
+        const piece = result?.[0]?.transcript ?? "";
+        if (result?.isFinal) finals += piece;
+        else interim += piece;
+      }
+      if (finals) finalText += finals;
+      interimText = interim;
     };
-    rec.onerror = () => settle(() => reject(new Error("browser STT failed")));
-    rec.onend = () => settle(() => resolve(""));
+
+    rec.onerror = (event) => {
+      lastError = event.error;
+      // no-speech / aborted: let onend resolve with whatever we have.
+      if (event.error === "no-speech" || event.error === "aborted") return;
+      settle(() => {
+        if (event.error === "network") {
+          reject(new Error("browser STT network"));
+          return;
+        }
+        reject(new Error(`browser STT failed: ${event.error ?? "unknown"}`));
+      });
+    };
+
+    rec.onend = () => {
+      const text = (finalText || interimText).trim();
+      settle(() => {
+        if (!text && lastError && lastError !== "no-speech" && lastError !== "aborted") {
+          reject(new Error(`browser STT failed: ${lastError}`));
+          return;
+        }
+        resolve(text);
+      });
+    };
+
     timer = window.setTimeout(() => {
       try {
         rec.stop?.();
       } catch {
         // Browser implementations differ; the timeout still settles below.
       }
-      settle(() => reject(new Error("browser STT timed out")));
+      settle(() => {
+        const text = (finalText || interimText).trim();
+        if (text) resolve(text);
+        else reject(new Error("browser STT timed out"));
+      });
     }, BROWSER_STT_TIMEOUT_MS);
+
     try {
       rec.start();
     } catch (err) {
@@ -102,17 +169,19 @@ export function canRecordAudio(): boolean {
 /** Check whether any STT method is available. */
 export function isSttAvailable(): boolean {
   if (canRecordAudio()) return true; // server STT via MediaRecorder
-  return browserSttAvailable(); // browser STT (Android Chrome only)
+  return browserSttAvailable(); // browser STT (Chrome / Edge)
 }
 
 export function useVoiceInput(onText: (text: string) => void) {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const [recording, setRecording] = useState(false);
   const [transcribing, setTranscribing] = useState(false);
   const mediaRecorderRef = useRef<MediaRecorder | null>(null);
   const chunksRef = useRef<Blob[]>([]);
 
-  const language = navigator.language || "zh-CN";
+  // Follow dashboard UI locale — not navigator.language (often en-US on
+  // machines used with Chinese UI / Chinese speech).
+  const language = speechLocaleFromUi(i18n.language);
 
   const stopRecording = useCallback(async () => {
     const recorder = mediaRecorderRef.current;
@@ -136,37 +205,24 @@ export function useVoiceInput(onText: (text: string) => void) {
     setTranscribing(true);
     try {
       const active = await fetchActiveVoice();
-      let text = "";
-      if (active.stt === "browser" && browserSttAvailable()) {
-        text = await transcribeWithBrowser(language);
-      } else {
-        try {
-          const result = await voiceApi.transcribe(blob, language);
-          text = result.text?.trim() ?? "";
-        } catch (err) {
-          const msg = err instanceof Error ? err.message : "";
-          if (msg.includes("VOICE_BROWSER_ONLY") || msg.includes("422")) {
-            if (browserSttAvailable()) {
-              text = await transcribeWithBrowser(language);
-            } else {
-              antMessage.error(t("voice.sttProviderRequired"));
-              return;
-            }
-          } else {
-            // Server STT failed — try browser fallback if available.
-            if (browserSttAvailable()) {
-              antMessage.warning(t("voice.sttFallback"));
-              text = await transcribeWithBrowser(language);
-            } else {
-              throw err;
-            }
-          }
-        }
+      // SpeechRecognition cannot consume a recorded blob. If STT is still
+      // "browser", ask the user to configure a server provider (or use the
+      // click-to-talk browser path from a cold start).
+      if (active.stt === "browser") {
+        antMessage.error(t("voice.sttProviderRequired"));
+        return;
       }
+      const result = await voiceApi.transcribe(blob, language);
+      const text = result.text?.trim() ?? "";
       if (text) onText(text);
       else antMessage.info(t("voice.sttEmpty"));
-    } catch {
-      antMessage.error(t("voice.sttFailed"));
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "";
+      if (msg.includes("VOICE_BROWSER_ONLY") || msg.includes("422")) {
+        antMessage.error(t("voice.sttProviderRequired"));
+      } else {
+        antMessage.error(t("voice.sttFailed"));
+      }
     } finally {
       setTranscribing(false);
     }
@@ -183,6 +239,13 @@ export function useVoiceInput(onText: (text: string) => void) {
         const text = await transcribeWithBrowser(language);
         if (text) onText(text);
         else antMessage.info(t("voice.sttEmpty"));
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : "";
+        if (msg.includes("network")) {
+          antMessage.error(t("voice.sttNetworkFailed"));
+        } else {
+          antMessage.error(t("voice.sttFailed"));
+        }
       } finally {
         setTranscribing(false);
       }

--- a/dashboard/src/locales/en.json
+++ b/dashboard/src/locales/en.json
@@ -2139,6 +2139,7 @@
     "sttFailed": "Speech recognition failed",
     "sttFallback": "Server STT failed — switched to browser recognition",
     "sttProviderRequired": "This browser does not support native speech recognition. Configure Tencent Cloud or OpenAI STT.",
+    "sttNetworkFailed": "Browser speech recognition could not reach the network (often Google). Configure Tencent Cloud, Xiaomi Mimo, or OpenAI STT under Settings → Voice.",
     "ttsFailed": "Text-to-speech failed",
     "nothingToRead": "No readable prose in this message (code blocks are skipped)",
     "browserNoChineseVoice": "Chrome has no Chinese voice — using Edge TTS instead",

--- a/dashboard/src/locales/zh.json
+++ b/dashboard/src/locales/zh.json
@@ -2139,6 +2139,7 @@
     "sttFailed": "语音识别失败",
     "sttFallback": "服务端识别失败，已切换浏览器识别",
     "sttProviderRequired": "当前浏览器不支持原生语音识别，请配置腾讯云或 OpenAI STT",
+    "sttNetworkFailed": "浏览器语音识别无法联网（常依赖 Google）。请在设置 → 语音服务中配置腾讯云、小米 Mimo 或 OpenAI STT",
     "ttsFailed": "语音合成失败",
     "nothingToRead": "没有可朗读的正文（代码块等内容已跳过）",
     "browserNoChineseVoice": "Chrome 没有中文语音，已改用 Edge TTS 朗读",

--- a/dashboard/src/utils/localePrefs.test.ts
+++ b/dashboard/src/utils/localePrefs.test.ts
@@ -3,6 +3,7 @@ import {
   detectBrowserLocale,
   readStoredUiLocale,
   resolveInitialLocale,
+  speechLocaleFromUi,
   storeUiLocale,
   UI_LOCALE_STORAGE_KEY,
 } from "./localePrefs";
@@ -39,5 +40,13 @@ describe("localePrefs", () => {
     expect(readStoredUiLocale()).toBe("zh");
     localStorage.removeItem(UI_LOCALE_STORAGE_KEY);
     expect(resolveInitialLocale()).toBe("en");
+  });
+
+  it("speechLocaleFromUi maps UI locale to STT BCP-47 tags", () => {
+    expect(speechLocaleFromUi("zh")).toBe("zh-CN");
+    expect(speechLocaleFromUi("zh-CN")).toBe("zh-CN");
+    expect(speechLocaleFromUi("en")).toBe("en-US");
+    expect(speechLocaleFromUi("en-US")).toBe("en-US");
+    expect(speechLocaleFromUi(null)).toBe("zh-CN");
   });
 });

--- a/dashboard/src/utils/localePrefs.ts
+++ b/dashboard/src/utils/localePrefs.ts
@@ -56,3 +56,8 @@ export function syncDocumentLang(locale: UiLocale): void {
   if (typeof document === "undefined") return;
   document.documentElement.lang = locale === "zh" ? "zh-CN" : "en";
 }
+
+/** BCP-47 tag for STT / SpeechRecognition from dashboard UI locale. */
+export function speechLocaleFromUi(locale: string | null | undefined): string {
+  return normalizeUiLocale(locale) === "zh" ? "zh-CN" : "en-US";
+}


### PR DESCRIPTION
## Summary
- STT 语言跟随仪表盘 UI 语言（中文界面用 `zh-CN`），不再使用常为 `en-US` 的 `navigator.language`
- 修复浏览器 SpeechRecognition 在 `onend` 抢先结算导致中文结果为空的竞态
- 网络失败时提示配置服务端 STT（国内 Chrome 常依赖 Google）

## Test plan
- [ ] `cd dashboard && npx vitest run src/utils/localePrefs.test.ts`
- [ ] 仪表盘语言为中文时，强制刷新后用麦克风说中文，应正确填入输入框
- [ ] 未配置服务端 STT 且浏览器网络失败时，应看到联网失败提示
- [ ] 配置腾讯云 / Mimo / OpenAI STT 后，录音识别中文正常


Made with [Cursor](https://cursor.com)