### PR TITLE
fix(cli): fix octop acp AttributeError (registry attr)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 ### 修复
 
+- `octop acp`：CLI 注册表属性名与 `acp_cmd` 对齐，修复启动即 `AttributeError`（#486）
 - 合并冲突的双份 schema v10 迁移：投影表不再被 `010_kb_max_documents` 抢先抬版本而跳过；启动时幂等补建 `thread_messages` / `thread_history_projection`
 - Windows CI：`test_create_keeps_user_workspace_dir` 等真实 Harness 单测关闭 memory，避免 GC 线程与 `close()` 争用 SQLite 触发 access violation
 - 更新腾讯云通用 Token Plan 的七个规范模型，新增企业版（中国站）与 Hy Token Plan 预设，并让企业版 DeepSeek 沿用嵌套 thinking effort 适配

--- a/src/octop/cli/registry.py
+++ b/src/octop/cli/registry.py
@@ -26,6 +26,6 @@ COMMANDS: dict[str, tuple[str, str, str]] = {
     "update": (".commands.update", "update", "Check for and install a newer Octop release."),
     "clean": (".commands.clean", "clean", "Remove CLI state or wipe all of ~/.octop."),
     "backup": (".commands.backup", "backup", "Export and restore Octop backups."),
-    "acp": (".commands.acp", "acp", "Run Octop agent as ACP server (stdio)."),
+    "acp": (".commands.acp", "acp_cmd", "Run Octop agent as ACP server (stdio)."),
     "plugin": (".commands.plugin", "plugin", "Install and manage plugins."),
 }

--- a/tests/unit/cli/test_registry.py
+++ b/tests/unit/cli/test_registry.py
@@ -1,0 +1,29 @@
+"""Lazy CLI registry integrity — every COMMANDS attr must resolve."""
+
+from __future__ import annotations
+
+import importlib
+
+import click
+from click.testing import CliRunner
+
+from octop.cli.main import cli
+from octop.cli.registry import COMMANDS
+
+
+def test_all_registry_attrs_are_click_commands() -> None:
+    for name, (module_path, attr, _help) in COMMANDS.items():
+        mod = importlib.import_module(module_path, package="octop.cli")
+        assert hasattr(mod, attr), f"{name}: module {module_path} missing attr {attr!r}"
+        result = getattr(mod, attr)
+        assert isinstance(result, click.Command), (
+            f"{name}: {module_path}.{attr} is {type(result).__name__}, not click.Command"
+        )
+
+
+def test_acp_help_loads() -> None:
+    """Regression for #486: registry must point at acp_cmd, not missing attr acp."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["acp", "--help"])
+    assert result.exit_code == 0, result.output or result.exception
+    assert "ACP" in result.output or "acp" in result.output.lower()


### PR DESCRIPTION
## Summary

- Point CLI lazy registry attribute for `acp` at `acp_cmd` (was looking up missing `acp`)
- Add registry integrity + `octop acp --help` regression tests
- Update `CHANGELOG.md` for the user-facing CLI crash fix

Fixes #486

## Test plan

- [x] `uv run octop acp --help` prints help (exit 0)
- [x] `uv run pytest tests/unit/cli/test_registry.py -q`
- [x] Pre-commit / `make all` green on commit