### PR TITLE
feat(chat): integrate ask-user-question HITL flow

### DIFF
--- a/dashboard/src/api/types/hitl.ts
+++ b/dashboard/src/api/types/hitl.ts
@@ -14,3 +14,59 @@ export interface HitlPendingPayload {
   action_requests: HitlActionRequest[];
   review_configs?: HitlReviewConfig[];
 }
+
+/** Tool whose HITL pause is a question for the user, not an approval. */
+export const ASK_USER_TOOL_NAME = "ask_user_question";
+
+export interface AskOption {
+  label: string;
+  description?: string;
+}
+
+export interface AskQuestion {
+  question: string;
+  header?: string;
+  options?: AskOption[];
+  multi_select?: boolean;
+}
+
+/** Extract the `questions` payload from an `ask_user_question` pause. */
+export function extractAskQuestions(
+  actions: HitlActionRequest[] | undefined,
+): AskQuestion[] {
+  if (!actions?.length) return [];
+  for (const action of actions) {
+    if (action.name !== ASK_USER_TOOL_NAME) continue;
+    const raw = action.args?.questions;
+    if (!Array.isArray(raw)) continue;
+    return raw
+      .filter((item): item is Record<string, unknown> =>
+        Boolean(item && typeof item === "object" && !Array.isArray(item)),
+      )
+      .map((item) => ({
+        question: typeof item.question === "string" ? item.question : "",
+        header: typeof item.header === "string" ? item.header : undefined,
+        multi_select: item.multi_select === true,
+        options: Array.isArray(item.options)
+          ? item.options
+              .filter((opt): opt is Record<string, unknown> =>
+                Boolean(opt && typeof opt === "object" && !Array.isArray(opt)),
+              )
+              .map((opt) => ({
+                label: typeof opt.label === "string" ? opt.label : "",
+                description:
+                  typeof opt.description === "string"
+                    ? opt.description
+                    : undefined,
+              }))
+              .filter((opt) => opt.label)
+          : [],
+      }))
+      .filter((q) => q.question);
+  }
+  return [];
+}
+
+export function isAskHitl(actions: HitlActionRequest[] | undefined): boolean {
+  return Boolean(actions?.some((a) => a.name === ASK_USER_TOOL_NAME));
+}

--- a/dashboard/src/locales/en.json
+++ b/dashboard/src/locales/en.json
@@ -1159,6 +1159,22 @@
       "rejectedLabel": "Rejected",
       "rejected": "Rejected by user"
     },
+    "ask": {
+      "title": "A few questions first",
+      "other": "Something else…",
+      "freeTextPlaceholder": "Type your answer",
+      "next": "Next",
+      "review": "Review & send",
+      "reviewTag": "Review",
+      "back": "Back",
+      "submit": "Send answers",
+      "skip": "You decide",
+      "skipMessage": "You decide — pick the best default and tell me what you assumed.",
+      "answered": "Answered",
+      "answeredSummary": "Answered {{count}} question(s)",
+      "dismissedSummary": "Closed {{count}} question(s)",
+      "expand": "View"
+    },
     "modifiedFiles": "Modified files ({{count}})",
     "openBrowser": "View browser",
     "openBrowserHint": "Agent is browsing the web",
@@ -1231,6 +1247,7 @@
     "mobile_handoff_to_user": "Hand off to user (mobile)",
     "read_env_file": "Read env file",
     "write_env_file": "Write env file",
+    "ask_user_question": "Ask the user",
     "generate_image": "Generate image",
     "generate_video": "Generate video"
   },
@@ -1250,6 +1267,7 @@
     "categories": {
       "filesystem": "Files & shell",
       "orchestration": "Planning & sub-agents",
+      "interaction": "User interaction",
       "web": "Web & browser",
       "media": "Media generation",
       "memory": "Memory",

--- a/dashboard/src/locales/zh.json
+++ b/dashboard/src/locales/zh.json
@@ -1159,6 +1159,22 @@
       "rejectedLabel": "已拒绝",
       "rejected": "用户已拒绝"
     },
+    "ask": {
+      "title": "先问几个问题",
+      "other": "其他…",
+      "freeTextPlaceholder": "输入你的答案",
+      "next": "下一个",
+      "review": "确认并提交",
+      "reviewTag": "回顾",
+      "back": "返回",
+      "submit": "提交回答",
+      "skip": "你决定",
+      "skipMessage": "你决定吧——按最优默认方案继续，并告诉我你依据的假设。",
+      "answered": "已回答",
+      "answeredSummary": "已回答 {{count}} 个问题",
+      "dismissedSummary": "已关闭 {{count}} 个问题",
+      "expand": "查看"
+    },
     "modifiedFiles": "已修改文件（{{count}}）",
     "openBrowser": "查看浏览器",
     "openBrowserHint": "Agent 正在网页中操作",
@@ -1231,6 +1247,7 @@
     "mobile_handoff_to_user": "交给用户操作（手机）",
     "read_env_file": "读取环境变量",
     "write_env_file": "写入环境变量",
+    "ask_user_question": "向你提问",
     "generate_image": "生成图片",
     "generate_video": "生成视频"
   },
@@ -1250,6 +1267,7 @@
     "categories": {
       "filesystem": "文件与终端",
       "orchestration": "规划与子智能体",
+      "interaction": "用户交互",
       "web": "网页与浏览器",
       "media": "媒体生成",
       "memory": "记忆",

--- a/dashboard/src/pages/Agent/Tools/ToolsPanel.tsx
+++ b/dashboard/src/pages/Agent/Tools/ToolsPanel.tsx
@@ -55,6 +55,7 @@ import styles from "./ToolsPanel.module.less";
 const CATEGORY_ORDER = [
   "filesystem",
   "orchestration",
+  "interaction",
   "web",
   "media",
   "memory",
@@ -70,6 +71,7 @@ const CATEGORY_ORDER = [
 const CATEGORY_ACCENT: Record<string, string> = {
   filesystem: "#3B82F6",
   orchestration: "#8B5CF6",
+  interaction: "#14B8A6",
   web: "#22C55E",
   media: "#EC4899",
   memory: "#F59E0B",

--- a/dashboard/src/pages/Chat/chatInputCore.partial.less
+++ b/dashboard/src/pages/Chat/chatInputCore.partial.less
@@ -18,6 +18,22 @@
   }
 }
 
+.askQuestionDock {
+  flex-shrink: 0;
+  padding: 0 20px 8px;
+  background: var(--fn-bg-elevated, #fff);
+
+  @media (max-width: 767px) {
+    padding: 0 12px 6px;
+  }
+}
+
+.askQuestionDockInner {
+  width: 100%;
+  max-width: var(--chat-column-max, 960px);
+  margin: 0 auto;
+}
+
 .chatInput {
   flex-shrink: 0;
   padding: 16px 24px 20px;

--- a/dashboard/src/pages/Chat/components/AskQuestionCard.module.less
+++ b/dashboard/src/pages/Chat/components/AskQuestionCard.module.less
@@ -1,0 +1,342 @@
+.card {
+  border: 1px solid var(--fn-border-primary);
+  border-radius: var(--fn-radius-lg);
+  padding: 14px 16px;
+  background: var(--fn-bg-primary);
+  box-shadow: var(--fn-shadow-xs);
+  box-sizing: border-box;
+  width: 100%;
+  max-width: var(--chat-column-max, 960px);
+}
+
+.titleRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+
+.title {
+  font-weight: 600;
+  font-size: 14px;
+  color: var(--fn-text-primary);
+}
+
+.progress {
+  padding: 2px 8px;
+  border: 1px solid var(--fn-border-secondary);
+  border-radius: var(--fn-radius-full);
+  background: var(--fn-bg-secondary);
+  font-size: 12px;
+  line-height: 18px;
+  color: var(--fn-text-tertiary);
+  font-variant-numeric: tabular-nums;
+}
+
+.steps {
+  max-height: min(420px, 42vh);
+  overflow-y: auto;
+}
+
+.block {
+  padding: 4px 0 14px;
+}
+
+.questionRow {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 8px;
+  align-items: baseline;
+}
+
+.qIndex {
+  color: var(--fn-text-tertiary);
+  font-variant-numeric: tabular-nums;
+  flex-shrink: 0;
+}
+
+.qText {
+  font-weight: 500;
+  line-height: 1.5;
+  color: var(--fn-text-primary);
+}
+
+.qHeader {
+  color: var(--fn-text-secondary);
+  font-weight: 400;
+}
+
+.options {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding-left: 20px;
+}
+
+.option {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  text-align: left;
+  min-height: 42px;
+  padding: 9px 11px;
+  border: 1px solid var(--fn-border-primary);
+  border-radius: var(--fn-radius-md);
+  background: var(--fn-bg-primary);
+  color: var(--fn-text-primary);
+  cursor: pointer;
+  transition:
+    border-color var(--fn-transition-fast),
+    background var(--fn-transition-fast),
+    box-shadow var(--fn-transition-fast),
+    transform var(--fn-transition-fast);
+
+  &:hover:not(:disabled) {
+    border-color: var(--fn-color-brand);
+    background: var(--fn-bg-hover);
+    box-shadow: var(--fn-shadow-xs);
+    transform: translateY(-1px);
+  }
+
+  &:active:not(:disabled) {
+    transform: scale(0.99);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--fn-color-brand);
+    outline-offset: 2px;
+  }
+
+  &:disabled {
+    cursor: default;
+  }
+}
+
+.selected {
+  border-color: var(--fn-color-brand);
+  background: var(--fn-color-brand-bg);
+}
+
+.key {
+  flex-shrink: 0;
+  width: 18px;
+  height: 18px;
+  border-radius: 4px;
+  border: 1px solid var(--fn-border-primary);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--fn-text-secondary);
+  margin-top: 1px;
+}
+
+.selected .key {
+  border-color: var(--fn-color-brand);
+  color: var(--fn-color-on-brand);
+  background: var(--fn-color-brand);
+}
+
+.optionBody {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.optionLabel {
+  font-weight: 500;
+  line-height: 1.4;
+}
+
+.optionDesc {
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--fn-text-tertiary);
+}
+
+.freeText {
+  margin-top: 6px;
+
+  &:global(.octop-input) {
+    border-color: var(--fn-border-input);
+    border-radius: var(--fn-radius-md);
+    background: var(--fn-bg-primary);
+
+    &:focus,
+    &:focus-within {
+      border-color: var(--fn-color-brand);
+      box-shadow: 0 0 0 2px var(--fn-color-brand-glow);
+    }
+  }
+}
+
+.doneAnswer {
+  padding-left: 20px;
+  font-size: 13px;
+  color: var(--fn-text-secondary);
+  line-height: 1.5;
+}
+
+.actions {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 6px;
+  padding-top: 12px;
+  border-top: 1px solid var(--fn-border-secondary);
+}
+
+.actionButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 68px;
+  height: 34px;
+  padding: 0 15px;
+  border: 1px solid transparent;
+  border-radius: var(--fn-radius-md);
+  font: inherit;
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 1;
+  cursor: pointer;
+  transition:
+    color var(--fn-transition-fast),
+    background var(--fn-transition-fast),
+    border-color var(--fn-transition-fast),
+    box-shadow var(--fn-transition-fast),
+    transform var(--fn-transition-fast);
+
+  &:active:not(:disabled) {
+    transform: scale(0.97);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--fn-color-brand);
+    outline-offset: 2px;
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.4;
+  }
+}
+
+.primaryAction {
+  color: var(--fn-color-on-brand);
+  background: var(--fn-color-brand);
+  border-color: var(--fn-color-brand);
+  box-shadow: 0 1px 2px var(--fn-color-brand-shadow);
+
+  &:hover:not(:disabled) {
+    background: var(--fn-color-brand-hover);
+    border-color: var(--fn-color-brand-hover);
+    box-shadow: var(--fn-shadow-brand);
+  }
+}
+
+.secondaryAction {
+  color: var(--fn-text-secondary);
+  background: var(--fn-bg-primary);
+  border-color: var(--fn-border-primary);
+
+  &:hover:not(:disabled) {
+    color: var(--fn-text-brand);
+    background: var(--fn-bg-hover);
+    border-color: var(--fn-color-brand-border);
+  }
+}
+
+.skipAction {
+  margin-left: auto;
+  min-width: auto;
+  padding-inline: 10px;
+  color: var(--fn-text-tertiary);
+  background: transparent;
+
+  &:hover:not(:disabled) {
+    color: var(--fn-text-secondary);
+    background: var(--fn-bg-secondary);
+  }
+}
+
+.completedCard {
+  padding: 0;
+  border-color: transparent;
+  background: transparent;
+  box-shadow: none;
+}
+
+.completedSummary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 8px 10px;
+  border: 1px solid var(--fn-border-secondary);
+  border-radius: var(--fn-radius-md);
+  color: var(--fn-text-secondary);
+  background: var(--fn-bg-secondary);
+  cursor: pointer;
+  list-style: none;
+  font-size: 13px;
+
+  &::-webkit-details-marker {
+    display: none;
+  }
+
+  &::before {
+    content: "›";
+    flex-shrink: 0;
+    color: var(--fn-text-tertiary);
+    transition: transform 0.15s ease;
+  }
+}
+
+.completedCard[open] .completedSummary::before {
+  transform: rotate(90deg);
+}
+
+.completedStatus {
+  flex: 1;
+  min-width: 0;
+  font-weight: 500;
+}
+
+.expandHint {
+  flex-shrink: 0;
+  font-size: 12px;
+  color: var(--fn-text-tertiary);
+}
+
+.completedQuestions {
+  margin-top: 6px;
+  padding: 10px 12px 0;
+  border-left: 2px solid var(--fn-border-primary);
+}
+
+@media (max-width: 767px) {
+  .card {
+    padding: 12px;
+  }
+
+  .options,
+  .doneAnswer {
+    padding-left: 0;
+  }
+
+  .option {
+    min-height: 44px;
+  }
+
+  .actions {
+    gap: 6px;
+  }
+
+  .actionButton {
+    height: 36px;
+    padding-inline: 13px;
+  }
+}

--- a/dashboard/src/pages/Chat/components/AskQuestionCard.test.tsx
+++ b/dashboard/src/pages/Chat/components/AskQuestionCard.test.tsx
@@ -1,0 +1,96 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import AskQuestionCard from "./AskQuestionCard";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+const questions = [
+  {
+    header: "Framework",
+    question: "Which framework?",
+    options: [{ label: "React" }, { label: "Vue" }],
+  },
+  {
+    header: "Database",
+    question: "Which databases?",
+    multi_select: true,
+    options: [{ label: "PostgreSQL" }, { label: "Redis" }],
+  },
+];
+
+describe("AskQuestionCard", () => {
+  it("shows exactly one question at a time", () => {
+    render(
+      <AskQuestionCard
+        questions={questions}
+        status="pending"
+        onSubmit={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Which framework?")).toBeInTheDocument();
+    expect(screen.queryByText("Which databases?")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /React/ }));
+
+    expect(screen.queryByText("Which framework?")).not.toBeInTheDocument();
+    expect(screen.getByText("Which databases?")).toBeInTheDocument();
+  });
+
+  it("collects all answers before submitting once", () => {
+    const onSubmit = vi.fn();
+    render(
+      <AskQuestionCard
+        questions={questions}
+        status="pending"
+        onSubmit={onSubmit}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /React/ }));
+    fireEvent.click(screen.getByRole("button", { name: /PostgreSQL/ }));
+    fireEvent.click(screen.getByRole("button", { name: "chat.ask.review" }));
+
+    expect(screen.getByText("Which framework?")).toBeInTheDocument();
+    expect(screen.getByText("Which databases?")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "chat.ask.submit" }));
+    expect(onSubmit).toHaveBeenCalledWith(
+      "Framework: React\nDatabase: PostgreSQL",
+    );
+  });
+
+  it("renders open-ended questions as a text field directly", () => {
+    render(
+      <AskQuestionCard
+        questions={[{ question: "Anything else?" }]}
+        status="pending"
+        onSubmit={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByPlaceholderText("chat.ask.freeTextPlaceholder"),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("chat.ask.other")).not.toBeInTheDocument();
+  });
+
+  it("collapses an answered question set in message history", () => {
+    const { container } = render(
+      <AskQuestionCard questions={questions} status="approved" />,
+    );
+
+    const details = container.querySelector("details");
+    expect(details).not.toHaveAttribute("open");
+    expect(screen.getByText("chat.ask.answeredSummary")).toBeInTheDocument();
+    expect(screen.queryByText("Which framework?")).not.toBeVisible();
+
+    fireEvent.click(container.querySelector("summary")!);
+    expect(details).toHaveAttribute("open");
+    expect(screen.getByText("Which framework?")).toBeVisible();
+  });
+});

--- a/dashboard/src/pages/Chat/components/AskQuestionCard.tsx
+++ b/dashboard/src/pages/Chat/components/AskQuestionCard.tsx
@@ -1,0 +1,320 @@
+import { useState } from "react";
+import { Input } from "antd";
+import { useTranslation } from "react-i18next";
+import type { AskQuestion } from "../../../api/types/hitl";
+import styles from "./AskQuestionCard.module.less";
+
+const { TextArea } = Input;
+
+/** Sentinel choice that reveals the free-text input for a question. */
+const OTHER = "__other__";
+
+const OPTION_KEYS = ["A", "B", "C", "D", "E", "F"] as const;
+
+export interface AskQuestionCardProps {
+  questions: AskQuestion[];
+  status: "pending" | "approved" | "rejected";
+  onSubmit?: (message: string) => void;
+}
+
+/** What the user picked for one question. */
+type Answer = { picked: string[]; other: string };
+
+/** Resolve one question's answer to display text, or `null` when unanswered. */
+function answerText(question: AskQuestion, answer: Answer): string | null {
+  const labels = answer.picked.filter((v) => v !== OTHER);
+  const wantsOther = answer.picked.includes(OTHER) || !question.options?.length;
+  const other = answer.other.trim();
+  if (wantsOther && other) labels.push(other);
+  if (!labels.length) return null;
+  return labels.join("; ");
+}
+
+interface QuestionCardProps {
+  question: AskQuestion;
+  index: number;
+  /** Stepped flow state for this question. */
+  state: "done" | "current";
+  answer: Answer;
+  onAnswer: (answer: Answer, changed: string) => void;
+}
+
+function QuestionCard({
+  question,
+  index,
+  state,
+  answer,
+  onAnswer,
+}: QuestionCardProps) {
+  const { t } = useTranslation();
+  const options = question.options ?? [];
+  const done = state === "done";
+  const interactive = state === "current";
+  const openEnded = options.length === 0;
+  const hasOther = openEnded || answer.picked.includes(OTHER);
+
+  const toggle = (label: string) => {
+    if (!interactive) return;
+    if (question.multi_select) {
+      const picked = answer.picked.includes(label)
+        ? answer.picked.filter((v) => v !== label)
+        : [...answer.picked, label];
+      onAnswer({ ...answer, picked }, label);
+    } else {
+      onAnswer({ ...answer, picked: [label] }, label);
+    }
+  };
+
+  const confirmed = answerText(question, answer);
+
+  return (
+    <div className={styles.block}>
+      <div className={styles.questionRow}>
+        <span className={styles.qIndex}>{index + 1}.</span>
+        <span className={styles.qText}>
+          {question.header ? (
+            <span className={styles.qHeader}>{question.header} · </span>
+          ) : null}
+          {question.question}
+        </span>
+      </div>
+
+      {done && confirmed !== null ? (
+        <div className={styles.doneAnswer}>{confirmed}</div>
+      ) : (
+        <div
+          className={`${styles.options} ${interactive ? "" : styles.locked}`}
+        >
+          {options.map((option, optionIndex) => {
+            const key = OPTION_KEYS[optionIndex] ?? String(optionIndex + 1);
+            const selected = answer.picked.includes(option.label);
+            return (
+              <button
+                key={option.label}
+                type="button"
+                className={`${styles.option} ${
+                  selected ? styles.selected : ""
+                }`}
+                disabled={!interactive}
+                onClick={() => toggle(option.label)}
+              >
+                <span className={styles.key}>{key}</span>
+                <span className={styles.optionBody}>
+                  <span className={styles.optionLabel}>{option.label}</span>
+                  {option.description ? (
+                    <span className={styles.optionDesc}>
+                      {option.description}
+                    </span>
+                  ) : null}
+                </span>
+              </button>
+            );
+          })}
+          {!openEnded ? (
+            <button
+              type="button"
+              className={`${styles.option} ${hasOther ? styles.selected : ""}`}
+              disabled={!interactive}
+              onClick={() => toggle(OTHER)}
+            >
+              <span className={styles.key}>
+                {options.length < OPTION_KEYS.length
+                  ? OPTION_KEYS[options.length]
+                  : ""}
+              </span>
+              <span className={styles.optionBody}>
+                <span className={styles.optionLabel}>
+                  {t("chat.ask.other")}
+                </span>
+              </span>
+            </button>
+          ) : null}
+          {interactive && hasOther ? (
+            <TextArea
+              className={styles.freeText}
+              autoSize={{ minRows: 1, maxRows: 4 }}
+              value={answer.other}
+              placeholder={t("chat.ask.freeTextPlaceholder")}
+              onChange={(e) =>
+                onAnswer({ ...answer, other: e.target.value }, OTHER)
+              }
+            />
+          ) : null}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function AskQuestionCard({
+  questions,
+  status,
+  onSubmit,
+}: AskQuestionCardProps) {
+  const { t } = useTranslation();
+  const interactive = status === "pending" && Boolean(onSubmit);
+  const [answers, setAnswers] = useState<Answer[]>(() =>
+    questions.map(() => ({ picked: [], other: "" })),
+  );
+  const [current, setCurrent] = useState(0);
+  const [reviewing, setReviewing] = useState(false);
+
+  const total = questions.length;
+  const resolved = questions.map((q, i) => answerText(q, answers[i]));
+  const currentAnswer = resolved[current];
+  const isLast = current === total - 1;
+
+  if (total === 0) return null;
+
+  if (!interactive) {
+    return (
+      <details className={`${styles.card} ${styles.completedCard}`}>
+        <summary className={styles.completedSummary}>
+          <span className={styles.completedStatus}>
+            {status === "approved"
+              ? t("chat.ask.answeredSummary", { count: questions.length })
+              : t("chat.ask.dismissedSummary", { count: questions.length })}
+          </span>
+          <span className={styles.expandHint}>{t("chat.ask.expand")}</span>
+        </summary>
+        <div className={styles.completedQuestions}>
+          {questions.map((question, index) => (
+            <div key={index} className={styles.block}>
+              <div className={styles.questionRow}>
+                <span className={styles.qIndex}>{index + 1}.</span>
+                <span className={styles.qText}>{question.question}</span>
+              </div>
+            </div>
+          ))}
+        </div>
+      </details>
+    );
+  }
+
+  const advance = () => {
+    if (isLast) {
+      setReviewing(true);
+    } else {
+      setCurrent((c) => c + 1);
+    }
+  };
+
+  const submit = () => {
+    if (!onSubmit || resolved.some((text) => text === null)) return;
+    const body = questions
+      .map((q, i) => {
+        const head = q.header?.trim() || q.question;
+        return `${head}: ${resolved[i]}`;
+      })
+      .join("\n");
+    onSubmit(body);
+  };
+
+  const skip = () => {
+    onSubmit?.(t("chat.ask.skipMessage"));
+  };
+
+  const setAnswerAt = (index: number, answer: Answer, changed: string) => {
+    setAnswers((prev) => prev.map((a, i) => (i === index ? answer : a)));
+    // Single-select: picking a preset option is a commitment, so advance
+    // straight to the next question. Multi-select needs explicit confirmation
+    // to know when the user is done toggling; "other" needs free text.
+    const question = questions[index];
+    if (!question.multi_select && changed !== OTHER) {
+      if (index === total - 1) {
+        setReviewing(true);
+      } else {
+        setCurrent((c) => c + 1);
+      }
+    }
+  };
+
+  return (
+    <div className={styles.card}>
+      <div className={styles.titleRow}>
+        <span className={styles.title}>{t("chat.ask.title")}</span>
+        <span className={styles.progress}>
+          {reviewing ? t("chat.ask.reviewTag") : `${current + 1} / ${total}`}
+        </span>
+      </div>
+
+      <div className={styles.steps}>
+        {reviewing ? (
+          questions.map((question, index) => (
+            <QuestionCard
+              key={index}
+              question={question}
+              index={index}
+              state="done"
+              answer={answers[index]}
+              onAnswer={(answer, changed) =>
+                setAnswerAt(index, answer, changed)
+              }
+            />
+          ))
+        ) : (
+          <QuestionCard
+            key={current}
+            question={questions[current]}
+            index={current}
+            state="current"
+            answer={answers[current]}
+            onAnswer={(answer, changed) =>
+              setAnswerAt(current, answer, changed)
+            }
+          />
+        )}
+      </div>
+
+      <div className={styles.actions}>
+        {reviewing ? (
+          <>
+            <button
+              type="button"
+              className={`${styles.actionButton} ${styles.primaryAction}`}
+              onClick={submit}
+            >
+              {t("chat.ask.submit")}
+            </button>
+            <button
+              type="button"
+              className={`${styles.actionButton} ${styles.secondaryAction}`}
+              onClick={() => setReviewing(false)}
+            >
+              {t("chat.ask.back")}
+            </button>
+          </>
+        ) : (
+          <>
+            <button
+              type="button"
+              className={`${styles.actionButton} ${styles.primaryAction}`}
+              disabled={currentAnswer === null}
+              onClick={advance}
+            >
+              {isLast ? t("chat.ask.review") : t("chat.ask.next")}
+            </button>
+            {current > 0 ? (
+              <button
+                type="button"
+                className={`${styles.actionButton} ${styles.secondaryAction}`}
+                onClick={() => setCurrent((value) => value - 1)}
+              >
+                {t("chat.ask.back")}
+              </button>
+            ) : null}
+            <button
+              type="button"
+              className={`${styles.actionButton} ${styles.skipAction}`}
+              onClick={skip}
+            >
+              {t("chat.ask.skip")}
+            </button>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default AskQuestionCard;

--- a/dashboard/src/pages/Chat/components/MessageBubble.tsx
+++ b/dashboard/src/pages/Chat/components/MessageBubble.tsx
@@ -38,6 +38,8 @@ import {
   isChatStreamError,
 } from "../../../utils/chatStreamError";
 import { MessageFileCard } from "./MessageFileCard";
+import AskQuestionCard from "./AskQuestionCard";
+import { extractAskQuestions, isAskHitl } from "../../../api/types/hitl";
 import styles from "../index.module.less";
 import {
   DefaultToolRenderer,
@@ -582,6 +584,32 @@ function MessageBubble({
   if (message.hitlData) {
     const actions = message.hitlData.action_requests ?? [];
     const hitlStatus = message.hitlData.status ?? "pending";
+    if (isAskHitl(actions)) {
+      // Pending questions are rendered in ChatPage's composer dock so they
+      // stay immediately above the input even when message history scrolls.
+      if (hitlStatus === "pending") return null;
+      const questions = extractAskQuestions(actions);
+      return (
+        <div
+          className={`${styles.bubble} ${styles.assistantBubble} ${
+            compact ? styles.compact : ""
+          }`}
+        >
+          <AskQuestionCard
+            questions={questions}
+            status={hitlStatus}
+            onSubmit={
+              onHitlDecision
+                ? (answer) =>
+                    onHitlDecision(
+                      actions.map(() => ({ type: "respond", message: answer })),
+                    )
+                : undefined
+            }
+          />
+        </div>
+      );
+    }
     return (
       <div
         className={`${styles.bubble} ${styles.assistantBubble} ${

--- a/dashboard/src/pages/Chat/hooks/chatStore.hitlResume.test.ts
+++ b/dashboard/src/pages/Chat/hooks/chatStore.hitlResume.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getSnapshot, removeSession, resumeHitl } from "./chatStore";
+
+vi.mock("../../../api/config", () => ({
+  getApiUrl: (path: string) => `/api${path}`,
+}));
+
+const SESSION = "test-hitl-resume";
+
+describe("resumeHitl", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    removeSession(SESSION);
+  });
+
+  it("renders resumed tokens and notifies after the completed stream", async () => {
+    const body = [
+      'event: chunk\ndata: {"type":"token","content":"completed answer"}\n\n',
+      'event: chunk\ndata: {"type":"done"}\n\n',
+    ].join("");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(body, {
+          status: 200,
+          headers: { "Content-Type": "text/event-stream" },
+        }),
+      ),
+    );
+    const onStreamEnd = vi.fn();
+
+    await resumeHitl(
+      SESSION,
+      "agent-1",
+      "thread-1",
+      [{ type: "respond", message: "answer" }],
+      onStreamEnd,
+    );
+
+    expect(getSnapshot(SESSION).messages.at(-1)?.content).toBe(
+      "completed answer",
+    );
+    expect(getSnapshot(SESSION).isStreaming).toBe(false);
+    expect(onStreamEnd).toHaveBeenCalledOnce();
+  });
+});

--- a/dashboard/src/pages/Chat/hooks/chatStore.ts
+++ b/dashboard/src/pages/Chat/hooks/chatStore.ts
@@ -2138,11 +2138,7 @@ async function consumeSseResponse(
       const chunk = parseHarnessChunk(line);
       if (!chunk) continue;
       handleHarnessChunk(state, chunk, sessionId);
-      if (
-        chunk.type === "done" ||
-        chunk.type === "error" ||
-        chunk.type === "hitl_required"
-      ) {
+      if (chunk.type === "done" || chunk.type === "error") {
         controller.abort();
         finish();
         return;
@@ -2163,6 +2159,7 @@ export async function resumeHitl(
   agentId: string,
   threadId: string,
   decisions: Array<{ type: string; message?: string }>,
+  onStreamEnd?: () => void,
 ): Promise<void> {
   const state = getOrCreate(sessionId);
   state.abortController?.abort();
@@ -2186,7 +2183,10 @@ export async function resumeHitl(
     (headers as Record<string, string>).Authorization = `Bearer ${token}`;
   }
 
+  let finished = false;
   const finish = () => {
+    if (finished) return;
+    finished = true;
     clearStreamingFlags(state);
     clearStreamActivity(sessionId);
     pendingResumeBySession.delete(sessionId);
@@ -2197,6 +2197,7 @@ export async function resumeHitl(
     sealInFlightAssistantMessages(state);
     notify(state);
     emitStreamEvent({ kind: "streamEnd", sessionId });
+    onStreamEnd?.();
   };
 
   try {

--- a/dashboard/src/pages/Chat/hooks/useChat.ts
+++ b/dashboard/src/pages/Chat/hooks/useChat.ts
@@ -962,54 +962,59 @@ export function useChat(
    * Used when the user overscrolls at the bottom to recover from a dropped WS
    * stream that left the last assistant turn incomplete in memory.
    */
-  const refreshHistory = useCallback(async () => {
-    const key = stableSessionId;
-    const snap = chatStore.getSnapshot(key);
-    if (
-      refreshInFlightRef.current ||
-      historyRefreshing ||
-      historyLoading ||
-      shouldBlockHistoryRefresh({
-        isStreaming: snap.isStreaming,
-        hasLiveSocket: chatStore.hasLiveSocket(key),
-      }) ||
-      !agentId ||
-      key === "__empty__"
-    ) {
-      return;
-    }
+  const refreshHistory = useCallback(
+    async (targetSessionId?: string) => {
+      const key = targetSessionId || stableSessionId;
+      const snap = chatStore.getSnapshot(key);
+      if (
+        refreshInFlightRef.current ||
+        historyRefreshing ||
+        historyLoading ||
+        shouldBlockHistoryRefresh({
+          isStreaming: snap.isStreaming,
+          hasLiveSocket: chatStore.hasLiveSocket(key),
+        }) ||
+        !agentId ||
+        key === "__empty__"
+      ) {
+        return;
+      }
 
-    refreshInFlightRef.current = true;
-    // Separate from loadGenRef: loadHistory may bump loadGen while we fetch.
-    // Always clear the refreshing flag in finally so the footer cannot stick.
-    const gen = ++loadGenRef.current;
-    setHistoryRefreshing(true);
+      refreshInFlightRef.current = true;
+      // Separate from loadGenRef: loadHistory may bump loadGen while we fetch.
+      // Always clear the refreshing flag in finally so the footer cannot stick.
+      const gen = ++loadGenRef.current;
+      setHistoryRefreshing(true);
 
-    try {
-      const {
-        messages: latest,
-        hasMore,
-        nextOffset,
-      } = await loadThreadHistory(agentId, key, { offset: 0 });
-      // Stale after a concurrent loadHistory / newer refresh — drop apply only.
-      if (loadGenRef.current !== gen) return;
+      try {
+        const {
+          messages: latest,
+          hasMore,
+          nextOffset,
+        } = await loadThreadHistory(agentId, key, { offset: 0 });
+        // Stale after a concurrent loadHistory / newer refresh — drop apply only.
+        if (loadGenRef.current !== gen) return;
 
-      // Keep older pages the user already scrolled in; replace the overlapping
-      // latest-page window with the server copy so truncated WS turns heal.
-      const latestIds = new Set(latest.map((m) => m.id));
-      const firstOverlap = snap.messages.findIndex((m) => latestIds.has(m.id));
-      const olderPrefix =
-        firstOverlap > 0 ? snap.messages.slice(0, firstOverlap) : [];
-      chatStore.setHistoryPage(key, [...olderPrefix, ...latest], {
-        hasMore: olderPrefix.length > 0 ? snap.historyHasMore : hasMore,
-        nextOffset:
-          olderPrefix.length > 0 ? snap.historyNextOffset : nextOffset,
-      });
-    } finally {
-      refreshInFlightRef.current = false;
-      setHistoryRefreshing(false);
-    }
-  }, [agentId, stableSessionId, historyRefreshing, historyLoading]);
+        // Keep older pages the user already scrolled in; replace the overlapping
+        // latest-page window with the server copy so truncated WS turns heal.
+        const latestIds = new Set(latest.map((m) => m.id));
+        const firstOverlap = snap.messages.findIndex((m) =>
+          latestIds.has(m.id),
+        );
+        const olderPrefix =
+          firstOverlap > 0 ? snap.messages.slice(0, firstOverlap) : [];
+        chatStore.setHistoryPage(key, [...olderPrefix, ...latest], {
+          hasMore: olderPrefix.length > 0 ? snap.historyHasMore : hasMore,
+          nextOffset:
+            olderPrefix.length > 0 ? snap.historyNextOffset : nextOffset,
+        });
+      } finally {
+        refreshInFlightRef.current = false;
+        setHistoryRefreshing(false);
+      }
+    },
+    [agentId, stableSessionId, historyRefreshing, historyLoading],
+  );
 
   /**
    * Edit a historical user message: truncate everything from that message
@@ -1059,9 +1064,11 @@ export function useChat(
       const threadId =
         storeKey || (stableSessionId !== "__empty__" ? stableSessionId : "");
       if (!threadId || threadId === "__empty__") return;
-      void chatStore.resumeHitl(key, agentId, threadId, decisions);
+      void chatStore.resumeHitl(key, agentId, threadId, decisions, () => {
+        void refreshHistory(threadId);
+      });
     },
-    [agentId, stableSessionId],
+    [agentId, stableSessionId, refreshHistory],
   );
 
   return {

--- a/dashboard/src/pages/Chat/index.tsx
+++ b/dashboard/src/pages/Chat/index.tsx
@@ -64,6 +64,8 @@ import {
 import ChatSidebarPanel from "./components/ChatSidebarPanel";
 import ChatTitleBar from "./components/ChatTitleBar";
 import ChatComposerChrome from "./components/ChatComposerChrome";
+import AskQuestionCard from "./components/AskQuestionCard";
+import { extractAskQuestions, isAskHitl } from "../../api/types/hitl";
 import { isAgentChatReady } from "../../utils/agentError";
 import { useMemoryMaintenance } from "./hooks/useMemoryMaintenance";
 import MemoryMaintenanceBanner from "./components/MemoryMaintenanceBanner";
@@ -672,6 +674,24 @@ function ChatPageInner() {
     () => messages.some((message) => message.hitlData?.status === "pending"),
     [messages],
   );
+  const pendingAsk = useMemo(() => {
+    for (let index = messages.length - 1; index >= 0; index -= 1) {
+      const message = messages[index];
+      const hitl = message.hitlData;
+      if (
+        !hitl ||
+        (hitl.status ?? "pending") !== "pending" ||
+        !isAskHitl(hitl.action_requests)
+      ) {
+        continue;
+      }
+      const questions = extractAskQuestions(hitl.action_requests);
+      if (questions.length > 0) {
+        return { id: message.id, actions: hitl.action_requests, questions };
+      }
+    }
+    return null;
+  }, [messages]);
   const forkDisabled = forking || isStreaming || hasPendingHitl;
   const forkDisabledHint =
     !forking && (isStreaming || hasPendingHitl)
@@ -1152,6 +1172,25 @@ function ChatPageInner() {
               )}
 
             <ChatComposerChrome sessionUsageLabel={sessionUsageLabel} />
+            {pendingAsk ? (
+              <div className={styles.askQuestionDock}>
+                <div className={styles.askQuestionDockInner}>
+                  <AskQuestionCard
+                    key={pendingAsk.id}
+                    questions={pendingAsk.questions}
+                    status="pending"
+                    onSubmit={(answer) =>
+                      handleHitlDecision(
+                        pendingAsk.actions.map(() => ({
+                          type: "respond",
+                          message: answer,
+                        })),
+                      )
+                    }
+                  />
+                </div>
+              </div>
+            ) : null}
             <ChatInput
               ref={chatInputRef}
               onSend={wrappedHandleSend}

--- a/src/octop/api/routers/chat/models.py
+++ b/src/octop/api/routers/chat/models.py
@@ -4,7 +4,13 @@ from __future__ import annotations
 
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
+
+# Decision types understood by langchain's HumanInTheLoopMiddleware.
+_DECISION_TYPES: frozenset[str] = frozenset({"approve", "edit", "reject", "respond"})
+# One decision per interrupted tool call; the model cannot fan out further.
+_MAX_DECISIONS = 16
+_MAX_DECISION_MESSAGE_CHARS = 8000
 
 
 class ChatTurnBody(BaseModel):
@@ -148,5 +154,40 @@ class HitlResumeBody(BaseModel):
     thread_id: str = Field(..., description="Conversation thread awaiting approval.")
     decisions: list[dict[str, Any]] = Field(
         ...,
-        description='Human decisions, e.g. [{"type": "approve"}] or [{"type": "reject", "message": "..."}].',
+        min_length=1,
+        max_length=_MAX_DECISIONS,
+        description=(
+            'Human decisions, e.g. [{"type": "approve"}], '
+            '[{"type": "reject", "message": "..."}] or '
+            '[{"type": "respond", "message": "<answer>"}].'
+        ),
     )
+
+    @field_validator("decisions")
+    @classmethod
+    def _validate_decisions(cls, value: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """Reject malformed decisions before they reach the agent graph.
+
+        ``respond``/``reject`` messages are injected into the model context
+        verbatim, so their payload is validated here rather than downstream.
+        """
+        for decision in value:
+            kind = decision.get("type")
+            if kind not in _DECISION_TYPES:
+                msg = f"unsupported decision type: {kind!r}"
+                raise ValueError(msg)
+            if kind == "edit" and not isinstance(decision.get("edited_action"), dict):
+                msg = "edit decision requires an 'edited_action' object"
+                raise ValueError(msg)
+            message = decision.get("message")
+            if kind == "respond" and (not isinstance(message, str) or not message.strip()):
+                msg = "respond decision requires a non-empty 'message'"
+                raise ValueError(msg)
+            if message is not None:
+                if not isinstance(message, str):
+                    msg = "decision 'message' must be a string"
+                    raise ValueError(msg)
+                if len(message) > _MAX_DECISION_MESSAGE_CHARS:
+                    msg = f"decision 'message' exceeds {_MAX_DECISION_MESSAGE_CHARS} characters"
+                    raise ValueError(msg)
+        return value

--- a/src/octop/api/routers/chat/routes.py
+++ b/src/octop/api/routers/chat/routes.py
@@ -6,7 +6,7 @@ import logging
 from collections.abc import AsyncIterator, Awaitable, Callable
 from typing import Any
 
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import StreamingResponse
 
 from octop.api.common.agent import assert_agent_access
@@ -22,7 +22,11 @@ from octop.infra.agents.experts.catalog import (
 )
 from octop.infra.agents.profile import welcome_from_row
 from octop.infra.errors import ErrorCode, OctopError
-from octop.infra.gateway.hitl.coordinator import HitlChannelCoordinator, HitlStreamContext
+from octop.infra.gateway.hitl.coordinator import (
+    HitlChannelCoordinator,
+    HitlStreamContext,
+    decision_rejection_reason,
+)
 from octop.infra.gateway.hitl.store import HitlPendingRecord
 from octop.infra.utils.llm_text import ainvoke_text
 from octop.infra.utils.locale import resolve_request_locale
@@ -89,7 +93,7 @@ async def get_chat_welcome(
 
 async def iter_dashboard_hitl_resume_sse(
     *,
-    agent_registry: Any,
+    processor: Any,
     hitl_coordinator: HitlChannelCoordinator,
     agent_id: str,
     thread_id: str,
@@ -114,21 +118,29 @@ async def iter_dashboard_hitl_resume_sse(
         session_key=session_key,
         channel_type=channel_type,
     )
+    disconnected = False
     try:
-        async for chunk in agent_registry.resume_hitl(agent_id, thread_id, decisions):
-            if await is_disconnected():
-                break
+        async for chunk in processor.iter_hitl_resume_chunks(
+            agent_id=agent_id,
+            thread_id=thread_id,
+            user_id=user_id,
+            decisions=decisions,
+        ):
+            if not disconnected:
+                disconnected = await is_disconnected()
             if isinstance(chunk, dict) and chunk.get("type") == "hitl_required":
                 request_payload = chunk.get("request")
                 if isinstance(request_payload, dict):
                     hitl_coordinator.register_from_request(request_payload, ctx=hitl_ctx)
-            yield format_sse("chunk", chunk)
+            if not disconnected:
+                yield format_sse("chunk", chunk)
         if pending is not None:
             hitl_coordinator.store.mark_resolved(
                 pending.pending_id,
                 "rejected" if rejected else "approved",
             )
-        yield format_sse("chunk", {"type": "done"})
+        if not disconnected:
+            yield format_sse("chunk", {"type": "done"})
     except Exception as exc:
         yield format_sse(
             "chunk",
@@ -162,8 +174,8 @@ async def resume_hitl(
 ) -> StreamingResponse:
     """Resume a paused human-in-the-loop tool approval and stream subsequent chunks."""
     assert_agent_access(server, agent_id, user)
-    agent_registry = server.app_runtime.agent_registry
-    hitl_coordinator = server.app_runtime.gateway.processor.hitl_coordinator
+    processor = server.app_runtime.gateway.processor
+    hitl_coordinator = processor.hitl_coordinator
     pending = hitl_coordinator.store.resolve_pending_for_thread(
         body.thread_id,
         agent_id=agent_id,
@@ -176,10 +188,14 @@ async def resume_hitl(
         user_id=user.id,
         pending=pending,
     )
+    if pending is not None:
+        reason = decision_rejection_reason(pending, body.decisions)
+        if reason is not None:
+            raise HTTPException(status_code=400, detail=reason)
 
     async def gen() -> AsyncIterator[str]:
         async for frame in iter_dashboard_hitl_resume_sse(
-            agent_registry=agent_registry,
+            processor=processor,
             hitl_coordinator=hitl_coordinator,
             agent_id=agent_id,
             thread_id=body.thread_id,

--- a/src/octop/i18n/domains/tools.py
+++ b/src/octop/i18n/domains/tools.py
@@ -16,6 +16,8 @@ HITL_TOOL_EXCLUDE: frozenset[str] = frozenset(
         "unknown",
         "current_time",
         "write_todos",
+        # Its own HITL channel — approving an approval prompt makes no sense.
+        "ask_user_question",
         # Memory
         "memory_search",
         "memory_get",

--- a/src/octop/i18n/en.json
+++ b/src/octop/i18n/en.json
@@ -71,6 +71,22 @@
       "pending_line": "`{pending_id}` — {count} tool(s)",
       "dashboard_hint": "Tool approval in chat uses the approval card in the dashboard, or `/approve` / `/reject` in IM channels."
     },
+    "ask": {
+      "card_title": "❓ I need you to decide",
+      "progress": "Question {current} of {total}",
+      "question_line": "**{index}. {question}**",
+      "question_line_headed": "**{index}. [{header}] {question}**",
+      "option_line": "   {opt}) {label}",
+      "option_line_desc": "   {opt}) {label} — {description}",
+      "multi_hint": "   (multiple allowed, e.g. `a,c`)",
+      "open_hint": "   (answer in a sentence)",
+      "card_footer": "Reply with a letter (e.g. `a`) or type your own answer.",
+      "card_pending_id": "Question ID: `{pending_id}` (valid for 30 minutes)",
+      "answer_ack": "Got it. Continuing…",
+      "answer_recorded": "✅ Recorded. Here is the next question.",
+      "not_owner": "Only the user who was asked can answer.",
+      "answered_prefix": "User answered: "
+    },
     "title": {
       "usage": "Usage: /title <text>",
       "done": "Title set: {title}"
@@ -492,6 +508,7 @@
     "mobile_handoff_to_user": "Hand off to user (mobile)",
     "read_env_file": "Read env file",
     "write_env_file": "Write env file",
+    "ask_user_question": "Ask the user",
     "generate_image": "Generate image",
     "generate_video": "Generate video"
   },

--- a/src/octop/i18n/zh.json
+++ b/src/octop/i18n/zh.json
@@ -71,6 +71,22 @@
       "pending_line": "`{pending_id}` — {count} 个工具",
       "dashboard_hint": "控制台聊天请使用审批卡片；IM 通道请使用 `/approve` 或 `/reject`。"
     },
+    "ask": {
+      "card_title": "❓ 有个地方需要你拍板",
+      "progress": "第 {current}/{total} 个问题",
+      "question_line": "**{index}. {question}**",
+      "question_line_headed": "**{index}. [{header}] {question}**",
+      "option_line": "   {opt}) {label}",
+      "option_line_desc": "   {opt}) {label} —— {description}",
+      "multi_hint": "   （可多选，如 `a,c`）",
+      "open_hint": "   （直接用一句话回答）",
+      "card_footer": "直接回复序号（如 `a`），或输入你自己的答案。",
+      "card_pending_id": "提问 ID：`{pending_id}`（30 分钟内有效）",
+      "answer_ack": "收到，继续处理…",
+      "answer_recorded": "✅ 已记录，下面是下一个问题。",
+      "not_owner": "仅被提问的用户可以回答。",
+      "answered_prefix": "用户回答："
+    },
     "title": {
       "usage": "用法：/title <标题>",
       "done": "标题已设置：{title}"
@@ -492,6 +508,7 @@
     "mobile_handoff_to_user": "交给用户操作（手机）",
     "read_env_file": "读取环境变量",
     "write_env_file": "写入环境变量",
+    "ask_user_question": "向你提问",
     "generate_image": "生成图片",
     "generate_video": "生成视频"
   },

--- a/src/octop/infra/agents/tool_catalog.py
+++ b/src/octop/infra/agents/tool_catalog.py
@@ -68,6 +68,7 @@ BUILTIN_TOOL_CATALOG: tuple[BuiltinToolEntry, ...] = (
     BuiltinToolEntry("send_file_to_user", "misc"),
     BuiltinToolEntry("read_env_file", "misc"),
     BuiltinToolEntry("write_env_file", "misc"),
+    BuiltinToolEntry("ask_user_question", "interaction"),
     BuiltinToolEntry("tavily_search", "web"),
     BuiltinToolEntry("brave_search", "web"),
     BuiltinToolEntry("google_search", "web"),

--- a/src/octop/infra/gateway/hitl/coordinator.py
+++ b/src/octop/infra/gateway/hitl/coordinator.py
@@ -10,7 +10,14 @@ from harness_agent.slash import SlashCommand
 from harness_gateway.models import MessageEvent
 
 from octop.i18n.domains.slash import tr
-from octop.infra.gateway.hitl.format import parse_action_requests, parse_review_configs
+from octop.infra.gateway.hitl.format import (
+    extract_questions,
+    format_ask_card,
+    is_ask_action_requests,
+    parse_action_requests,
+    parse_ask_reply,
+    parse_review_configs,
+)
 from octop.infra.gateway.hitl.store import HitlPendingRecord, HitlPendingStore
 from octop.infra.gateway.process.usage_record import UsageTracker
 from octop.infra.gateway.slash.ctx import ensure_thread_id
@@ -38,6 +45,14 @@ class HitlSlashOutcome:
     completed_turn: bool = False
 
 
+@dataclass
+class HitlAnswerOutcome:
+    """Whether an IM answer resumed the graph or only advanced the form."""
+
+    completed_turn: bool = False
+    awaiting_more: bool = False
+
+
 def pending_hitl_payload(
     store: HitlPendingStore,
     *,
@@ -57,6 +72,41 @@ def pending_hitl_payload(
         "action_requests": record.action_requests,
         "review_configs": record.review_configs,
     }
+
+
+def decision_rejection_reason(
+    record: HitlPendingRecord,
+    decisions: list[dict[str, Any]],
+) -> str | None:
+    """Check decisions against the pause's ``allowed_decisions``.
+
+    The agent middleware raises deep inside the graph when a decision type is
+    not allowed for its tool, which surfaces to the user as an opaque "model
+    retry failed". Catching it at the API boundary turns a stale or buggy client
+    into an actionable 400 instead.
+
+    Returns an error message, or ``None`` when the decisions are acceptable.
+    """
+    actions = record.action_requests
+    if len(decisions) != len(actions):
+        return f"expected {len(actions)} decision(s) for this pause, got {len(decisions)}"
+    allowed_by_action: dict[str, set[str]] = {}
+    for config in record.review_configs or []:
+        name = config.get("action_name")
+        allowed = config.get("allowed_decisions")
+        if isinstance(name, str) and isinstance(allowed, list):
+            allowed_by_action[name] = {str(item) for item in allowed}
+    for action, decision in zip(actions, decisions, strict=True):
+        allowed = allowed_by_action.get(str(action.get("name")))
+        if not allowed:
+            continue
+        kind = str(decision.get("type"))
+        if kind not in allowed:
+            return (
+                f"decision '{kind}' is not allowed for tool "
+                f"'{action.get('name')}' (allowed: {', '.join(sorted(allowed))})"
+            )
+    return None
 
 
 class HitlChannelCoordinator:
@@ -95,6 +145,169 @@ class HitlChannelCoordinator:
             return [{"type": "approve"} for _ in range(count)]
         reject_message = message or "Rejected by user"
         return [{"type": "reject", "message": reject_message} for _ in range(count)]
+
+    def resolve_ask_pending(
+        self,
+        session_key: str,
+        *,
+        agent_id: str,
+        user_id: int,
+    ) -> HitlPendingRecord | None:
+        """Return the open ``ask_user_question`` pause this user may answer.
+
+        Returns ``None`` for approval pauses (those keep using ``/approve``) and
+        for questions addressed to a different user in the same group chat.
+        """
+        record = self._store.resolve_for_session(session_key, agent_id=agent_id)
+        if record is None or record.status != "pending":
+            return None
+        if record.user_id != user_id:
+            return None
+        if not is_ask_action_requests(record.action_requests):
+            return None
+        return record
+
+    @staticmethod
+    def build_answer_decisions(
+        record: HitlPendingRecord,
+        text: str,
+        *,
+        locale: str,
+    ) -> list[dict[str, Any]]:
+        """Build ``respond`` decisions carrying the user's answer to the model."""
+        message = parse_ask_reply(
+            text,
+            extract_questions(record.action_requests),
+            locale=locale,
+        )
+        count = len(record.action_requests) or 1
+        return [{"type": "respond", "message": message} for _ in range(count)]
+
+    @staticmethod
+    def _answer_decisions(
+        record: HitlPendingRecord,
+        message: str,
+    ) -> list[dict[str, Any]]:
+        count = len(record.action_requests) or 1
+        return [{"type": "respond", "message": message} for _ in range(count)]
+
+    @staticmethod
+    def _collected_answer_message(
+        questions: list[dict[str, Any]],
+        answers: list[str],
+        *,
+        locale: Locale,
+    ) -> str:
+        lines = [tr("ask.answered_prefix", locale).rstrip()]
+        for index, answer in enumerate(answers):
+            question = questions[index] if index < len(questions) else {}
+            header = str(question.get("header") or "").strip()
+            prompt = str(question.get("question") or "").strip()
+            label = header or prompt or str(index + 1)
+            lines.append(f"- {label}: {answer}")
+        return "\n".join(lines)
+
+    def collect_ask_reply(
+        self,
+        record: HitlPendingRecord,
+        text: str,
+        *,
+        locale: str | Locale,
+    ) -> tuple[str | None, str | None]:
+        """Collect one IM answer; return ``(resume_message, next_card)``."""
+        lang = normalize_locale(str(locale))
+        questions = extract_questions(record.action_requests)
+        if not questions:
+            return parse_ask_reply(text, questions, locale=lang), None
+
+        current = min(record.ask_question_index, len(questions) - 1)
+        answer = parse_ask_reply(text, [questions[current]], locale=lang)
+        prefix = tr("ask.answered_prefix", lang)
+        if answer.startswith(prefix):
+            answer = answer[len(prefix) :].strip()
+        updated = self._store.append_ask_answer(record.pending_id, answer)
+        if updated is None:
+            return None, None
+
+        if updated.ask_question_index < len(questions):
+            next_card = format_ask_card(
+                questions,
+                pending_id=record.pending_id,
+                locale=lang,
+                question_index=updated.ask_question_index,
+            )
+            return None, next_card
+
+        return (
+            self._collected_answer_message(
+                questions,
+                updated.ask_answers,
+                locale=lang,
+            ),
+            None,
+        )
+
+    async def iter_answer_resolution(
+        self,
+        record: HitlPendingRecord,
+        text: str,
+        *,
+        agent_manager: AgentManager,
+        locale: str,
+        usage_tracker: UsageTracker | None = None,
+        history_tracker: Any | None = None,
+        projection_state: Any | None = None,
+        outcome: HitlAnswerOutcome | None = None,
+    ) -> AsyncIterator[MessageEvent]:
+        """Collect one IM answer and resume only after the final question."""
+        from octop.infra.gateway.process.stream_project import (
+            StreamProjectionState,
+            project_resume_stream,
+        )
+
+        lang = normalize_locale(locale)
+        resume_message, next_card = self.collect_ask_reply(record, text, locale=lang)
+        if next_card is not None:
+            if outcome is not None:
+                outcome.awaiting_more = True
+            yield MessageEvent.text(f"{tr('ask.answer_recorded', lang)}\n\n{next_card}")
+            return
+        if resume_message is None:
+            yield MessageEvent.error_event(tr("hitl.expired", lang))
+            return
+
+        yield MessageEvent.typing()
+        decisions = self._answer_decisions(record, resume_message)
+        hitl_ctx = HitlStreamContext(
+            thread_id=record.thread_id,
+            agent_id=record.agent_id,
+            user_id=record.user_id,
+            session_key=record.session_key,
+            channel_type=record.channel_type,
+        )
+        state = projection_state if projection_state is not None else StreamProjectionState()
+        # Resolve before streaming: a follow-up question registered mid-stream
+        # must not be clobbered by a late mark_resolved on the old record.
+        self._store.mark_resolved(record.pending_id, "approved")
+        try:
+            async for ev in project_resume_stream(
+                agent_manager,
+                record.agent_id,
+                record.thread_id,
+                decisions,
+                usage_tracker=usage_tracker or UsageTracker(),
+                history_tracker=history_tracker,
+                locale=lang,
+                projection_state=state,
+                hitl_coordinator=self,
+                hitl_ctx=hitl_ctx,
+            ):
+                yield ev
+        except Exception as exc:
+            yield MessageEvent.error_event(tr("hitl.resume_failed", lang, error=str(exc)))
+            return
+        if outcome is not None:
+            outcome.completed_turn = True
 
     async def iter_slash_resolution(
         self,

--- a/src/octop/infra/gateway/hitl/format.py
+++ b/src/octop/infra/gateway/hitl/format.py
@@ -3,10 +3,21 @@
 from __future__ import annotations
 
 import json
+import re
+import string
 from typing import Any
 
 from octop.i18n import tool_display_name, tr
 from octop.infra.utils.locale import Locale, normalize_locale
+
+# Tool whose HITL interrupt is a question for the user rather than an approval.
+ASK_USER_TOOL_NAME = "ask_user_question"
+
+# Option keys shown in IM cards: a) b) c) d)
+_OPTION_KEYS = string.ascii_lowercase
+
+# `1`, `a`, `1,3`, `a c`, `b、d` — a pure selection reply.
+_SELECTION_RE = re.compile(r"^[0-9a-z]+(?:\s*[,，、/\s]\s*[0-9a-z]+)*$")
 
 
 def parse_action_requests(raw: dict[str, Any]) -> list[dict[str, Any]]:
@@ -35,6 +46,33 @@ def parse_review_configs(raw: dict[str, Any]) -> list[dict[str, Any]] | None:
     return out or None
 
 
+def is_ask_action_requests(action_requests: list[dict[str, Any]]) -> bool:
+    """True when this HITL pause is an ``ask_user_question`` interrupt."""
+    return any(isinstance(a, dict) and a.get("name") == ASK_USER_TOOL_NAME for a in action_requests)
+
+
+def extract_questions(action_requests: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Pull the normalized ``questions`` list out of an ask action request."""
+    for action in action_requests:
+        if not isinstance(action, dict) or action.get("name") != ASK_USER_TOOL_NAME:
+            continue
+        args = action.get("args")
+        if not isinstance(args, dict):
+            continue
+        raw = args.get("questions")
+        if not isinstance(raw, list):
+            continue
+        return [q for q in raw if isinstance(q, dict)]
+    return []
+
+
+def _options_of(question: dict[str, Any]) -> list[dict[str, Any]]:
+    raw = question.get("options")
+    if not isinstance(raw, list):
+        return []
+    return [o for o in raw if isinstance(o, dict)]
+
+
 def _format_args(args: dict[str, Any], *, limit: int = 400) -> str:
     try:
         text = json.dumps(args, ensure_ascii=False, indent=2)
@@ -51,6 +89,13 @@ def format_hitl_card(
     pending_id: str,
     locale: str | Locale,
 ) -> str:
+    """Render the IM card for a paused turn (approval or question)."""
+    if is_ask_action_requests(record_action_requests):
+        return format_ask_card(
+            extract_questions(record_action_requests),
+            pending_id=pending_id,
+            locale=locale,
+        )
     loc = normalize_locale(str(locale))
     lines = [
         tr("slash.hitl.card_title", loc),
@@ -79,3 +124,152 @@ def format_hitl_card(
         ]
     )
     return "\n".join(lines).strip()
+
+
+def format_ask_card(
+    questions: list[dict[str, Any]],
+    *,
+    pending_id: str,
+    locale: str | Locale,
+    question_index: int = 0,
+) -> str:
+    """Render one ``ask_user_question`` item as a plain-text IM card.
+
+    IM clients do not provide the dashboard's interactive multi-question card.
+    Showing one item at a time also lets letter/number replies map unambiguously
+    to the visible option list.
+    """
+    loc = normalize_locale(str(locale))
+    lines = [tr("slash.ask.card_title", loc), ""]
+    total = len(questions)
+    if total == 0:
+        lines.extend(
+            [
+                tr("slash.ask.open_hint", loc),
+                "",
+                tr("slash.ask.card_footer", loc),
+                tr("slash.ask.card_pending_id", loc, pending_id=pending_id),
+            ]
+        )
+        return "\n".join(lines).strip()
+
+    current = min(max(question_index, 0), total - 1)
+    if total > 1:
+        lines.extend(
+            [
+                tr("slash.ask.progress", loc, current=current + 1, total=total),
+                "",
+            ]
+        )
+
+    question = questions[current]
+    idx = current + 1
+    text = str(question.get("question") or "").strip()
+    header = question.get("header")
+    if isinstance(header, str) and header.strip():
+        lines.append(
+            tr(
+                "slash.ask.question_line_headed",
+                loc,
+                index=idx,
+                header=header.strip(),
+                question=text,
+            )
+        )
+    else:
+        lines.append(tr("slash.ask.question_line", loc, index=idx, question=text))
+    lines.append("")
+    options = _options_of(question)
+    for opt_idx, option in enumerate(options):
+        if opt_idx >= len(_OPTION_KEYS):
+            break
+        label = str(option.get("label") or "").strip()
+        description = str(option.get("description") or "").strip()
+        opt = _OPTION_KEYS[opt_idx]
+        if description:
+            lines.append(
+                tr(
+                    "slash.ask.option_line_desc",
+                    loc,
+                    opt=opt,
+                    label=label,
+                    description=description,
+                )
+            )
+        else:
+            lines.append(tr("slash.ask.option_line", loc, opt=opt, label=label))
+        # A blank paragraph is preserved by plain-text IM clients such as Weixin,
+        # while a single newline may be collapsed into one dense line.
+        lines.append("")
+    if not options:
+        lines.append(tr("slash.ask.open_hint", loc))
+        lines.append("")
+    elif question.get("multi_select"):
+        lines.append(tr("slash.ask.multi_hint", loc))
+        lines.append("")
+    lines.extend(
+        [
+            tr("slash.ask.card_footer", loc),
+            tr("slash.ask.card_pending_id", loc, pending_id=pending_id),
+        ]
+    )
+    return "\n".join(lines).strip()
+
+
+def _resolve_selection(token: str, options: list[dict[str, Any]]) -> str | None:
+    """Map one reply token (``a`` / ``1``) to an option label, if it matches."""
+    if not options:
+        return None
+    index: int | None = None
+    if token.isdigit():
+        index = int(token) - 1
+    elif len(token) == 1 and token in _OPTION_KEYS:
+        index = _OPTION_KEYS.index(token)
+    if index is None or not (0 <= index < len(options)):
+        return None
+    label = str(options[index].get("label") or "").strip()
+    return label or None
+
+
+def parse_ask_reply(
+    text: str,
+    questions: list[dict[str, Any]],
+    *,
+    locale: str | Locale,
+) -> str:
+    """Turn a plain IM reply into the ``respond`` message sent back to the model.
+
+    Selection shorthands (``a``, ``2``, ``a,c``) are expanded to their option
+    labels so the model sees the semantic choice rather than an index. Anything
+    else is forwarded verbatim — free-form answers, counter-proposals and even
+    topic switches are all valid replies, and the model handles them better than
+    any parser could.
+    """
+    loc = normalize_locale(str(locale))
+    stripped = text.strip()
+    # Shorthand selection only makes sense against a single option list.
+    if len(questions) == 1:
+        options = _options_of(questions[0])
+        candidate = stripped.lower()
+        if options and _SELECTION_RE.match(candidate):
+            tokens = [t for t in re.split(r"[,，、/\s]+", candidate) if t]
+            labels = [_resolve_selection(t, options) for t in tokens]
+            picked = [label for label in labels if label]
+            if picked and len(picked) == len(tokens):
+                if not questions[0].get("multi_select") and len(picked) > 1:
+                    picked = picked[:1]
+                return tr("slash.ask.answered_prefix", loc) + "; ".join(picked)
+
+    return stripped
+
+
+__all__ = [
+    "ASK_USER_TOOL_NAME",
+    "extract_questions",
+    "format_ask_card",
+    "format_hitl_card",
+    "is_ask_action_requests",
+    "parse_action_requests",
+    "parse_ask_reply",
+    "parse_review_configs",
+]

--- a/src/octop/infra/gateway/hitl/store.py
+++ b/src/octop/infra/gateway/hitl/store.py
@@ -24,6 +24,8 @@ class HitlPendingRecord:
     review_configs: list[dict[str, Any]] | None
     created_at: float
     status: HitlPendingStatus = "pending"
+    ask_question_index: int = 0
+    ask_answers: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -164,6 +166,15 @@ class HitlPendingStore:
         record = self._records.get(pending_id)
         if record is not None:
             record.status = status
+
+    def append_ask_answer(self, pending_id: str, answer: str) -> HitlPendingRecord | None:
+        """Record one IM answer and advance to the next question."""
+        record = self.get(pending_id)
+        if record is None or record.status != "pending":
+            return None
+        record.ask_answers.append(answer)
+        record.ask_question_index += 1
+        return record
 
     def _gc(self) -> None:
         now = time.time()

--- a/src/octop/infra/gateway/process/processor.py
+++ b/src/octop/infra/gateway/process/processor.py
@@ -20,6 +20,7 @@ from harness_gateway.models import (
 from octop.i18n.domains.stream import format_stream_error
 from octop.infra.agents.providers.reasoning import reasoning_request_parameters
 from octop.infra.gateway.hitl.coordinator import (
+    HitlAnswerOutcome,
     HitlChannelCoordinator,
     HitlSlashOutcome,
     HitlStreamContext,
@@ -391,6 +392,41 @@ class GlobalProcessor:
             yield MessageEvent.completed()
             return
 
+        # An open ``ask_user_question`` pause turns the user's next message into
+        # the answer for that paused turn instead of starting a new one.
+        if cmd is None and msg.text.strip():
+            ask_record = self._hitl.resolve_ask_pending(
+                session_key,
+                agent_id=agent_id,
+                user_id=user_id,
+            )
+            if ask_record is not None:
+                usage_tracker = UsageTracker()
+                history_tracker = TurnHistoryTracker()
+                answer_outcome = HitlAnswerOutcome()
+                async for ev in self._hitl.iter_answer_resolution(
+                    ask_record,
+                    msg.text,
+                    agent_manager=self._agent_manager,
+                    locale=locale,
+                    usage_tracker=usage_tracker,
+                    history_tracker=history_tracker,
+                    outcome=answer_outcome,
+                ):
+                    yield ev
+                if answer_outcome.completed_turn:
+                    self._touch_thread_after_turn(ask_record.thread_id, msg.text)
+                    if usage_tracker.usage:
+                        self._record_turn_usage(
+                            agent_id=agent_id,
+                            user_id=user_id,
+                            thread_id=ask_record.thread_id,
+                            usage=usage_tracker.usage,
+                        )
+                    self._record_turn_history(ask_record.thread_id, history_tracker)
+                yield MessageEvent.completed()
+                return
+
         if cmd is not None:
             sink = _MessageEventSink()
             handled = await self._dispatcher.handle(
@@ -662,6 +698,39 @@ class GlobalProcessor:
             )
             self._record_turn_history(thread_id, history_tracker)
         yield {"type": "done"}
+
+    async def iter_hitl_resume_chunks(
+        self,
+        *,
+        agent_id: str,
+        thread_id: str,
+        user_id: int,
+        decisions: list[dict[str, Any]],
+    ) -> AsyncIterator[dict[str, Any]]:
+        """Resume a dashboard HITL turn with the normal history bookkeeping."""
+        usage_tracker = UsageTracker()
+        history_tracker = TurnHistoryTracker()
+        completed = False
+        try:
+            async for chunk in self._agent_manager.resume_hitl(
+                agent_id,
+                thread_id,
+                decisions,
+            ):
+                usage_tracker.observe(chunk)
+                history_tracker.observe(chunk)
+                yield chunk
+            completed = True
+        finally:
+            if completed:
+                self._touch_thread_after_turn(thread_id, None)
+                self._record_turn_usage(
+                    agent_id=agent_id,
+                    user_id=user_id,
+                    thread_id=thread_id,
+                    usage=usage_tracker.usage,
+                )
+                self._record_turn_history(thread_id, history_tracker)
 
     async def _build_dashboard_request(
         self,

--- a/tests/unit/agents/test_onnx_service.py
+++ b/tests/unit/agents/test_onnx_service.py
@@ -344,6 +344,9 @@ def test_is_downloaded_finds_nested_onnx_weights(tmp_path, monkeypatch) -> None:
     from octop.infra.agents.providers import onnx_service as mod
 
     mid = "jinaai/jina-clip-v1"
+    # Keep this cache-layout regression independent of whether the optional
+    # fastembed package is installed and contributes this model to the catalog.
+    monkeypatch.setattr(mod, "list_onnx_catalog_models", lambda: [{"id": mid}])
     snap = mod.model_cache_dir(mid) / "snapshots" / "abc123"
     (snap / "onnx").mkdir(parents=True)
     (snap / "config.json").write_text("{}", encoding="utf-8")

--- a/tests/unit/api/test_chat_hitl_resume.py
+++ b/tests/unit/api/test_chat_hitl_resume.py
@@ -43,8 +43,8 @@ async def test_dashboard_hitl_resume_registers_followup_hitl_required() -> None:
             },
         }
 
-    agent_registry = MagicMock()
-    agent_registry.resume_hitl = _resume
+    processor = MagicMock()
+    processor.iter_hitl_resume_chunks = _resume
     hitl = HitlChannelCoordinator()
     first = hitl.store.register(
         thread_id="thr-follow",
@@ -58,7 +58,7 @@ async def test_dashboard_hitl_resume_registers_followup_hitl_required() -> None:
 
     frames: list[str] = []
     async for frame in iter_dashboard_hitl_resume_sse(
-        agent_registry=agent_registry,
+        processor=processor,
         hitl_coordinator=hitl,
         agent_id="agent-1",
         thread_id="thr-follow",
@@ -98,12 +98,12 @@ async def test_dashboard_hitl_resume_registers_without_prior_pending() -> None:
             },
         }
 
-    agent_registry = MagicMock()
-    agent_registry.resume_hitl = _resume
+    processor = MagicMock()
+    processor.iter_hitl_resume_chunks = _resume
     hitl = HitlChannelCoordinator()
 
     async for _ in iter_dashboard_hitl_resume_sse(
-        agent_registry=agent_registry,
+        processor=processor,
         hitl_coordinator=hitl,
         agent_id="agent-1",
         thread_id="thr-orphan",
@@ -124,3 +124,37 @@ async def test_dashboard_hitl_resume_registers_without_prior_pending() -> None:
     )
     assert pending is not None
     assert pending.action_requests[0]["args"]["command"] == "echo hi"
+
+
+@pytest.mark.asyncio
+async def test_dashboard_hitl_resume_finishes_after_client_disconnect() -> None:
+    completed = False
+
+    async def _resume(*_args: object, **_kwargs: object):
+        nonlocal completed
+        yield {"type": "token", "content": "hidden after disconnect"}
+        completed = True
+
+    processor = MagicMock()
+    processor.iter_hitl_resume_chunks = _resume
+    hitl = HitlChannelCoordinator()
+
+    frames = [
+        frame
+        async for frame in iter_dashboard_hitl_resume_sse(
+            processor=processor,
+            hitl_coordinator=hitl,
+            agent_id="agent-1",
+            thread_id="thr-disconnected",
+            user_id=9,
+            decisions=[{"type": "respond", "message": "answer"}],
+            pending=None,
+            session_key="sk-disconnected",
+            channel_type="dashboard",
+            locale="en",
+            is_disconnected=AsyncMock(return_value=True),
+        )
+    ]
+
+    assert completed is True
+    assert frames == []

--- a/tests/unit/api/test_hitl_resume_validation.py
+++ b/tests/unit/api/test_hitl_resume_validation.py
@@ -1,0 +1,74 @@
+"""Validation for the HITL resume request body."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from octop.api.routers.chat.models import HitlResumeBody
+
+
+def _body(decisions: list[dict]) -> HitlResumeBody:
+    return HitlResumeBody(thread_id="thr1", decisions=decisions)
+
+
+class TestAccepted:
+    def test_approve(self) -> None:
+        assert _body([{"type": "approve"}]).decisions[0]["type"] == "approve"
+
+    def test_reject_with_message(self) -> None:
+        assert _body([{"type": "reject", "message": "no"}]).decisions[0]["message"] == "no"
+
+    def test_reject_without_message(self) -> None:
+        assert _body([{"type": "reject"}]).decisions[0]["type"] == "reject"
+
+    def test_respond(self) -> None:
+        assert (
+            _body([{"type": "respond", "message": "PostgreSQL"}]).decisions[0]["message"]
+            == "PostgreSQL"
+        )
+
+    def test_edit(self) -> None:
+        decision = {"type": "edit", "edited_action": {"name": "execute", "args": {}}}
+        assert _body([decision]).decisions[0]["type"] == "edit"
+
+    def test_multiple_decisions(self) -> None:
+        assert len(_body([{"type": "approve"}, {"type": "approve"}]).decisions) == 2
+
+
+class TestRejected:
+    def test_empty_decisions(self) -> None:
+        with pytest.raises(ValidationError):
+            _body([])
+
+    def test_unknown_type(self) -> None:
+        with pytest.raises(ValidationError, match="unsupported decision type"):
+            _body([{"type": "detonate"}])
+
+    def test_missing_type(self) -> None:
+        with pytest.raises(ValidationError, match="unsupported decision type"):
+            _body([{"message": "hi"}])
+
+    def test_respond_without_message(self) -> None:
+        with pytest.raises(ValidationError, match="non-empty 'message'"):
+            _body([{"type": "respond"}])
+
+    def test_respond_with_blank_message(self) -> None:
+        with pytest.raises(ValidationError, match="non-empty 'message'"):
+            _body([{"type": "respond", "message": "   "}])
+
+    def test_edit_without_edited_action(self) -> None:
+        with pytest.raises(ValidationError, match="edited_action"):
+            _body([{"type": "edit"}])
+
+    def test_non_string_message(self) -> None:
+        with pytest.raises(ValidationError, match="must be a string"):
+            _body([{"type": "reject", "message": 42}])
+
+    def test_oversized_message(self) -> None:
+        with pytest.raises(ValidationError, match="exceeds"):
+            _body([{"type": "respond", "message": "x" * 8001}])
+
+    def test_too_many_decisions(self) -> None:
+        with pytest.raises(ValidationError):
+            _body([{"type": "approve"}] * 17)

--- a/tests/unit/gateway/test_hitl_ask_user.py
+++ b/tests/unit/gateway/test_hitl_ask_user.py
@@ -1,0 +1,338 @@
+"""Unit tests for the ``ask_user_question`` HITL channel."""
+
+from __future__ import annotations
+
+import pytest
+
+from octop.infra.gateway.hitl.coordinator import (
+    HitlChannelCoordinator,
+    decision_rejection_reason,
+)
+from octop.infra.gateway.hitl.format import (
+    extract_questions,
+    format_ask_card,
+    format_hitl_card,
+    is_ask_action_requests,
+    parse_ask_reply,
+)
+from octop.infra.gateway.hitl.store import HitlPendingStore
+
+SINGLE_CHOICE = [
+    {
+        "name": "ask_user_question",
+        "args": {
+            "questions": [
+                {
+                    "header": "Storage",
+                    "question": "Which database should we use?",
+                    "options": [
+                        {"label": "PostgreSQL", "description": "Concurrent writes"},
+                        {"label": "SQLite", "description": "Zero ops"},
+                    ],
+                }
+            ]
+        },
+    }
+]
+
+MULTI_CHOICE = [
+    {
+        "name": "ask_user_question",
+        "args": {
+            "questions": [
+                {
+                    "question": "Which channels should be enabled?",
+                    "multi_select": True,
+                    "options": [
+                        {"label": "Feishu"},
+                        {"label": "Slack"},
+                        {"label": "Telegram"},
+                    ],
+                }
+            ]
+        },
+    }
+]
+
+OPEN_ENDED = [
+    {
+        "name": "ask_user_question",
+        "args": {"questions": [{"question": "What should the report cover?"}]},
+    }
+]
+
+THREE_QUESTIONS = [
+    {
+        "name": "ask_user_question",
+        "args": {
+            "questions": [
+                {
+                    "header": "Destination",
+                    "question": "Where should we go?",
+                    "options": [{"label": "Mountains"}, {"label": "City"}],
+                },
+                {
+                    "header": "Budget",
+                    "question": "What is the budget?",
+                    "options": [{"label": "Economy"}, {"label": "Premium"}],
+                },
+                {
+                    "header": "Transport",
+                    "question": "How should we travel?",
+                    "options": [{"label": "Train"}, {"label": "Drive"}],
+                },
+            ]
+        },
+    }
+]
+
+APPROVAL = [{"name": "execute", "args": {"command": "ls"}}]
+
+
+def _questions(actions: list[dict]) -> list[dict]:
+    return extract_questions(actions)
+
+
+class TestDetection:
+    def test_ask_actions_detected(self) -> None:
+        assert is_ask_action_requests(SINGLE_CHOICE)
+
+    def test_approval_actions_not_detected(self) -> None:
+        assert not is_ask_action_requests(APPROVAL)
+
+    def test_empty_actions_not_detected(self) -> None:
+        assert not is_ask_action_requests([])
+
+    def test_extract_questions(self) -> None:
+        questions = _questions(SINGLE_CHOICE)
+        assert len(questions) == 1
+        assert questions[0]["question"] == "Which database should we use?"
+
+    def test_extract_questions_ignores_malformed(self) -> None:
+        actions = [{"name": "ask_user_question", "args": {"questions": "nope"}}]
+        assert extract_questions(actions) == []
+
+
+class TestCard:
+    def test_hitl_card_dispatches_to_ask(self) -> None:
+        card = format_hitl_card(SINGLE_CHOICE, pending_id="p1", locale="en")
+        assert "PostgreSQL" in card
+        assert "a) PostgreSQL" in card
+        assert "b) SQLite" in card
+        assert "p1" in card
+
+    def test_ask_card_shows_header(self) -> None:
+        card = format_ask_card(_questions(SINGLE_CHOICE), pending_id="p1", locale="en")
+        assert "[Storage]" in card
+
+    def test_multi_select_hint(self) -> None:
+        card = format_ask_card(_questions(MULTI_CHOICE), pending_id="p1", locale="en")
+        assert "multiple allowed" in card
+
+    def test_open_ended_hint(self) -> None:
+        card = format_ask_card(_questions(OPEN_ENDED), pending_id="p1", locale="en")
+        assert "answer in a sentence" in card
+
+    def test_approval_card_unchanged(self) -> None:
+        card = format_hitl_card(APPROVAL, pending_id="p1", locale="en")
+        assert "command" in card
+
+    def test_zh_locale(self) -> None:
+        card = format_hitl_card(SINGLE_CHOICE, pending_id="p1", locale="zh")
+        assert "拍板" in card
+
+    def test_im_card_shows_only_current_question(self) -> None:
+        questions = _questions(THREE_QUESTIONS)
+        first = format_ask_card(questions, pending_id="p1", locale="en")
+        assert "Question 1 of 3" in first
+        assert "Where should we go?" in first
+        assert "What is the budget?" not in first
+
+        second = format_ask_card(
+            questions,
+            pending_id="p1",
+            locale="en",
+            question_index=1,
+        )
+        assert "Question 2 of 3" in second
+        assert "What is the budget?" in second
+        assert "Where should we go?" not in second
+
+    def test_im_options_are_separated_by_blank_lines(self) -> None:
+        card = format_ask_card(_questions(SINGLE_CHOICE), pending_id="p1", locale="en")
+        assert "a) PostgreSQL — Concurrent writes\n\n" in card
+
+
+class TestReplyParsing:
+    @pytest.mark.parametrize("reply", ["a", "1"])
+    def test_letter_and_digit_select_first_option(self, reply: str) -> None:
+        answer = parse_ask_reply(reply, _questions(SINGLE_CHOICE), locale="en")
+        assert "PostgreSQL" in answer
+
+    def test_second_option(self) -> None:
+        answer = parse_ask_reply("b", _questions(SINGLE_CHOICE), locale="en")
+        assert "SQLite" in answer
+
+    def test_multi_select_expands_all(self) -> None:
+        answer = parse_ask_reply("a,c", _questions(MULTI_CHOICE), locale="en")
+        assert "Feishu" in answer
+        assert "Telegram" in answer
+
+    def test_single_select_keeps_one(self) -> None:
+        answer = parse_ask_reply("a,b", _questions(SINGLE_CHOICE), locale="en")
+        assert "SQLite" not in answer
+        assert "PostgreSQL" in answer
+
+    def test_out_of_range_forwarded_verbatim(self) -> None:
+        answer = parse_ask_reply("z", _questions(SINGLE_CHOICE), locale="en")
+        assert answer == "z"
+
+    def test_free_text_forwarded_verbatim(self) -> None:
+        text = "SQLite, but enable WAL mode"
+        assert parse_ask_reply(text, _questions(SINGLE_CHOICE), locale="en") == text
+
+    def test_topic_switch_forwarded_verbatim(self) -> None:
+        text = "actually, show me the logs first"
+        assert parse_ask_reply(text, _questions(SINGLE_CHOICE), locale="en") == text
+
+    def test_open_ended_forwarded_verbatim(self) -> None:
+        assert parse_ask_reply("a", _questions(OPEN_ENDED), locale="en") == "a"
+
+    def test_multi_question_forwarded_verbatim(self) -> None:
+        questions = _questions(SINGLE_CHOICE) + _questions(MULTI_CHOICE)
+        assert parse_ask_reply("a", questions, locale="en") == "a"
+
+
+class TestCoordinatorRouting:
+    def _register(self, store: HitlPendingStore, actions: list[dict]) -> None:
+        store.register(
+            thread_id="thr1",
+            agent_id="agent1",
+            user_id=7,
+            session_key="sk1",
+            channel_type="feishu",
+            action_requests=actions,
+            review_configs=None,
+        )
+
+    def test_resolves_ask_pending(self) -> None:
+        coordinator = HitlChannelCoordinator(HitlPendingStore())
+        self._register(coordinator.store, SINGLE_CHOICE)
+        record = coordinator.resolve_ask_pending("sk1", agent_id="agent1", user_id=7)
+        assert record is not None
+        assert record.thread_id == "thr1"
+
+    def test_approval_pending_not_routed(self) -> None:
+        coordinator = HitlChannelCoordinator(HitlPendingStore())
+        self._register(coordinator.store, APPROVAL)
+        assert coordinator.resolve_ask_pending("sk1", agent_id="agent1", user_id=7) is None
+
+    def test_other_user_cannot_answer(self) -> None:
+        coordinator = HitlChannelCoordinator(HitlPendingStore())
+        self._register(coordinator.store, SINGLE_CHOICE)
+        assert coordinator.resolve_ask_pending("sk1", agent_id="agent1", user_id=99) is None
+
+    def test_other_agent_not_routed(self) -> None:
+        coordinator = HitlChannelCoordinator(HitlPendingStore())
+        self._register(coordinator.store, SINGLE_CHOICE)
+        assert coordinator.resolve_ask_pending("sk1", agent_id="other", user_id=7) is None
+
+    def test_no_pending(self) -> None:
+        coordinator = HitlChannelCoordinator(HitlPendingStore())
+        assert coordinator.resolve_ask_pending("sk1", agent_id="agent1", user_id=7) is None
+
+    def test_build_answer_decisions(self) -> None:
+        coordinator = HitlChannelCoordinator(HitlPendingStore())
+        self._register(coordinator.store, SINGLE_CHOICE)
+        record = coordinator.resolve_ask_pending("sk1", agent_id="agent1", user_id=7)
+        assert record is not None
+        decisions = coordinator.build_answer_decisions(record, "a", locale="en")
+        assert len(decisions) == 1
+        assert decisions[0]["type"] == "respond"
+        assert "PostgreSQL" in decisions[0]["message"]
+
+    def test_resolved_pending_not_routed(self) -> None:
+        coordinator = HitlChannelCoordinator(HitlPendingStore())
+        self._register(coordinator.store, SINGLE_CHOICE)
+        record = coordinator.resolve_ask_pending("sk1", agent_id="agent1", user_id=7)
+        assert record is not None
+        coordinator.store.mark_resolved(record.pending_id, "approved")
+        assert coordinator.resolve_ask_pending("sk1", agent_id="agent1", user_id=7) is None
+
+    def test_multiple_questions_are_collected_before_resume(self) -> None:
+        coordinator = HitlChannelCoordinator(HitlPendingStore())
+        self._register(coordinator.store, THREE_QUESTIONS)
+        record = coordinator.resolve_ask_pending("sk1", agent_id="agent1", user_id=7)
+        assert record is not None
+
+        resume, next_card = coordinator.collect_ask_reply(record, "a", locale="en")
+        assert resume is None
+        assert next_card is not None
+        assert "Question 2 of 3" in next_card
+        assert record.ask_answers == ["Mountains"]
+
+        resume, next_card = coordinator.collect_ask_reply(record, "b", locale="en")
+        assert resume is None
+        assert next_card is not None
+        assert "Question 3 of 3" in next_card
+        assert record.ask_answers == ["Mountains", "Premium"]
+
+        resume, next_card = coordinator.collect_ask_reply(record, "a", locale="en")
+        assert next_card is None
+        assert resume is not None
+        assert "Destination: Mountains" in resume
+        assert "Budget: Premium" in resume
+        assert "Transport: Train" in resume
+
+
+ASK_REVIEW = [{"action_name": "ask_user_question", "allowed_decisions": ["respond"]}]
+APPROVAL_REVIEW = [{"action_name": "execute", "allowed_decisions": ["approve", "reject"]}]
+
+
+class TestDecisionValidation:
+    """A stale client must fail fast at the API, not deep inside the graph."""
+
+    def _record(self, actions: list[dict], review: list[dict] | None):
+        store = HitlPendingStore()
+        return store.register(
+            thread_id="thr1",
+            agent_id="agent1",
+            user_id=7,
+            session_key="sk1",
+            channel_type="dashboard",
+            action_requests=actions,
+            review_configs=review,
+        )
+
+    def test_approve_on_ask_tool_rejected(self) -> None:
+        record = self._record(SINGLE_CHOICE, ASK_REVIEW)
+        reason = decision_rejection_reason(record, [{"type": "approve"}])
+        assert reason is not None
+        assert "not allowed" in reason
+        assert "ask_user_question" in reason
+
+    def test_respond_on_ask_tool_accepted(self) -> None:
+        record = self._record(SINGLE_CHOICE, ASK_REVIEW)
+        decisions = [{"type": "respond", "message": "PostgreSQL"}]
+        assert decision_rejection_reason(record, decisions) is None
+
+    def test_respond_on_approval_tool_rejected(self) -> None:
+        record = self._record(APPROVAL, APPROVAL_REVIEW)
+        reason = decision_rejection_reason(record, [{"type": "respond", "message": "x"}])
+        assert reason is not None
+        assert "not allowed" in reason
+
+    def test_approve_on_approval_tool_accepted(self) -> None:
+        record = self._record(APPROVAL, APPROVAL_REVIEW)
+        assert decision_rejection_reason(record, [{"type": "approve"}]) is None
+
+    def test_count_mismatch_rejected(self) -> None:
+        record = self._record(SINGLE_CHOICE, ASK_REVIEW)
+        decisions = [{"type": "respond", "message": "a"}, {"type": "respond", "message": "b"}]
+        reason = decision_rejection_reason(record, decisions)
+        assert reason is not None
+        assert "expected 1 decision" in reason
+
+    def test_missing_review_configs_allows_anything(self) -> None:
+        record = self._record(SINGLE_CHOICE, None)
+        assert decision_rejection_reason(record, [{"type": "approve"}]) is None

--- a/tests/unit/gateway/test_hitl_resume_projection.py
+++ b/tests/unit/gateway/test_hitl_resume_projection.py
@@ -1,0 +1,84 @@
+"""Dashboard HITL resume keeps the thread-history projection complete."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+
+from octop.infra.gateway.process.processor import GlobalProcessor
+from octop.infra.gateway.slash.dispatcher import SlashDispatcher
+
+
+@pytest.mark.asyncio
+async def test_hitl_resume_records_final_answer_in_thread_history() -> None:
+    messages = [
+        HumanMessage(content="plan a trip", id="user-1"),
+        AIMessage(
+            content="",
+            id="ask-1",
+            tool_calls=[
+                {
+                    "name": "ask_user_question",
+                    "args": {"questions": []},
+                    "id": "call-1",
+                    "type": "tool_call",
+                }
+            ],
+        ),
+        ToolMessage(content="nature, premium, mixed", tool_call_id="call-1", id="answer-1"),
+        AIMessage(content="Here is the completed itinerary.", id="final-1"),
+    ]
+
+    async def _resume(*_args: object, **_kwargs: object):
+        yield {"type": "state_snapshot", "data": {"messages": messages}}
+        yield {
+            "type": "usage",
+            "usage": {"input_tokens": 100, "output_tokens": 20, "total_tokens": 120},
+        }
+
+    agent_manager = MagicMock()
+    agent_manager.resume_hitl = _resume
+    thread_registry = MagicMock()
+    history_repo = MagicMock()
+    usage_repo = MagicMock()
+    processor = GlobalProcessor(
+        agent_manager=agent_manager,
+        thread_registry=thread_registry,
+        audit_repo=MagicMock(),
+        agent_repo=MagicMock(),
+        user_repo=MagicMock(),
+        connector_repo=MagicMock(),
+        dispatcher=SlashDispatcher(),
+        usage_repo=usage_repo,
+        thread_message_repo=history_repo,
+        gateway=None,
+    )
+
+    chunks = [
+        chunk
+        async for chunk in processor.iter_hitl_resume_chunks(
+            agent_id="agent-1",
+            thread_id="thread-1",
+            user_id=7,
+            decisions=[{"type": "respond", "message": "nature, premium, mixed"}],
+        )
+    ]
+
+    assert [chunk["type"] for chunk in chunks] == ["state_snapshot", "usage"]
+    thread_registry.touch_last_active.assert_called_once_with("thread-1")
+    history_repo.append_if_ready.assert_called_once()
+    thread_id, projected = history_repo.append_if_ready.call_args.args
+    assert thread_id == "thread-1"
+    assert [item.message_id for item in projected] == [
+        "user-1",
+        "ask-1",
+        "answer-1",
+        "final-1",
+    ]
+    assert json.loads(projected[-1].message_json)["data"]["content"] == (
+        "Here is the completed itinerary."
+    )
+    usage_repo.record.assert_called_once()


### PR DESCRIPTION
## Summary

- add a Dashboard question card that stays above the composer, asks bundled questions one at a time, and collapses after answering
- resume `ask_user_question` through the existing HITL `respond` path with validation, usage tracking, and history persistence
- support sequential question/answer collection in IM channels, including letter/number option shortcuts and follow-up HITL pauses
- expose the built-in interaction tool in the tool catalog and add Chinese/English UI and IM copy

## Merge prerequisite

- [x] **Do not merge until a harness-agent release containing `ask_user_question` is published and installable.**
- Verified on 2026-08-30: `orcakit-harness-agent==1.0.1` is published on PyPI, its wheel contains `harness_agent/builtin/tools/ask_user.py`, and current `develop` already requires `orcakit-harness-agent[all]>=1.0.1`.
- If CI or an internal package mirror cannot resolve 1.0.1 yet, keep this PR unmerged until propagation completes.

## Validation

- `make all`: 2717 passed, 15 skipped; Ruff, formatting, and mypy passed
- Dashboard focused tests: 2 files, 5 tests passed
- Dashboard production build: passed

## Notes

- The implementation reuses Octop's existing HITL coordinator and persistence flow; it does not add a second question database or require a harness-gateway change.
- `/skip` is intentionally not part of the IM ask-user flow; a user's next ordinary text message answers the current question.
