### PR TITLE
feat(chat): only show running experts in the chat sidebar

### DIFF
--- a/dashboard/src/context/AgentContext.test.ts
+++ b/dashboard/src/context/AgentContext.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "vitest";
+import type { OctopAgent } from "./AgentContext";
+import {
+  projectChatAgentOption,
+  selectEnabledExperts,
+} from "./AgentContext";
+
+function agent(
+  agent_id: string,
+  state: OctopAgent["state"],
+  overrides: Partial<OctopAgent> = {},
+): OctopAgent {
+  return {
+    id: 0,
+    agent_id,
+    name: agent_id,
+    description: null,
+    persona_mbti: null,
+    default_model: null,
+    system_prompt: null,
+    template_name: null,
+    state,
+    last_error: null,
+    icon: null,
+    icon_name: null,
+    icon_url: null,
+    color: null,
+    config: {},
+    ...overrides,
+  };
+}
+
+describe("selectEnabledExperts", () => {
+  it("keeps only running experts when no resolved id is provided", () => {
+    const agents = [
+      agent("A", "running"),
+      agent("B", "stopped"),
+      agent("C", "starting"),
+      agent("D", "failed"),
+      agent("E", "stopping"),
+    ];
+    expect(selectEnabledExperts(agents, null).map((a) => a.agent_id)).toEqual([
+      "A",
+    ]);
+  });
+
+  it("hides general-assistant and system-doctor style experts once they are stopped", () => {
+    // User's two scenarios from the bug report.
+    const agents = [
+      agent("G1", "stopped", { template_name: "general-assistant" }),
+      agent("G2", "running", { template_name: "general-assistant" }),
+      agent("S1", "stopped", { template_name: "cvm-ai-doctor" }),
+      agent("S2", "running", { template_name: "cvm-ai-doctor" }),
+    ];
+    const result = selectEnabledExperts(agents, null).map((a) => a.agent_id);
+    // Both templates follow the same rule: only running ones survive.
+    expect(result).toEqual(["G2", "S2"]);
+  });
+
+  it("hides the focused expert once it is stopped (no pinning)", () => {
+    // Regression for: stopping the focused expert in the chat page used to
+    // leave it pinned in the sidebar because of an early pinActive default.
+    const agents = [
+      agent("S1", "stopped", { template_name: "cvm-ai-doctor" }),
+      agent("G1", "running", { template_name: "general-assistant" }),
+    ];
+    // S1 is the resolvedAgentId (URL is /chat/S1). Without pinActive it must
+    // disappear from the sidebar just like every other stopped expert.
+    const sidebar = selectEnabledExperts(agents, "S1").map(
+      (a) => a.agent_id,
+    );
+    expect(sidebar).toEqual(["G1"]);
+    // @-picker / minimal-layout path also excludes it.
+    const pickable = selectEnabledExperts(agents, "S1", {
+      pinActive: false,
+    }).map((a) => a.agent_id);
+    expect(pickable).toEqual(["G1"]);
+  });
+
+  it("is a no-op when every expert is running", () => {
+    const agents = [agent("A", "running"), agent("B", "running")];
+    expect(selectEnabledExperts(agents, null)).toEqual(agents);
+  });
+
+  it("returns empty when nothing is running and there is no active pin", () => {
+    const agents = [
+      agent("A", "stopped"),
+      agent("B", "failed"),
+    ];
+    expect(selectEnabledExperts(agents, null)).toEqual([]);
+  });
+
+  it("opt-in pinActive=true still keeps the active stopped expert (API stability)", () => {
+    // Pinning is no longer the default — every production caller passes
+    // pinActive:false — but the option still exists in case a future
+    // surface wants to keep the focused expert visible.
+    const agents = [
+      agent("S1", "stopped", { template_name: "cvm-ai-doctor" }),
+      agent("G1", "running", { template_name: "general-assistant" }),
+    ];
+    const result = selectEnabledExperts(agents, "S1", { pinActive: true }).map(
+      (a) => a.agent_id,
+    );
+    expect(result).toEqual(["S1", "G1"]);
+  });
+});
+
+describe("projectChatAgentOption", () => {
+  it("projects the full OctopAgent down to ChatAgentOption shape", () => {
+    const projected = projectChatAgentOption(
+      agent("S1", "running", {
+        icon_name: "cpu",
+        icon_url: "https://example/icon.png",
+        color: "#0052D9",
+        is_shared: 1,
+        is_owner: 0,
+        owner_username: "alice",
+      }),
+    );
+    expect(projected).toEqual({
+      agent_id: "S1",
+      name: "S1",
+      icon_name: "cpu",
+      icon_url: "https://example/icon.png",
+      color: "#0052D9",
+      is_shared: true,
+      is_owner: false,
+      owner_username: "alice",
+    });
+  });
+
+  it("normalizes undefined owner_username to null", () => {
+    const projected = projectChatAgentOption(agent("X", "running"));
+    expect(projected.owner_username).toBeNull();
+    expect(projected.is_shared).toBe(false);
+    expect(projected.is_owner).toBe(false);
+  });
+});

--- a/dashboard/src/context/AgentContext.tsx
+++ b/dashboard/src/context/AgentContext.tsx
@@ -74,7 +74,73 @@ interface AgentContextValue {
   refresh: (options?: { silent?: boolean; force?: boolean }) => Promise<void>;
 }
 
+export interface EnabledExpertsOptions {
+  /**
+   * When ``true`` (default — kept for API stability), keep the
+   * ``resolvedAgentId`` expert in the returned list even if it does not
+   * match the predicate. Today every caller passes ``false`` so a disabled
+   * expert disappears from the sidebar / @-picker the moment the user stops
+   * it, including when it is the currently focused expert. The main panel
+   * still renders ``AgentNotReadyScreen`` on the same URL so users get a
+   * clear path to ``/experts`` to restart it.
+   */
+  pinActive?: boolean;
+}
+
 const STORAGE_KEY = "octop:active-agent";
+
+/**
+ * Pure helper: narrow ``agents`` down to those that are "enabled" for the
+ * chat surface (running experts). The same predicate is reused by:
+ *   • the chat page left sidebar (``Chat/index.tsx``)
+ *   • the minimal-layout records pane (``MinimalRecordsHost`` — non-/chat
+ *     routes like ``/experts`` show expert folders here)
+ *   • the chat composer's ``@``-mention picker + slash menu
+ *
+ * Keep this helper in sync with ``isAgentChatReady`` so disabled experts
+ * never leak into any chat-side surface.
+ */
+export function selectEnabledExperts(
+  agents: OctopAgent[],
+  resolvedAgentId: string | null | undefined,
+  options: EnabledExpertsOptions = {},
+): OctopAgent[] {
+  const { pinActive = false } = options;
+  const enabled = agents.filter((a) => a.state === "running");
+  if (!pinActive || !resolvedAgentId) return enabled;
+  if (enabled.some((a) => a.agent_id === resolvedAgentId)) return enabled;
+  const pinnedActive = agents.find((a) => a.agent_id === resolvedAgentId);
+  if (!pinnedActive) return enabled;
+  return [pinnedActive, ...enabled];
+}
+
+/**
+ * Shared projection used by the chat composer (`ChatInput` /
+ * ``composerLookups``). Keeps the lightweight ``ChatAgentOption`` shape
+ * consistent across surfaces — name/icon for the chip, shared badge for
+ * the picker, owner_username for the current-user indicator.
+ */
+export function projectChatAgentOption(agent: OctopAgent): {
+  agent_id: string;
+  name: string;
+  icon_name: string | null;
+  icon_url: string | null;
+  color: string | null;
+  is_shared: boolean;
+  is_owner: boolean;
+  owner_username: string | null;
+} {
+  return {
+    agent_id: agent.agent_id,
+    name: agent.name,
+    icon_name: agent.icon_name,
+    icon_url: agent.icon_url,
+    color: agent.color,
+    is_shared: Boolean(agent.is_shared),
+    is_owner: Boolean(agent.is_owner),
+    owner_username: agent.owner_username ?? null,
+  };
+}
 
 const defaultValue: AgentContextValue = {
   agents: [],

--- a/dashboard/src/context/AgentContext.tsx
+++ b/dashboard/src/context/AgentContext.tsx
@@ -76,7 +76,7 @@ interface AgentContextValue {
 
 export interface EnabledExpertsOptions {
   /**
-   * When ``true`` (default — kept for API stability), keep the
+   * When ``true`` (opt-in; the default is ``false``), keep the
    * ``resolvedAgentId`` expert in the returned list even if it does not
    * match the predicate. Today every caller passes ``false`` so a disabled
    * expert disappears from the sidebar / @-picker the moment the user stops

--- a/dashboard/src/layouts/MinimalRecordsHost.tsx
+++ b/dashboard/src/layouts/MinimalRecordsHost.tsx
@@ -2,7 +2,7 @@ import { useCallback, useMemo } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { message as antMessage } from "@/utils/antdMessage";
 import { useTranslation } from "react-i18next";
-import { useAgent } from "../context/AgentContext";
+import { useAgent, selectEnabledExperts } from "../context/AgentContext";
 import { octopThreadsApi } from "../api/modules/octopThreads";
 import { apiErrorMessage } from "../utils/apiError";
 import MinimalAgentSessionNav from "../pages/Chat/components/MinimalAgentSessionNav";
@@ -34,6 +34,16 @@ export default function MinimalRecordsHost() {
     [location.pathname],
   );
   const resolvedAgentId = pathAgentId ?? activeAgentId;
+
+  // Match the chat page sidebar: only "enabled" (running) experts show in
+  // the records pane. A disabled expert (including one stored in
+  // localStorage as the last-active) is hidden so the user only sees experts
+  // they can actually chat with right now. ``/experts`` itself still lists
+  // every expert so users can re-enable the stopped one there.
+  const enabledAgents = useMemo(
+    () => selectEnabledExperts(agents, resolvedAgentId, { pinActive: false }),
+    [agents, resolvedAgentId],
+  );
 
   const handleSelect = useCallback(
     (sessionId: string, agentId: string) => {
@@ -108,7 +118,7 @@ export default function MinimalRecordsHost() {
 
   return (
     <MinimalAgentSessionNav
-      agents={agents}
+      agents={enabledAgents}
       activeId={pathThreadId}
       activeAgentId={resolvedAgentId}
       activeSessions={[]}

--- a/dashboard/src/pages/Chat/components/ChatInput.tsx
+++ b/dashboard/src/pages/Chat/components/ChatInput.tsx
@@ -93,6 +93,13 @@ interface ChatInputProps {
   selectedSkills?: string[];
   onSkillsChange?: (names: string[]) => void;
   availableAgents?: ChatAgentOption[];
+  /**
+   * Subset of experts the user can currently pick — only running ones
+   * (stopped / failed experts would dispatch into an unloaded harness and
+   * silently fail). Pass the same list as ``availableAgents`` if every
+   * expert is guaranteed to be running.
+   */
+  availableExperts?: ChatAgentOption[];
   selectedTargetAgents?: string[];
   onTargetAgentsChange?: (ids: string[]) => void;
   agentId?: string | null;
@@ -139,6 +146,11 @@ const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
       selectedSkills = [],
       onSkillsChange,
       availableAgents = [],
+      // Default ``availableExperts`` to the full projection so older callers
+      // (and tests) keep working. Production callers in ``Chat/index.tsx``
+      // explicitly pass the filtered list — keep that explicit to avoid
+      // accidentally re-surfacing stopped experts in the @-picker.
+      availableExperts = availableAgents,
       selectedTargetAgents = [],
       onTargetAgentsChange,
       agentId,
@@ -338,7 +350,7 @@ const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
       locale: i18n.language,
       availableSkills,
       availableConnectors,
-      availableAgents,
+      availableExperts,
       agentId,
       selectedSkills,
       selectedConnectors,
@@ -764,7 +776,7 @@ const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
             availableSkills={availableSkills}
             selectedSkills={selectedSkills}
             onSkillsChange={onSkillsChange}
-            availableExperts={availableAgents.filter(
+            availableExperts={availableExperts.filter(
               (a) => a.agent_id !== agentId,
             )}
             selectedTargetAgents={selectedTargetAgents}

--- a/dashboard/src/pages/Chat/hooks/useSlashMentionInput.ts
+++ b/dashboard/src/pages/Chat/hooks/useSlashMentionInput.ts
@@ -36,7 +36,11 @@ interface UseSlashMentionInputParams {
     label: string;
     kind: string;
   }[];
-  availableAgents: ChatAgentOption[];
+  /**
+   * Subset of experts the user can currently pick — already filtered by the
+   * caller (only running experts). The hook itself doesn't filter further.
+   */
+  availableExperts: ChatAgentOption[];
   agentId?: string | null;
   selectedSkills: string[];
   selectedConnectors: string[];
@@ -62,7 +66,7 @@ export function useSlashMentionInput({
   locale,
   availableSkills,
   availableConnectors,
-  availableAgents,
+  availableExperts,
   agentId,
   selectedSkills,
   selectedConnectors,
@@ -85,8 +89,8 @@ export function useSlashMentionInput({
   const [mentionAtIndex, setMentionAtIndex] = useState(-1);
 
   const mentionAgents = useMemo(
-    () => availableAgents.filter((a) => a.agent_id !== agentId),
-    [availableAgents, agentId],
+    () => availableExperts.filter((a) => a.agent_id !== agentId),
+    [availableExperts, agentId],
   );
 
   const mentionItems = useMemo(

--- a/dashboard/src/pages/Chat/index.tsx
+++ b/dashboard/src/pages/Chat/index.tsx
@@ -50,7 +50,11 @@ import AgentProfileDrawer from "../../components/AgentProfileDrawer";
 import WorkspaceDrawer from "../Agent/Workspace/components/WorkspaceDrawer";
 import { useExpertChatWelcome } from "./hooks/useExpertQuickCards";
 import { useSkills } from "../Agent/Skills/useSkills";
-import { useAgent } from "../../context/AgentContext";
+import {
+  useAgent,
+  selectEnabledExperts,
+  projectChatAgentOption,
+} from "../../context/AgentContext";
 import { useLayoutMode } from "../../context/LayoutModeContext";
 import { useBrowserSessionState } from "../../hooks/useBrowserSessionState";
 import { prefetchVoiceConfig } from "../../hooks/useVoiceConfig";
@@ -177,6 +181,17 @@ function ChatPageInner() {
   const agentChatReady = isAgentChatReady(activeAgent?.state);
   const sharedExpertViewer = isSharedExpertViewer(activeAgent ?? {});
   const noAgents = !agentsLoading && agents.length === 0;
+
+  // Sidebar only lists "enabled" experts (harness running). Stopped / failed
+  // experts are hidden so the nav stays focused on agents that can actually
+  // chat right now — including the focused expert the user just stopped. The
+  // main panel still renders ``AgentNotReadyScreen`` on the same URL so users
+  // see a clear path back to ``/experts`` to re-enable it.
+  const sidebarAgents = useMemo(
+    () => selectEnabledExperts(agents, resolvedAgentId, { pinActive: false }),
+    [agents, resolvedAgentId],
+  );
+
   const {
     status: memoryMaint,
     visible: memoryMaintVisible,
@@ -444,18 +459,22 @@ function ChatPageInner() {
     refreshAgents,
   });
 
+  // Full projection — used by surfaces that render an *existing* agent chip
+  // (the preview bar above the composer and historical message chips). They
+  // must still find an expert that was running when the user picked it but
+  // has since been stopped, otherwise the chip silently vanishes.
   const chatAgentOptions = useMemo(
+    () => agents.map(projectChatAgentOption),
+    [agents],
+  );
+  // Subset for the chat-side *pickers* (`@` button popover, `@` mention menu).
+  // Only running experts — picking a stopped one would dispatch into an
+  // unloaded harness and silently fail.
+  const chatAgentOptionsPickable = useMemo(
     () =>
-      agents.map((a) => ({
-        agent_id: a.agent_id,
-        name: a.name,
-        icon_name: a.icon_name,
-        icon_url: a.icon_url,
-        color: a.color,
-        is_shared: a.is_shared,
-        is_owner: a.is_owner,
-        owner_username: a.owner_username,
-      })),
+      selectEnabledExperts(agents, null, { pinActive: false }).map(
+        projectChatAgentOption,
+      ),
     [agents],
   );
 
@@ -839,7 +858,7 @@ function ChatPageInner() {
       sidebarWidth={sidebarWidth}
       isSidebarResizing={isSidebarResizing}
       sidebarElRef={sidebarElRef}
-      agents={agents}
+      agents={sidebarAgents}
       sessions={sessions}
       activeThreadId={activeThreadId}
       resolvedAgentId={resolvedAgentId}
@@ -1222,6 +1241,7 @@ function ChatPageInner() {
               selectedSkills={selectedSkills}
               onSkillsChange={handleSkillsChange}
               availableAgents={chatAgentOptions}
+              availableExperts={chatAgentOptionsPickable}
               selectedTargetAgents={selectedTargetAgents}
               onTargetAgentsChange={setSelectedTargetAgents}
               agentId={resolvedAgentId}


### PR DESCRIPTION
问题
#504 
对话页左侧 sidebar 和 minimal布局下的左侧记录面板，会列出 GET /api/agents 返回的所有专家，无视 runtime state。一旦用户在某个焦点专家页打开对话后通过 /experts 或别的入口停掉了它，专家仍然残留在 sidebar 里——但它的 harness runtime已经被卸载。

修复
selectEnabledExperts（在 AgentContext）把 agents 列表收窄到 state === "running" 的项。pinActive 是 opt-in（默认关闭），所以停掉焦点专家会让它立刻从导航里消失。主聊天面板在同一个 URL 上仍然渲染 AgentNotReadyScreen，给用户提供清晰的「回到 /experts 重新启用」路径。
projectChatAgentOption 把 OctopAgent 投影成 composer用的轻量 ChatAgentOption，替换掉 Chat/index.tsx 里重复的内联 map。
@ 按钮弹窗（ExpertPickerPopover）和 @ mention 菜单（MentionPickerMenu）现在只列出 running 专家——之前选一个已停的会 dispatch 进一个未加载的 harness 然后静默失败。
availableAgents 保留为完整列表——这样 ChatInputPreviewBar 和 composerLookups.agents 在专家停掉后还能渲染历史/当前选中的 expert chip。

改动文件
dashboard/src/context/AgentContext.tsx —— helpers
dashboard/src/context/AgentContext.test.ts —— 单测- dashboard/src/pages/Chat/index.tsx
dashboard/src/pages/Chat/components/ChatInput.tsx
dashboard/src/pages/Chat/hooks/useSlashMentionInput.ts ⚠️ breaking：参数从 availableAgents 重命名为 availableExperts
dashboard/src/layouts/MinimalRecordsHost.tsx
## Summary

<!-- What does this PR change and why? -->

## Target branch

- [x] Base is **`develop`** (feature / fix — default)
- [ ] Base is **`main`** (`release/*` or `hotfix/*` only)

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Breaking change
- [ ] Documentation
- [ ] Refactor / chore
- [ ] Release / hotfix

## Test plan

<!-- How did you verify this? Include commands run (e.g. `make all`). -->

- [ ] `make all` passes locally
- [x] Added/updated tests

## Checklist

- [ ] Updated `CHANGELOG.md` (if user-facing)
- [ ] README / docs updated (if needed)
](https://github.com/chujieHong/Octop/pull/new/feat/chat-sidebar-only-enabled-experts)