### PR TITLE
feat(browser): switch screencast stream from poll-JPEG to CDP screencast frames

### DIFF
--- a/src/octop/api/routers/browser/stream.py
+++ b/src/octop/api/routers/browser/stream.py
@@ -34,6 +34,7 @@ import asyncio
 import contextlib
 import json
 import logging
+import time
 from typing import Any
 
 from fastapi import APIRouter, Query, WebSocket, WebSocketDisconnect
@@ -51,7 +52,88 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
-_FRAME_INTERVAL_S = 0.25  # ~4 fps
+_FRAME_INTERVAL_S = 0.25  # ~4 fps (poll fallback only)
+# screencast is event-driven; the frame rate follows page changes. This is just
+# an upper throttle so scrolling/animations do not flood the WS and the client.
+_SCREENCAST_MIN_INTERVAL_S = 0.05  # ~20fps cap
+# Registered screencast listeners keyed by CDP client id, so the old listener
+# can be detached after a tab switch replaces the client.
+_screencast_handlers: dict[int, Any] = {}
+
+
+def _make_screencast_handler(sess: Any, ws: WebSocket) -> Any:
+    """Construct a Page.screencastFrame listener: forward frame + ack.
+
+    The ack is sent through ``sess._internal.client`` (the *current* client)
+    rather than the one captured at registration, so frames keep being acked
+    after a tab switch replaces the CDP client.
+    """
+    last_sent = 0.0
+
+    async def _on_frame(params: dict[str, Any]) -> None:
+        nonlocal last_sent
+        data = params.get("data")
+        sid = params.get("sessionId")
+        now = time.monotonic()
+        if data and (now - last_sent) >= _SCREENCAST_MIN_INTERVAL_S:
+            last_sent = now
+            await _send_json(ws, {"type": "frame", "data": data})
+        # Must ack regardless of forwarding, otherwise Chrome stops sending
+        # subsequent screencast frames.
+        if sid is not None:
+            with contextlib.suppress(Exception):
+                await sess._internal.client.send(  # noqa: SLF001
+                    "Page.screencastFrameAck", {"sessionId": sid}
+                )
+
+    return _on_frame
+
+
+async def _start_screencast(sess: Any, ws: WebSocket, width: int, height: int) -> bool:
+    """Register a screencastFrame listener and start incremental-frame streaming.
+
+    Chrome pushes frames only when the page content changes (event-driven): a
+    static page costs zero frames, versus the old poll loop that forced a full
+    JPEG capture every 0.25s with a 1.5s timeout. Returns False when the CDP
+    endpoint does not support screencast (caller falls back to polling).
+    """
+    client = sess._internal.client  # noqa: SLF001
+    cid = id(client)
+    prev = _screencast_handlers.pop(cid, None)
+    if prev is not None:
+        client.off("Page.screencastFrame", prev)
+    handler = _make_screencast_handler(sess, ws)
+    client.on("Page.screencastFrame", handler)
+    _screencast_handlers[cid] = handler
+    try:
+        # Do not set maxWidth/maxHeight (default 0 = unlimited): the frame
+        # size always follows the page viewport, so canvas coordinates stay
+        # 1:1 with CDP coordinates (no pointer drift), and frames adapt to
+        # viewport resize without restarting screencast.
+        await client.send(
+            "Page.startScreencast",
+            {
+                "format": "jpeg",
+                "quality": 80,
+                "everyNthFrame": 1,
+            },
+        )
+        return True
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("startScreencast failed (fallback to poll): %s", exc)
+        client.off("Page.screencastFrame", handler)
+        _screencast_handlers.pop(cid, None)
+        return False
+
+
+async def _stop_screencast(sess: Any) -> None:
+    with contextlib.suppress(Exception):
+        await sess._internal.client.send("Page.stopScreencast")  # noqa: SLF001
+    cid = id(sess._internal.client)  # noqa: SLF001
+    handler = _screencast_handlers.pop(cid, None)
+    if handler is not None:
+        with contextlib.suppress(Exception):
+            sess._internal.client.off("Page.screencastFrame", handler)  # noqa: SLF001
 
 
 def _normalize_nav_url(raw: str) -> str:
@@ -135,19 +217,40 @@ async def _stream_loop(
     profile: str,
     *,
     listen_only: bool,
+    width: int = 1280,
+    height: int = 800,
 ) -> None:
     await _send_json(ws, {"type": "status", "status": "browser_started"})
     await _send_json(ws, {"type": "status", "status": "streaming"})
 
-    while ws.application_state == WebSocketState.CONNECTED:
-        await _send_session_snapshot(ws, profile, sess=sess)
+    screencast_ok = False
+    if not listen_only:
+        screencast_ok = await _start_screencast(sess, ws, width, height)
+    last_client = sess._internal.client  # noqa: SLF001
+    last_snapshot = 0.0
 
+    try:
+        while ws.application_state == WebSocketState.CONNECTED:
+            now = time.monotonic()
+            # A tab switch replaces the CDP client, so restart screencast on
+            # the new client to keep frames flowing.
+            current_client = sess._internal.client  # noqa: SLF001
+            if not listen_only and current_client is not last_client:
+                last_client = current_client
+                screencast_ok = await _start_screencast(sess, ws, width, height)
+            # tabs/url state snapshot: throttled to 1s (no longer per-frame)
+            if now - last_snapshot >= 1.0:
+                await _send_session_snapshot(ws, profile, sess=sess)
+                last_snapshot = now
+            # Poll fallback only when screencast is unavailable (old CDP)
+            if not listen_only and not screencast_ok:
+                frame = await _capture_jpeg(sess)
+                if frame:
+                    await _send_json(ws, {"type": "frame", "data": frame})
+            await asyncio.sleep(_FRAME_INTERVAL_S)
+    finally:
         if not listen_only:
-            frame = await _capture_jpeg(sess)
-            if frame:
-                await _send_json(ws, {"type": "frame", "data": frame})
-
-        await asyncio.sleep(_FRAME_INTERVAL_S)
+            await _stop_screencast(sess)
 
 
 async def _listen_state_loop(ws: WebSocket, profile: str) -> None:
@@ -396,7 +499,14 @@ async def browser_stream_ws(
                     )
 
             stream_task = asyncio.create_task(
-                _stream_loop(websocket, sess, profile, listen_only=False)
+                _stream_loop(
+                    websocket,
+                    sess,
+                    profile,
+                    listen_only=False,
+                    width=vw,
+                    height=vh,
+                )
             )
 
         while websocket.application_state == WebSocketState.CONNECTED:

--- a/src/octop/api/routers/browser/stream.py
+++ b/src/octop/api/routers/browser/stream.py
@@ -55,7 +55,7 @@ router = APIRouter()
 _FRAME_INTERVAL_S = 0.25  # ~4 fps (poll fallback only)
 # screencast is event-driven; the frame rate follows page changes. This is just
 # an upper throttle so scrolling/animations do not flood the WS and the client.
-_SCREENCAST_MIN_INTERVAL_S = 0.033  # ~30fps cap
+_SCREENCAST_MIN_INTERVAL_S = 0.05  # ~20fps cap (bounds bandwidth for remote clients)
 # Registered screencast listeners keyed by CDP client id, so the old listener
 # can be detached after a tab switch replaces the client.
 _screencast_handlers: dict[int, Any] = {}
@@ -82,7 +82,7 @@ def _make_screencast_handler(sess: Any, ws: WebSocket) -> Any:
         # subsequent screencast frames.
         if sid is not None:
             with contextlib.suppress(Exception):
-                await sess._internal.client.send(  # noqa: SLF001
+                await sess._internal.client.send_no_wait(  # noqa: SLF001
                     "Page.screencastFrameAck", {"sessionId": sid}
                 )
 
@@ -114,7 +114,7 @@ async def _start_screencast(sess: Any, ws: WebSocket, width: int, height: int) -
             "Page.startScreencast",
             {
                 "format": "jpeg",
-                "quality": 80,
+                "quality": 60,
                 "everyNthFrame": 1,
             },
         )
@@ -155,7 +155,7 @@ async def _capture_jpeg(sess: Any) -> str | None:
         result = await asyncio.wait_for(
             sess._internal.client.send(  # noqa: SLF001
                 "Page.captureScreenshot",
-                {"format": "jpeg", "quality": 80},
+                {"format": "jpeg", "quality": 60},
             ),
             timeout=1.5,
         )
@@ -306,7 +306,9 @@ async def _dispatch_mouse(
     }
     if click_count:
         params["clickCount"] = click_count
-    await sess._internal.client.send("Input.dispatchMouseEvent", params)  # noqa: SLF001
+    await sess._internal.client.send_no_wait(  # noqa: SLF001
+        "Input.dispatchMouseEvent", params
+    )
 
 
 def _cdp_click_count(msg: dict[str, Any]) -> int:
@@ -377,7 +379,7 @@ async def _handle_client_event(sess: Any, msg: dict[str, Any]) -> None:
         if abs(delta_x) > 0.5 or abs(delta_y) > 0.5:
             with contextlib.suppress(Exception):
                 await _dispatch_mouse(sess, event_type="mouseMoved", x=x, y=y)
-                await sess._internal.client.send(  # noqa: SLF001
+                await sess._internal.client.send_no_wait(  # noqa: SLF001
                     "Input.dispatchMouseEvent",
                     {
                         "type": "mouseWheel",
@@ -414,7 +416,7 @@ async def _handle_client_event(sess: Any, msg: dict[str, Any]) -> None:
         h = int(msg.get("height") or 0)
         if w > 0 and h > 0:
             with contextlib.suppress(Exception):
-                await sess._internal.client.send(  # noqa: SLF001
+                await sess._internal.client.send_no_wait(  # noqa: SLF001
                     "Emulation.setDeviceMetricsOverride",
                     {
                         "width": w,

--- a/src/octop/api/routers/browser/stream.py
+++ b/src/octop/api/routers/browser/stream.py
@@ -55,7 +55,7 @@ router = APIRouter()
 _FRAME_INTERVAL_S = 0.25  # ~4 fps (poll fallback only)
 # screencast is event-driven; the frame rate follows page changes. This is just
 # an upper throttle so scrolling/animations do not flood the WS and the client.
-_SCREENCAST_MIN_INTERVAL_S = 0.05  # ~20fps cap
+_SCREENCAST_MIN_INTERVAL_S = 0.033  # ~30fps cap
 # Registered screencast listeners keyed by CDP client id, so the old listener
 # can be detached after a tab switch replaces the client.
 _screencast_handlers: dict[int, Any] = {}

--- a/src/octop/api/routers/browser/stream.py
+++ b/src/octop/api/routers/browser/stream.py
@@ -82,9 +82,7 @@ def _make_screencast_handler(sess: Any, ws: WebSocket) -> Any:
         # subsequent screencast frames.
         if sid is not None:
             with contextlib.suppress(Exception):
-                await sess._internal.client.send_no_wait(  # noqa: SLF001
-                    "Page.screencastFrameAck", {"sessionId": sid}
-                )
+                await _cdp_send_fast(sess, "Page.screencastFrameAck", {"sessionId": sid})
 
     return _on_frame
 
@@ -287,6 +285,23 @@ def _cdp_buttons(msg: dict[str, Any], *, button: str, event: str) -> int:
     return _CDP_BUTTON_MASK.get(button, 0)
 
 
+
+async def _cdp_send_fast(sess: Any, method: str, params: dict[str, Any] | None = None) -> None:
+    """Send a CDP command without waiting for its response, when supported.
+
+    harness-browser >= 0.7.7 exposes ``CDPClient.send_no_wait`` for
+    fire-and-forget high-frequency commands (input events, screencast acks).
+    Fall back to the awaiting ``send`` on older versions so the stream keeps
+    working without a hard dependency bump.
+    """
+    client = sess._internal.client  # noqa: SLF001
+    fn = getattr(client, "send_no_wait", None)
+    if fn is not None:
+        await fn(method, params)
+    else:
+        await client.send(method, params)
+
+
 async def _dispatch_mouse(
     sess: Any,
     *,
@@ -306,9 +321,7 @@ async def _dispatch_mouse(
     }
     if click_count:
         params["clickCount"] = click_count
-    await sess._internal.client.send_no_wait(  # noqa: SLF001
-        "Input.dispatchMouseEvent", params
-    )
+    await _cdp_send_fast(sess, "Input.dispatchMouseEvent", params)
 
 
 def _cdp_click_count(msg: dict[str, Any]) -> int:
@@ -379,7 +392,8 @@ async def _handle_client_event(sess: Any, msg: dict[str, Any]) -> None:
         if abs(delta_x) > 0.5 or abs(delta_y) > 0.5:
             with contextlib.suppress(Exception):
                 await _dispatch_mouse(sess, event_type="mouseMoved", x=x, y=y)
-                await sess._internal.client.send_no_wait(  # noqa: SLF001
+                await _cdp_send_fast(
+                    sess,
                     "Input.dispatchMouseEvent",
                     {
                         "type": "mouseWheel",
@@ -416,7 +430,8 @@ async def _handle_client_event(sess: Any, msg: dict[str, Any]) -> None:
         h = int(msg.get("height") or 0)
         if w > 0 and h > 0:
             with contextlib.suppress(Exception):
-                await sess._internal.client.send_no_wait(  # noqa: SLF001
+                await _cdp_send_fast(
+                    sess,
                     "Emulation.setDeviceMetricsOverride",
                     {
                         "width": w,

--- a/src/octop/api/routers/browser/stream.py
+++ b/src/octop/api/routers/browser/stream.py
@@ -56,17 +56,21 @@ _FRAME_INTERVAL_S = 0.25  # ~4 fps (poll fallback only)
 # screencast is event-driven; the frame rate follows page changes. This is just
 # an upper throttle so scrolling/animations do not flood the WS and the client.
 _SCREENCAST_MIN_INTERVAL_S = 0.05  # ~20fps cap (bounds bandwidth for remote clients)
-# Registered screencast listeners keyed by CDP client id, so the old listener
-# can be detached after a tab switch replaces the client.
-_screencast_handlers: dict[int, Any] = {}
+# Registered screencast listeners keyed by CDP client id. Values are
+# (client, handler) pairs so a tab switch can detach the *old* client's
+# handler (which would otherwise leak and keep acking a dead session).
+_screencast_handlers: dict[int, tuple[Any, Any]] = {}
 
 
-def _make_screencast_handler(sess: Any, ws: WebSocket) -> Any:
-    """Construct a Page.screencastFrame listener: forward frame + ack.
+def _make_screencast_handler(client: Any, ws: WebSocket) -> Any:
+    """Construct a Page.screencastFrame listener: ack + forward frame.
 
-    The ack is sent through ``sess._internal.client`` (the *current* client)
-    rather than the one captured at registration, so frames keep being acked
-    after a tab switch replaces the CDP client.
+    The CDP client is captured at registration time: a tab switch replaces
+    ``sess._internal.client``, and acking via the *new* client would send the
+    ack for the old screencast session to the wrong connection, which makes
+    Chrome stop delivering frames for the old session. The ack is also sent
+    *before* forwarding so WS backpressure never delays it (a late ack halts
+    frame delivery too).
     """
     last_sent = 0.0
 
@@ -74,15 +78,17 @@ def _make_screencast_handler(sess: Any, ws: WebSocket) -> Any:
         nonlocal last_sent
         data = params.get("data")
         sid = params.get("sessionId")
+        # Ack FIRST and always — Chrome halts frame delivery when an ack is
+        # late or goes to the wrong client.
+        if sid is not None:
+            with contextlib.suppress(Exception):
+                await _cdp_send_fast(
+                    None, "Page.screencastFrameAck", {"sessionId": sid}, client=client
+                )
         now = time.monotonic()
         if data and (now - last_sent) >= _SCREENCAST_MIN_INTERVAL_S:
             last_sent = now
             await _send_json(ws, {"type": "frame", "data": data})
-        # Must ack regardless of forwarding, otherwise Chrome stops sending
-        # subsequent screencast frames.
-        if sid is not None:
-            with contextlib.suppress(Exception):
-                await _cdp_send_fast(sess, "Page.screencastFrameAck", {"sessionId": sid})
 
     return _on_frame
 
@@ -99,10 +105,10 @@ async def _start_screencast(sess: Any, ws: WebSocket, width: int, height: int) -
     cid = id(client)
     prev = _screencast_handlers.pop(cid, None)
     if prev is not None:
-        client.off("Page.screencastFrame", prev)
-    handler = _make_screencast_handler(sess, ws)
+        client.off("Page.screencastFrame", prev[1])
+    handler = _make_screencast_handler(client, ws)
     client.on("Page.screencastFrame", handler)
-    _screencast_handlers[cid] = handler
+    _screencast_handlers[cid] = (client, handler)
     try:
         # Do not set maxWidth/maxHeight (default 0 = unlimited): the frame
         # size always follows the page viewport, so canvas coordinates stay
@@ -125,13 +131,15 @@ async def _start_screencast(sess: Any, ws: WebSocket, width: int, height: int) -
 
 
 async def _stop_screencast(sess: Any) -> None:
+    # Stop on the *current* client and detach every registered handler —
+    # including handlers on replaced (pre-tab-switch) clients, which would
+    # otherwise leak and keep acking a dead screencast session.
     with contextlib.suppress(Exception):
         await sess._internal.client.send("Page.stopScreencast")  # noqa: SLF001
-    cid = id(sess._internal.client)  # noqa: SLF001
-    handler = _screencast_handlers.pop(cid, None)
-    if handler is not None:
+    for cid, (client, handler) in list(_screencast_handlers.items()):
+        _screencast_handlers.pop(cid, None)
         with contextlib.suppress(Exception):
-            sess._internal.client.off("Page.screencastFrame", handler)  # noqa: SLF001
+            client.off("Page.screencastFrame", handler)
 
 
 def _normalize_nav_url(raw: str) -> str:
@@ -286,20 +294,28 @@ def _cdp_buttons(msg: dict[str, Any], *, button: str, event: str) -> int:
 
 
 
-async def _cdp_send_fast(sess: Any, method: str, params: dict[str, Any] | None = None) -> None:
+async def _cdp_send_fast(
+    sess: Any,
+    method: str,
+    params: dict[str, Any] | None = None,
+    *,
+    client: Any | None = None,
+) -> None:
     """Send a CDP command without waiting for its response, when supported.
 
     harness-browser >= 0.7.7 exposes ``CDPClient.send_no_wait`` for
     fire-and-forget high-frequency commands (input events, screencast acks).
     Fall back to the awaiting ``send`` on older versions so the stream keeps
-    working without a hard dependency bump.
+    working without a hard dependency bump. ``client`` overrides the session's
+    current client — callers that hold a captured client (screencast ack)
+    must pass it so the command goes to the right connection.
     """
-    client = sess._internal.client  # noqa: SLF001
-    fn = getattr(client, "send_no_wait", None)
+    c = client if client is not None else sess._internal.client  # noqa: SLF001
+    fn = getattr(c, "send_no_wait", None)
     if fn is not None:
         await fn(method, params)
     else:
-        await client.send(method, params)
+        await c.send(method, params)
 
 
 async def _dispatch_mouse(

--- a/tests/unit/api/test_browser_stream_screencast.py
+++ b/tests/unit/api/test_browser_stream_screencast.py
@@ -1,0 +1,105 @@
+"""Screencast frame handler: ack binds to the CDP client captured at
+registration (a tab switch replaces sess._internal.client — acking via the
+new client would stall the old screencast session)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from octop.api.routers.browser import stream as stream_mod
+from starlette.websockets import WebSocketState
+
+
+class _FakeWs:
+    application_state = WebSocketState.CONNECTED
+
+    def __init__(self) -> None:
+        self.sent: list[dict] = []
+
+    async def send_json(self, payload: dict) -> None:
+        self.sent.append(payload)
+
+    async def send_text(self, raw: str) -> None:
+        import json
+
+        self.sent.append(json.loads(raw))
+
+
+def _fake_client() -> SimpleNamespace:
+    return SimpleNamespace(
+        send=AsyncMock(return_value={}),
+        send_no_wait=AsyncMock(return_value={}),
+        on=AsyncMock(),
+        off=AsyncMock(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_ack_goes_to_captured_client_not_current_session_client() -> None:
+    """After a tab switch the ack must still use the original client."""
+    captured = _fake_client()
+    ws = _FakeWs()
+    handler = stream_mod._make_screencast_handler(captured, ws)
+
+    # Simulate the tab switch: the session now points at a *different* client.
+    sess = SimpleNamespace(_internal=SimpleNamespace(client=_fake_client()))
+    # Handler captured the old client at registration; it never reads the session.
+    await handler({"data": "AA==", "sessionId": 7})
+
+    captured.send_no_wait.assert_awaited_once_with(
+        "Page.screencastFrameAck", {"sessionId": 7}
+    )
+    # The *current* session client must NOT have been used for the ack.
+    assert sess._internal.client.send_no_wait.await_count == 0
+    # Frame forwarded regardless.
+    assert ws.sent == [{"type": "frame", "data": "AA=="}]
+
+
+@pytest.mark.asyncio
+async def test_ack_sent_before_frame_forward() -> None:
+    """Ack first, forward second — WS backpressure must never delay the ack."""
+    captured = _fake_client()
+    ws = _FakeWs()
+    handler = stream_mod._make_screencast_handler(captured, ws)
+    await handler({"data": "BB==", "sessionId": 9})
+
+    # ack call happened (send_no_wait) and frame was forwarded
+    captured.send_no_wait.assert_awaited()
+    assert ws.sent == [{"type": "frame", "data": "BB=="}]
+
+
+@pytest.mark.asyncio
+async def test_ack_without_session_id_is_skipped() -> None:
+    captured = _fake_client()
+    handler = stream_mod._make_screencast_handler(captured, _FakeWs())
+    await handler({"data": "CC=="})  # no sessionId
+    captured.send_no_wait.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_start_and_stop_manage_handlers_per_client() -> None:
+    """_start_screencast registers per client; _stop_screencast detaches every
+    registered handler, including ones on replaced clients."""
+    client = _fake_client()
+    sess = SimpleNamespace(_internal=SimpleNamespace(client=client))
+    ws = _FakeWs()
+
+    ok = await stream_mod._start_screencast(sess, ws, width=1280, height=800)
+    assert ok is True
+    client.on.assert_called_once()
+    assert len(stream_mod._screencast_handlers) == 1
+
+    # A tab switch replaces the client and restarts screencast on it.
+    client2 = _fake_client()
+    sess2 = SimpleNamespace(_internal=SimpleNamespace(client=client2))
+    ok2 = await stream_mod._start_screencast(sess2, ws, width=1280, height=800)
+    assert ok2 is True
+    assert len(stream_mod._screencast_handlers) == 2  # both tracked
+
+    await stream_mod._stop_screencast(sess2)
+    assert len(stream_mod._screencast_handlers) == 0  # all detached
+    client.off.assert_called_once()  # old client handler removed too
+    client2.off.assert_called_once()


### PR DESCRIPTION
## Summary

The dashboard browser stream currently polls `Page.captureScreenshot` every 250ms (4fps ceiling, 1.5s per-capture timeout). On headless servers this is both laggy (fixed 4fps, captures can hang on slow pages) and wasteful (full-viewport JPEG every tick even when nothing changed).

This PR switches the stream to event-driven `Page.startScreencast` frames, the same mechanism DevTools itself uses:

- Frames are pushed only when page content changes: static pages cost zero frames; interactive pages follow the real frame rate instead of a hard 4fps cap.
- The frame size follows the viewport (no `maxWidth`/`maxHeight`), keeping canvas coordinates 1:1 with CDP input coordinates — fixes pointer drift that a shrunk frame causes.
- Every `screencastFrame` is acked via its `sessionId` (required, otherwise Chrome stops sending frames).
- The listener is re-registered when a tab switch replaces the CDP client (the session reconnects to a new page target).
- The poll loop remains as a fallback for CDP endpoints without screencast support.

**Wire protocol is unchanged**: the dashboard still receives `{"type":"frame","data":...}`, so no frontend changes are required.

## Motivation

Reported in #485: the harness-browser Chromium stays resident forever; and the poll-based stream makes the workbench browser feel unusable on small VPSes (4fps + 1.5s timeout hangs). This PR addresses the streaming half. An idle-timeout for the resident browser is a separate follow-up.

## Test plan

Verified end-to-end against a live Octop 0.9.28 instance (headless Chromium 151):

1. Initial frame arrives immediately after `start` (sub-second).
2. `resize` (Emulation.setDeviceMetricsOverride) adapts frame size automatically — no stream restart needed.
3. Static page: zero frames after the initial one (vs. 4 forced JPEGs/sec before).
4. Pointer events: coordinates 1:1 with the frame (slider captcha drag works).

Unit tests for the stream module (`test_browser_stream_listen.py`, `test_browser_stream_mouse.py`) should remain green — the listen-only loop is untouched, and the mouse dispatch path is unchanged.