### PR TITLE
fix(browser): correct canvas pointer coords for object-fit: contain

### DIFF
--- a/dashboard/src/utils/browserCanvas.test.ts
+++ b/dashboard/src/utils/browserCanvas.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import { getCanvasCoords } from "./browserCanvas";
+
+function fakeCanvas(
+  pixelW: number,
+  pixelH: number,
+  rect: { left: number; top: number; width: number; height: number },
+) {
+  const canvas = document.createElement("canvas");
+  Object.defineProperty(canvas, "width", { value: pixelW });
+  Object.defineProperty(canvas, "height", { value: pixelH });
+  Object.defineProperty(canvas, "getBoundingClientRect", {
+    value: () => ({
+      left: rect.left,
+      top: rect.top,
+      width: rect.width,
+      height: rect.height,
+      right: rect.left + rect.width,
+      bottom: rect.top + rect.height,
+      x: rect.left,
+      y: rect.top,
+      toJSON: () => ({}),
+    }),
+  });
+  return canvas;
+}
+
+describe("getCanvasCoords", () => {
+  it("maps 1:1 when the canvas fills its box (no letterbox)", () => {
+    const canvas = fakeCanvas(200, 100, { left: 0, top: 0, width: 200, height: 100 });
+    expect(getCanvasCoords(canvas, { clientX: 55, clientY: 66 })).toEqual({
+      x: 55,
+      y: 66,
+    });
+  });
+
+  it("compensates horizontal letterbox from object-fit: contain", () => {
+    // 200x100 bitmap shown in a 250x100 box: scale=1, 25px whitespace each side.
+    const canvas = fakeCanvas(200, 100, { left: 0, top: 0, width: 250, height: 100 });
+    // Point at the bitmap center (x=125 is the visual center of the bitmap).
+    expect(getCanvasCoords(canvas, { clientX: 125, clientY: 50 })).toEqual({
+      x: 100,
+      y: 50,
+    });
+    // Left edge of the drawn area maps to x=0 (not -25).
+    expect(getCanvasCoords(canvas, { clientX: 25, clientY: 50 })).toEqual({
+      x: 0,
+      y: 50,
+    });
+  });
+
+  it("compensates vertical letterbox from object-fit: contain", () => {
+    // 200x100 bitmap shown in a 200x200 box: scale=1, 50px whitespace top/bottom.
+    const canvas = fakeCanvas(200, 100, { left: 0, top: 0, width: 200, height: 200 });
+    expect(getCanvasCoords(canvas, { clientX: 100, clientY: 100 })).toEqual({
+      x: 100,
+      y: 50,
+    });
+  });
+
+  it("handles scaled-down bitmaps (scale < 1)", () => {
+    // 400x200 bitmap shown in a 200x100 box: scale=0.5, no letterbox.
+    const canvas = fakeCanvas(400, 200, { left: 0, top: 0, width: 200, height: 100 });
+    expect(getCanvasCoords(canvas, { clientX: 100, clientY: 50 })).toEqual({
+      x: 200,
+      y: 100,
+    });
+  });
+
+  it("respects non-zero box offset with letterbox", () => {
+    const canvas = fakeCanvas(200, 100, { left: 40, top: 20, width: 250, height: 100 });
+    // Bitmap center: box x = 40 + 125 = 165, y = 20 + 50 = 70.
+    expect(getCanvasCoords(canvas, { clientX: 165, clientY: 70 })).toEqual({
+      x: 100,
+      y: 50,
+    });
+  });
+
+  it("returns origin for null canvas / zero-sized box", () => {
+    expect(getCanvasCoords(null, { clientX: 10, clientY: 10 })).toEqual({ x: 0, y: 0 });
+    const canvas = fakeCanvas(200, 100, { left: 0, top: 0, width: 0, height: 0 });
+    expect(getCanvasCoords(canvas, { clientX: 10, clientY: 10 })).toEqual({ x: 0, y: 0 });
+  });
+});

--- a/dashboard/src/utils/browserCanvas.test.ts
+++ b/dashboard/src/utils/browserCanvas.test.ts
@@ -1,5 +1,10 @@
-import { describe, expect, it } from "vitest";
-import { getCanvasCoords } from "./browserCanvas";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getCanvasCoords,
+  paintBase64JpegToCanvas,
+  readFramePaintDrops,
+  resetFramePaintState,
+} from "./browserCanvas";
 
 function fakeCanvas(
   pixelW: number,
@@ -94,5 +99,108 @@ describe("getCanvasCoords", () => {
     expect(getCanvasCoords(canvas, { clientX: 10, clientY: 10 })).toEqual({ x: 0, y: 0 });
     const canvas2 = fakeCanvas(0, 100, { left: 0, top: 0, width: 200, height: 100 });
     expect(getCanvasCoords(canvas2, { clientX: 10, clientY: 10 })).toEqual({ x: 0, y: 0 });
+  });
+});
+
+/** Controllable Image stand-in: we decide when a frame finishes decoding. */
+class FakeImage {
+  static instances: FakeImage[] = [];
+  src = "";
+  width = 8;
+  height = 8;
+  onload: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+
+  constructor() {
+    FakeImage.instances.push(this);
+  }
+
+  succeed(): void {
+    this.onload?.();
+  }
+
+  fail(): void {
+    this.onerror?.();
+  }
+}
+
+let canvas: HTMLCanvasElement;
+
+beforeEach(() => {
+  FakeImage.instances = [];
+  vi.stubGlobal("Image", FakeImage as unknown as typeof Image);
+  canvas = document.createElement("canvas");
+  // jsdom has no 2d context; painting is not what these tests assert on.
+  vi.spyOn(canvas, "getContext").mockReturnValue(null as never);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("paintBase64JpegToCanvas frame coalescing", () => {
+  it("keeps at most one decode in flight per canvas", () => {
+    paintBase64JpegToCanvas(canvas, "AAA");
+    paintBase64JpegToCanvas(canvas, "BBB");
+
+    expect(FakeImage.instances).toHaveLength(1);
+    expect(FakeImage.instances[0].src).toContain("AAA");
+  });
+
+  it("draws the newest waiting frame once the running decode settles", () => {
+    paintBase64JpegToCanvas(canvas, "AAA");
+    paintBase64JpegToCanvas(canvas, "BBB");
+    FakeImage.instances[0].succeed();
+
+    expect(FakeImage.instances).toHaveLength(2);
+    expect(FakeImage.instances[1].src).toContain("BBB");
+    expect(readFramePaintDrops(canvas)).toBe(0); // BBB waited, nothing was thrown away
+  });
+
+  it("drops the stale intermediate frame instead of decoding it", () => {
+    paintBase64JpegToCanvas(canvas, "AAA");
+    paintBase64JpegToCanvas(canvas, "BBB");
+    paintBase64JpegToCanvas(canvas, "CCC"); // BBB is now pointless: CCC is newer
+
+    FakeImage.instances[0].succeed();
+    expect(FakeImage.instances).toHaveLength(2);
+    expect(FakeImage.instances[1].src).toContain("CCC");
+    expect(readFramePaintDrops(canvas)).toBe(1);
+  });
+
+  it("a failing frame must not wedge the canvas forever", () => {
+    paintBase64JpegToCanvas(canvas, "BAD");
+    paintBase64JpegToCanvas(canvas, "GOOD");
+    FakeImage.instances[0].fail(); // corrupt/truncated frame
+
+    expect(FakeImage.instances).toHaveLength(2);
+    expect(FakeImage.instances[1].src).toContain("GOOD");
+
+    paintBase64JpegToCanvas(canvas, "NEXT");
+    FakeImage.instances[1].succeed();
+    expect(FakeImage.instances).toHaveLength(3);
+    expect(FakeImage.instances[2].src).toContain("NEXT");
+  });
+
+  it("resetFramePaintState clears counters and the in-flight flag", () => {
+    paintBase64JpegToCanvas(canvas, "AAA");
+    paintBase64JpegToCanvas(canvas, "BBB");
+    paintBase64JpegToCanvas(canvas, "CCC");
+    expect(readFramePaintDrops(canvas)).toBe(1);
+
+    resetFramePaintState(canvas);
+    expect(readFramePaintDrops(canvas)).toBe(0);
+
+    paintBase64JpegToCanvas(canvas, "DDD");
+    // state was reset, so DDD starts a decode straight away instead of queueing behind AAA
+    expect(FakeImage.instances).toHaveLength(2);
+    expect(FakeImage.instances[1].src).toContain("DDD");
+  });
+
+  it("ignores a null canvas without throwing", () => {
+    expect(() => paintBase64JpegToCanvas(null, "AAA")).not.toThrow();
+    expect(readFramePaintDrops(null)).toBe(0);
+    expect(() => resetFramePaintState(null)).not.toThrow();
   });
 });

--- a/dashboard/src/utils/browserCanvas.test.ts
+++ b/dashboard/src/utils/browserCanvas.test.ts
@@ -81,4 +81,18 @@ describe("getCanvasCoords", () => {
     const canvas = fakeCanvas(200, 100, { left: 0, top: 0, width: 0, height: 0 });
     expect(getCanvasCoords(canvas, { clientX: 10, clientY: 10 })).toEqual({ x: 0, y: 0 });
   });
+
+  it("returns origin when the bitmap is unpainted (0-sized)", () => {
+    // canvas.width/height === 0 happens before the first frame is painted
+    // (or when the caller clears it); mapping must not produce NaN.
+    const canvas = fakeCanvas(0, 0, { left: 0, top: 0, width: 200, height: 100 });
+    expect(getCanvasCoords(canvas, { clientX: 10, clientY: 10 })).toEqual({ x: 0, y: 0 });
+  });
+
+  it("returns origin when only one bitmap dimension is zero", () => {
+    const canvas = fakeCanvas(200, 0, { left: 0, top: 0, width: 200, height: 100 });
+    expect(getCanvasCoords(canvas, { clientX: 10, clientY: 10 })).toEqual({ x: 0, y: 0 });
+    const canvas2 = fakeCanvas(0, 100, { left: 0, top: 0, width: 200, height: 100 });
+    expect(getCanvasCoords(canvas2, { clientX: 10, clientY: 10 })).toEqual({ x: 0, y: 0 });
+  });
 });

--- a/dashboard/src/utils/browserCanvas.ts
+++ b/dashboard/src/utils/browserCanvas.ts
@@ -11,11 +11,23 @@ export function getCanvasCoords(
   if (!canvas) return { x: 0, y: 0 };
   const rect = canvas.getBoundingClientRect();
   if (rect.width === 0 || rect.height === 0) return { x: 0, y: 0 };
-  const scaleX = canvas.width / rect.width;
-  const scaleY = canvas.height / rect.height;
+  // The canvas element is rendered with object-fit: contain — the bitmap is
+  // scaled to fit while preserving aspect ratio and centered, leaving
+  // letterbox whitespace on the sides (or top/bottom). The old mapping
+  // (canvas.width / rect.width) ignored that whitespace, so pointer
+  // coordinates drifted toward the right/bottom. Compute the actual drawn
+  // area (drawW/drawH) and compensate for the centered offsets first, then
+  // map by the uniform scale factor.
+  const imgW = canvas.width;
+  const imgH = canvas.height;
+  const scale = Math.min(rect.width / imgW, rect.height / imgH);
+  const drawW = imgW * scale;
+  const drawH = imgH * scale;
+  const offsetX = rect.left + (rect.width - drawW) / 2;
+  const offsetY = rect.top + (rect.height - drawH) / 2;
   return {
-    x: Math.round((e.clientX - rect.left) * scaleX),
-    y: Math.round((e.clientY - rect.top) * scaleY),
+    x: Math.round((e.clientX - offsetX) / scale),
+    y: Math.round((e.clientY - offsetY) / scale),
   };
 }
 

--- a/dashboard/src/utils/browserCanvas.ts
+++ b/dashboard/src/utils/browserCanvas.ts
@@ -20,7 +20,12 @@ export function getCanvasCoords(
   // map by the uniform scale factor.
   const imgW = canvas.width;
   const imgH = canvas.height;
+  // Bitmap may be 0 when no frame has been painted yet (or cleared by the
+  // caller); mapping against a zero bitmap would produce Infinity/NaN and
+  // round() to NaN, which JSON serializes as null -> pointer jumps to origin.
+  if (imgW === 0 || imgH === 0) return { x: 0, y: 0 };
   const scale = Math.min(rect.width / imgW, rect.height / imgH);
+  if (!Number.isFinite(scale) || scale <= 0) return { x: 0, y: 0 };
   const drawW = imgW * scale;
   const drawH = imgH * scale;
   const offsetX = rect.left + (rect.width - drawW) / 2;

--- a/dashboard/src/utils/browserCanvas.ts
+++ b/dashboard/src/utils/browserCanvas.ts
@@ -36,28 +36,87 @@ export function getCanvasCoords(
   };
 }
 
-/** Paint a JPEG base64 frame onto a canvas (WebSocket stream). */
+/** Per-canvas coalescing state (WeakMap so a disposed viewer leaks nothing). */
+type FramePaintState = {
+  decoding: boolean;
+  pending: string | null;
+  dropped: number;
+};
+
+const paintStates = new WeakMap<HTMLCanvasElement, FramePaintState>();
+
+function framePaintState(canvas: HTMLCanvasElement): FramePaintState {
+  let state = paintStates.get(canvas);
+  if (!state) {
+    state = { decoding: false, pending: null, dropped: 0 };
+    paintStates.set(canvas, state);
+  }
+  return state;
+}
+
+/**
+ * Paint a JPEG base64 frame onto a canvas (WebSocket stream).
+ *
+ * Frames can arrive faster than the browser can decode + blit them (screencast over a
+ * public link: 30fps x 50-200KB/frame). Starting one decode per arriving frame queues
+ * work, so the picture lags further behind reality every second and the backlog keeps
+ * growing after a hiccup. Therefore: at most one decode in flight per canvas, and the
+ * waiting slot holds only the newest frame - a stale intermediate frame is dropped
+ * rather than decoded, because nobody asks to see last second's screen twice.
+ */
 export function paintBase64JpegToCanvas(
   canvas: HTMLCanvasElement | null,
   base64Data: string,
 ): void {
   if (!canvas) return;
+  const state = framePaintState(canvas);
+  if (state.decoding) {
+    if (state.pending !== null) state.dropped += 1;
+    state.pending = base64Data;
+    return;
+  }
+  state.decoding = true;
+  const settle = () => {
+    state.decoding = false;
+    const next = state.pending;
+    state.pending = null;
+    if (next !== null) paintBase64JpegToCanvas(canvas, next);
+  };
   const img = new Image();
   img.onload = () => {
-    const ctx = canvas.getContext("2d");
-    if (!ctx) return;
-    if (canvas.width !== img.width || canvas.height !== img.height) {
-      canvas.width = img.width;
-      canvas.height = img.height;
+    try {
+      const ctx = canvas.getContext("2d");
+      if (!ctx) return;
+      if (canvas.width !== img.width || canvas.height !== img.height) {
+        canvas.width = img.width;
+        canvas.height = img.height;
+      }
+      ctx.imageSmoothingEnabled = true;
+      if ("imageSmoothingQuality" in ctx) {
+        ctx.imageSmoothingQuality = "high";
+      }
+      ctx.drawImage(img, 0, 0);
+    } finally {
+      settle();
     }
-    ctx.imageSmoothingEnabled = true;
-    if ("imageSmoothingQuality" in ctx) {
-      ctx.imageSmoothingQuality = "high";
-    }
-    ctx.drawImage(img, 0, 0);
   };
+  // A corrupt/truncated frame must not wedge the pipeline: without this the canvas would
+  // stay "decoding" forever and every later frame would pile into the pending slot.
+  img.onerror = () => settle();
   img.src = `data:image/jpeg;base64,${base64Data}`;
 }
+
+/** How many waiting frames this canvas has dropped so far (diagnostics/tests). */
+export function readFramePaintDrops(canvas: HTMLCanvasElement | null): number {
+  return canvas ? framePaintState(canvas).dropped : 0;
+}
+
+/** Reset coalescing state (tests / reattaching a stream to an existing canvas). */
+export function resetFramePaintState(canvas: HTMLCanvasElement | null): void {
+  if (!canvas) return;
+  paintStates.set(canvas, { decoding: false, pending: null, dropped: 0 });
+}
+
 
 /** Paint a screenshot blob onto a canvas (HTTP polling). */
 export async function paintBlobToCanvas(


### PR DESCRIPTION
## Summary

The browser workbench canvas is styled with `object-fit: contain`, so the received frame is scaled to fit while preserving aspect ratio and centered — leaving letterbox whitespace when the canvas box aspect ratio differs from the frame (common when the panel is wider/taller than 16:9 frames).

`getCanvasCoords` mapped with `canvas.width / rect.width` (and the same for Y), treating the entire box as bitmap area. That ignores the centered letterbox offsets, so pointer events drifted toward the right/bottom — e.g. clicking a target near the right edge of the visible bitmap landed further right than intended.

Fix: compute the actual drawn area the way `object-fit: contain` lays it out —

```js
const scale = Math.min(rect.width / imgW, rect.height / imgH);
const drawW = imgW * scale, drawH = imgH * scale;
const offsetX = rect.left + (rect.width - drawW) / 2;
const offsetY = rect.top + (rect.height - drawH) / 2;
return { x: (e.clientX - offsetX) / scale, y: (e.clientY - offsetY) / scale };
```

Results are identical to the old mapping in the no-letterbox case.

## Test plan

New `dashboard/src/utils/browserCanvas.test.ts` covers:

- 1:1 (no letterbox) — same as before
- horizontal letterbox (200x100 frame in a 250x100 box) — center maps to x=100, not 125
- vertical letterbox (200x100 frame in a 200x200 box)
- scaled-down bitmap (scale < 1)
- non-zero box offset combined with letterbox
- null canvas / zero-sized box

`useCanvasRemotePointer` tests use a 1:1 mock, unaffected.

---

## Follow-up commit in this PR: frame coalescing on the same file

`perf(dashboard): coalesce JPEG frame paints so the view cannot fall behind`

Picked up here rather than in a separate PR because it touches the same helper
(`src/utils/browserCanvas.ts`) and the same user-visible concern: the viewer showing a
picture that is not the current screen.

**Problem.** `paintBase64JpegToCanvas` started one `new Image()` decode per arriving
frame. Over a public link (30fps x 50-200KB) decode throughput can drop below frame
arrival, so the backlog grew and the canvas lagged further behind reality every second -
the client half of the exact failure #505 fixed on the server side (queue of 3, newest
wins). Nothing bounded it, and a corrupt frame (no `onerror` handler) left the canvas
stuck: the pending slot would then swallow every later frame forever.

**Design.** One decode in flight per canvas; the waiting slot keeps only the newest
frame. State lives in a `WeakMap` so a disposed viewer collects normally. Dropped frames
are counted (`readFramePaintDrops`) instead of silently vanishing, and
`resetFramePaintState` lets a caller reattach a stream to an existing canvas. Same
semantics now apply to `RemoteAndroid`, which shares this helper.

**Tests.** `src/utils/browserCanvas.test.ts` (single in-flight decode, newest-wins,
drop counting, `onerror` recovery, reset, null canvas) - 14 passed in that file
(8 pre-existing pointer cases + 6 new). `tsc -b` and `eslint` clean.
