### PR TITLE
feat(browser): reap idle Chromium after configurable timeout (#485)

### DIFF
--- a/src/octop/api/routers/browser/harness.py
+++ b/src/octop/api/routers/browser/harness.py
@@ -108,6 +108,11 @@ async def resolve_harness_session(
         if cached is None:
             continue
         if await _is_session_alive(cached):
+            # 仅真实使用（create=True，如打开面板/发起浏览器操作）刷新 idle 计时；
+            # create=False 是 dashboard 状态轮询（listen_state_loop 每 2s 一次），
+            # 打点会导致浏览器永不回收。
+            if create:
+                _notify_browser_activity(server)
             return cached
         logger.warning(
             "harness session %r is dead (stale CDP connection); discarding%s",
@@ -202,7 +207,19 @@ async def resolve_harness_session(
                 status=503,
             ) from exc
     _registry[profile] = sess
+    _notify_browser_activity(server)
     return sess
+
+
+def _notify_browser_activity(server: Any | None) -> None:
+    """刷新浏览器闲置计时（#485 idle monitor 打点）。"""
+    if server is None:
+        return
+    rt = getattr(server, "app_runtime", None)
+    monitor = getattr(rt, "browser_idle_monitor", None) if rt is not None else None
+    if monitor is not None:
+        with contextlib.suppress(Exception):
+            monitor.notify_activity()
 
 
 async def harness_page_url(sess: Any) -> str:

--- a/src/octop/api/routers/browser/stream.py
+++ b/src/octop/api/routers/browser/stream.py
@@ -150,6 +150,37 @@ async def _stream_loop(
         await asyncio.sleep(_FRAME_INTERVAL_S)
 
 
+
+
+def _stream_monitor(ws: WebSocket) -> Any | None:
+    """Locate the BrowserIdleMonitor from the WebSocket's app state."""
+    server = getattr(ws, "app", None)
+    if server is None:
+        return None
+    server = getattr(server, "state", None)
+    if server is None:
+        return None
+    server = getattr(server, "octop_server", None)
+    if server is None:
+        return None
+    rt = getattr(server, "app_runtime", None)
+    return getattr(rt, "browser_idle_monitor", None) if rt is not None else None
+
+
+def _notify_stream_open(ws: WebSocket) -> None:
+    monitor = _stream_monitor(ws)
+    if monitor is not None:
+        with contextlib.suppress(Exception):
+            monitor.notify_stream_open()
+
+
+def _notify_stream_close(ws: WebSocket) -> None:
+    monitor = _stream_monitor(ws)
+    if monitor is not None:
+        with contextlib.suppress(Exception):
+            monitor.notify_stream_close()
+
+
 async def _listen_state_loop(ws: WebSocket, profile: str) -> None:
     """Push session_update events without launching Chrome or capturing frames.
 
@@ -341,6 +372,7 @@ async def browser_stream_ws(
         return
 
     await websocket.accept()
+    _notify_stream_open(websocket)
     sess: Any | None = None
     profile = "default"
     stream_task: asyncio.Task[None] | None = None
@@ -423,6 +455,7 @@ async def browser_stream_ws(
             await _send_json(websocket, {"type": "error", "message": str(exc)})
             await _send_json(websocket, {"type": "status", "status": "error"})
     finally:
+        _notify_stream_close(websocket)
         if stream_task is not None:
             stream_task.cancel()
             with contextlib.suppress(asyncio.CancelledError):

--- a/src/octop/config.py
+++ b/src/octop/config.py
@@ -134,6 +134,9 @@ class OctopConfig:
     backup: BackupConfig = field(default_factory=BackupConfig)
     capabilities: CapabilitiesConfig = field(default_factory=CapabilitiesConfig)
     max_upload_mb: int = DEFAULT_MAX_UPLOAD_MB
+    # 浏览器闲置回收: 无活跃页面/无 WS 流连接且超过该分钟数后关闭 Chrome
+    # 进程（下次使用自动拉起）。0 = 禁用。
+    browser_idle_timeout_minutes: int = 0
 
     @property
     def max_upload_bytes(self) -> int:
@@ -417,6 +420,10 @@ def load_config(path: Path) -> OctopConfig:
         merged["login_lockout_seconds"] = _coerce_int(
             "OCTOP_LOGIN_LOCKOUT_SECONDS", v, merged.get("login_lockout_seconds", 900)
         )
+    if v := os.environ.get("OCTOP_BROWSER_IDLE_TIMEOUT_MINUTES"):
+        merged["browser_idle_timeout_minutes"] = _coerce_int(
+            "OCTOP_BROWSER_IDLE_TIMEOUT_MINUTES", v, 0
+        )
     if (v := os.environ.get("OCTOP_DEFAULT_TIMEZONE")) or (
         v := os.environ.get("OCTOP_CRON_TIMEZONE")
     ):
@@ -514,4 +521,7 @@ def load_config(path: Path) -> OctopConfig:
         backup=backup,
         capabilities=capabilities,
         max_upload_mb=int(merged.get("max_upload_mb", DEFAULT_MAX_UPLOAD_MB)),
+        browser_idle_timeout_minutes=int(
+            merged.get("browser_idle_timeout_minutes", 0)
+        ),
     )

--- a/src/octop/infra/browser/idle.py
+++ b/src/octop/infra/browser/idle.py
@@ -200,7 +200,20 @@ class BrowserIdleMonitor:
                 timeout=5,
                 check=False,
             ).stdout
-            dirs = {Path(d) for d in re.findall(r"user-data-dir=([^\s]+)", out)}
+            # Only kill Chrome instances backed by harness-managed profiles
+            # (Octop relocates them under /tmp/harness-browser-profiles-* or
+            # ~/.octop/browser-profiles) -- never user-launched browsers such
+            # as a dedicated workstation instance.
+            markers = (
+                "harness-browser-profiles",
+                ".octop/browser-profiles",
+                ".harness-browser/profiles",
+            )
+            dirs = {
+                Path(d)
+                for d in re.findall(r"user-data-dir=([^\s]+)", out)
+                if any(m in d for m in markers)
+            }
             for d in dirs:
                 await asyncio.to_thread(pkill_chrome_profile, d)
                 await asyncio.to_thread(clear_profile_locks, d)

--- a/src/octop/infra/browser/idle.py
+++ b/src/octop/infra/browser/idle.py
@@ -1,0 +1,210 @@
+"""Idle reaper for the Octop-managed browser.
+
+harness-browser intentionally keeps its Chromium process running after a
+session closes (profile reuse, sticky CDP targets), so on a headless server
+a single browser use leaves a permanent ~500MB RSS / ~260MB PSS resident
+process (see issue #485). This monitor periodically checks whether the
+browser is actually in use and terminates it after a configurable idle
+window. The next browser_tool / dashboard open relaunches it automatically
+(``launch_or_attach`` + stale-lock cleanup in ``setup.py``).
+
+Activity model (conservative, avoids killing a busy browser):
+
+- ``notify_activity()`` — any Octop-side touch of the browser (session
+  resolve, stream message, tab ops). Agent-driven ``browser_tool`` calls go
+  through harness-browser directly and are not visible here, so activity is
+  also inferred from the browser itself:
+- active page targets (anything other than about:blank / chrome://newtab)
+  count as in-use, and
+- an open ``/api/browser-stream/ws`` connection counts as in-use.
+
+A browser is reaped only when ALL of the following hold:
+
+1. ``browser_idle_timeout_minutes > 0`` (opt-in),
+2. no live stream WS connection,
+3. no non-blank page target,
+4. no ``notify_activity`` within the timeout window,
+5. the CDP port still responds (Chrome is alive).
+
+Reaping closes registered sessions (CDP connection) then kills the Chrome
+process tree for the profile's user-data-dir (reuses ``pkill_chrome_profile``
+from ``setup.py``); login cookies survive on disk, so relaunch is cheap.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import time
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# 检查周期: 后台任务每 60s 跑一次, 判定期望在 timeout 窗口内多次命中
+_CHECK_INTERVAL_S = 60.0
+
+_BLANK_URLS = {"about:blank", "chrome://newtab/", "chrome://newtab"}
+
+
+class BrowserIdleMonitor:
+    """Track browser activity and reap the Chrome process after idle timeout."""
+
+    def __init__(self, timeout_minutes: int, profiles_dir: Any) -> None:
+        self._timeout_s = max(int(timeout_minutes), 0) * 60
+        self._profiles_dir = profiles_dir
+        self._last_activity = time.monotonic()
+        self._stream_conns = 0
+        self._task: asyncio.Task[None] | None = None
+
+    @property
+    def enabled(self) -> bool:
+        return self._timeout_s > 0
+
+    def notify_activity(self) -> None:
+        """Record any Octop-side browser activity."""
+        self._last_activity = time.monotonic()
+
+    def notify_stream_open(self) -> None:
+        self._stream_conns += 1
+        self.notify_activity()
+
+    def notify_stream_close(self) -> None:
+        self._stream_conns = max(0, self._stream_conns - 1)
+        self.notify_activity()
+
+    def start(self) -> None:
+        if not self.enabled or self._task is not None:
+            return
+        self._task = asyncio.create_task(self._run(), name="browser-idle-monitor")
+        logger.info(
+            "browser idle monitor started: reap after %ds without activity",
+            self._timeout_s,
+        )
+
+    async def shutdown(self) -> None:
+        if self._task is None:
+            return
+        self._task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await self._task
+        self._task = None
+
+    # ------------------------------------------------------------------
+
+    async def _run(self) -> None:
+        while True:
+            await asyncio.sleep(_CHECK_INTERVAL_S)
+            try:
+                await self._check_once()
+            except Exception:  # noqa: BLE001 - never kill the loop
+                logger.debug("browser idle check failed", exc_info=True)
+
+    async def _check_once(self) -> None:
+        if self._stream_conns > 0:
+            return
+        if time.monotonic() - self._last_activity < self._timeout_s:
+            return
+        if not await self._cdp_alive():
+            return
+        if await self._has_active_pages():
+            self.notify_activity()  # 页面还在用, 重新计时
+            return
+        logger.info(
+            "browser idle for %.0fs (timeout %ds), reaping Chrome",
+            time.monotonic() - self._last_activity,
+            self._timeout_s,
+        )
+        await self._reap()
+
+    async def _cdp_alive(self) -> bool:
+        try:
+            import aiohttp
+
+            from harness_browser.profile import ProfileManager  # noqa: PLC0415
+
+            pm = ProfileManager(base_dir=self._profiles_dir)
+            ports = [p.cdp_port for p in pm.list_profiles()] or [9222]
+            async with aiohttp.ClientSession() as session:
+                for port in ports:
+                    try:
+                        async with session.get(
+                            f"http://127.0.0.1:{port}/json/version",
+                            timeout=aiohttp.ClientTimeout(total=2),
+                        ) as resp:
+                            if resp.status == 200:
+                                return True
+                    except Exception:  # noqa: BLE001
+                        continue
+            return False
+        except Exception:  # noqa: BLE001
+            return False
+
+    async def _has_active_pages(self) -> bool:
+        try:
+            import aiohttp
+
+            from harness_browser.profile import ProfileManager  # noqa: PLC0415
+
+            pm = ProfileManager(base_dir=self._profiles_dir)
+            ports = [p.cdp_port for p in pm.list_profiles()] or [9222]
+            async with aiohttp.ClientSession() as session:
+                for port in ports:
+                    try:
+                        async with session.get(
+                            f"http://127.0.0.1:{port}/json/list",
+                            timeout=aiohttp.ClientTimeout(total=2),
+                        ) as resp:
+                            targets = await resp.json(content_type=None)
+                        if any(
+                            t.get("type") == "page"
+                            and t.get("url") not in _BLANK_URLS
+                            for t in targets
+                            if isinstance(t, dict)
+                        ):
+                            return True
+                    except Exception:  # noqa: BLE001
+                        continue
+            return False
+        except Exception:  # noqa: BLE001
+            return False
+
+    async def _reap(self) -> None:
+        # 1) 关闭 Octop 进程内缓存的 harness sessions (断 CDP 连接)
+        try:
+            from harness_browser.tool_interface import _registry  # noqa: PLC0415
+
+            for name, sess in list(_registry.items()):
+                _registry.pop(name, None)
+                with contextlib.suppress(Exception):
+                    await sess.close()
+        except Exception:  # noqa: BLE001
+            logger.debug("closing harness registry failed", exc_info=True)
+        # 2) 按 user-data-dir 杀 Chrome 进程树 + 清锁
+        #    不依赖 profiles_dir 配置推断：直接从运行中 Chrome 进程扫描实际
+        #    user-data-dir（Octop 可能 relocate 到 /tmp/harness-browser-profiles-*）。
+        try:
+            import re
+            import subprocess
+
+            from octop.infra.browser.setup import (  # noqa: PLC0415
+                clear_profile_locks,
+                pkill_chrome_profile,
+            )
+
+            out = subprocess.run(
+                ["pgrep", "-af", "chrome"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+                check=False,
+            ).stdout
+            dirs = {Path(d) for d in re.findall(r"user-data-dir=([^\s]+)", out)}
+            for d in dirs:
+                await asyncio.to_thread(pkill_chrome_profile, d)
+                await asyncio.to_thread(clear_profile_locks, d)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("browser reap failed: %s", exc)
+        self._last_activity = time.monotonic()  # 防止紧接的重启风暴
+        logger.info("browser reaped; next use will relaunch automatically")

--- a/src/octop/infra/server.py
+++ b/src/octop/infra/server.py
@@ -85,6 +85,7 @@ class AppRuntime:
     cron_manager: CronManager
     user_manager: UserManager
     proactive_scheduler: ProactiveCareScheduler
+    browser_idle_monitor: Any = None  # BrowserIdleMonitor | None
 
     def replace_services(self, services: SharedServices, config: OctopConfig) -> None:
         """Retarget all runtime singletons onto a new SharedServices / config.
@@ -282,12 +283,30 @@ class OctopServer:
         await user_mgr.boot()
         await proactive_scheduler.start_all()
 
+        # 浏览器闲置回收（#485 配套）: 配置 browser_idle_timeout_minutes > 0 时启用
+        browser_idle_monitor = None
+        timeout_minutes = int(config.browser_idle_timeout_minutes or 0)
+        if timeout_minutes > 0:
+            try:
+                from harness_browser.settings import settings as hb_settings  # noqa: PLC0415
+
+                from octop.infra.browser.idle import BrowserIdleMonitor  # noqa: PLC0415
+
+                browser_idle_monitor = BrowserIdleMonitor(
+                    timeout_minutes=timeout_minutes,
+                    profiles_dir=Path(hb_settings.profiles_dir),
+                )
+                browser_idle_monitor.start()
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("browser idle monitor not started: %s", exc)
+
         self.app_runtime = AppRuntime(
             agent_registry=registry,
             gateway=gateway,
             cron_manager=cron_mgr,
             user_manager=user_mgr,
             proactive_scheduler=proactive_scheduler,
+            browser_idle_monitor=browser_idle_monitor,
         )
         from octop.infra.knowledge.jobs import resume_pending_index_jobs  # noqa: PLC0415
 
@@ -329,6 +348,8 @@ class OctopServer:
         try:
             if self.app_runtime is not None:
                 rt = self.app_runtime
+                if rt.browser_idle_monitor is not None:
+                    await rt.browser_idle_monitor.shutdown()
                 await rt.proactive_scheduler.shutdown()
                 await rt.cron_manager.shutdown()
                 await rt.gateway.shutdown()

--- a/tests/unit/browser/test_browser_idle.py
+++ b/tests/unit/browser/test_browser_idle.py
@@ -1,0 +1,109 @@
+"""Browser idle monitor unit tests (issue #485 follow-up)."""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from octop.infra.browser.idle import BrowserIdleMonitor
+
+
+def _monitor(timeout_minutes: int = 30) -> BrowserIdleMonitor:
+    m = BrowserIdleMonitor(
+        timeout_minutes=timeout_minutes,
+        profiles_dir=Path("/tmp/octop-test-profiles"),
+    )
+    m._last_activity = time.monotonic() - (timeout_minutes * 60 + 60)  # 已超时
+    return m
+
+
+@pytest.mark.asyncio
+async def test_disabled_when_timeout_zero() -> None:
+    m = BrowserIdleMonitor(timeout_minutes=0, profiles_dir=Path("/tmp/x"))
+    assert not m.enabled
+    m.start()  # 不应启动任务
+    assert m._task is None
+
+
+@pytest.mark.asyncio
+async def test_skip_when_stream_connection_open() -> None:
+    m = _monitor()
+    m.notify_stream_open()
+    with patch.object(m, "_cdp_alive", new=AsyncMock(return_value=True)), patch.object(
+        m, "_reap", new=AsyncMock()
+    ):
+        await m._check_once()
+    m._reap.assert_not_awaited()  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_skip_within_timeout_window() -> None:
+    m = _monitor()
+    m.notify_activity()  # 重置计时
+    with patch.object(m, "_cdp_alive", new=AsyncMock(return_value=True)), patch.object(
+        m, "_reap", new=AsyncMock()
+    ):
+        await m._check_once()
+    m._reap.assert_not_awaited()  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_skip_when_active_pages_present() -> None:
+    m = _monitor()
+    with patch.object(m, "_cdp_alive", new=AsyncMock(return_value=True)), patch.object(
+        m, "_has_active_pages", new=AsyncMock(return_value=True)
+    ), patch.object(m, "_reap", new=AsyncMock()):
+        await m._check_once()
+    m._reap.assert_not_awaited()  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_reap_when_idle_and_no_pages() -> None:
+    m = _monitor()
+    with patch.object(m, "_cdp_alive", new=AsyncMock(return_value=True)), patch.object(
+        m, "_has_active_pages", new=AsyncMock(return_value=False)
+    ), patch.object(m, "_reap", new=AsyncMock()):
+        await m._check_once()
+    m._reap.assert_awaited_once()  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_reap_ignores_missing_browser() -> None:
+    m = _monitor()
+    with patch.object(m, "_cdp_alive", new=AsyncMock(return_value=False)), patch.object(
+        m, "_reap", new=AsyncMock()
+    ):
+        await m._check_once()
+    m._reap.assert_not_awaited()  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_reap_closes_registry_and_kills_chrome() -> None:
+    """_reap 应关闭 _registry session 并 pkill 实际 user-data-dir 的 Chrome。"""
+    m = _monitor()
+
+    class _FakeSess:
+        async def close(self) -> None:
+            pass
+
+    fake_registry = {"default": _FakeSess()}
+    fake_pgrep = "1234 chrome --remote-debugging-port=9222 --user-data-dir=/tmp/prof/default\n"
+
+    with (
+        patch(
+            "harness_browser.tool_interface._registry", fake_registry, create=True
+        ),
+        patch(
+            "subprocess.run",
+            return_value=SimpleNamespace(stdout=fake_pgrep),
+        ) as mock_run,
+        patch("octop.infra.browser.setup.pkill_chrome_profile", AsyncMock()),
+        patch("octop.infra.browser.setup.clear_profile_locks", AsyncMock()),
+    ):
+        await m._reap()
+    assert not fake_registry  # session 已弹出
+    mock_run.assert_called()


### PR DESCRIPTION
## Summary

Follow-up to #485. `harness-browser` keeps its headless Chromium resident forever after a session closes (profile reuse, sticky CDP targets), so on a headless server a single browser use leaves a permanent ~500MB RSS / ~260MB PSS process. This PR adds an opt-in idle reaper to Octop:

- **Config**: `browser_idle_timeout_minutes` (0 = disabled, default), env `OCTOP_BROWSER_IDLE_TIMEOUT_MINUTES`.
- **`BrowserIdleMonitor`** (`infra/browser/idle.py`): background task, 60s interval. A browser is reaped only when ALL of these hold:
  1. no live `/api/browser-stream/ws` connection (open dashboard panel keeps it alive),
  2. no non-blank page target (agent working pages keep it alive),
  3. no `notify_activity` within the timeout window,
  4. the CDP port still answers (browser alive).
- **Activity tracking**: `resolve_harness_session(create=True)` and stream WS open/close. `create=False` (dashboard status polling, every 2s) deliberately does NOT extend the timer — otherwise the browser would never be reaped.
- **Reap**: closes registered harness sessions, pkills Chrome by the actual `user-data-dir` scanned from running processes (Octop relocates profiles under `/tmp/harness-browser-profiles-*`), clears stale locks. Next `browser_tool` / dashboard open relaunches automatically (`launch_or_attach` + `setup.py` lock cleanup already handle this).
- **Unit tests** (`tests/unit/browser/test_browser_idle.py`) cover the decision logic.

## Test plan

Verified live on Octop 0.9.28 + Chromium 151 headless:

1. With `OCTOP_BROWSER_IDLE_TIMEOUT_MINUTES=2`: checks run every 60s (`browser idle check` logs), reaping triggers at the 120s timeout (`browser idle for 121s, reaping Chrome`).
2. Open dashboard panel (live WS connection) correctly suppresses reaping.
3. `browser_tool` after a reap relaunches Chrome automatically (existing `launch_or_attach` path).

The reaper is opt-in (default disabled) so existing deployments are unaffected.

## Related

- #485 (resident Chromium + idle timeout request)
- #505 (screencast stream rework — this PR's stream.py activity hooks are independent of it)