### PR TITLE
feat: align default experts on home storage and keep chat todos in plan order

### DIFF
--- a/dashboard/src/api/modules/publishedExperts.ts
+++ b/dashboard/src/api/modules/publishedExperts.ts
@@ -44,7 +44,9 @@ export interface InstalledPublishedExpert {
   agent_id: string;
   name: string;
   description: string | null;
+  state: string;
   published_expert_id: string;
+  bootstrap_pending: boolean;
 }
 
 const publishedPath = (expertId: string) =>

--- a/dashboard/src/pages/Chat/chatWelcome.partial.less
+++ b/dashboard/src/pages/Chat/chatWelcome.partial.less
@@ -286,7 +286,7 @@
   overflow: hidden;
   text-overflow: ellipsis;
   display: -webkit-box;
-  -webkit-line-clamp: 2;
+  -webkit-line-clamp: 1;
   -webkit-box-orient: vertical;
 }
 

--- a/dashboard/src/pages/Experts/components/AgentBackendFields.tsx
+++ b/dashboard/src/pages/Experts/components/AgentBackendFields.tsx
@@ -24,6 +24,7 @@ interface AgentBackendFieldsProps {
   pathMappings: PathMapping[];
   /** ``create`` fills empty root_dir with home; ``edit`` leaves existing values. */
   rootDirMode?: "create" | "edit";
+  disabled?: boolean;
   onAddPathMapping: () => void;
   onRemovePathMapping: (index: number) => void;
   onUpdatePathMapping: (
@@ -39,6 +40,7 @@ export default function AgentBackendFields({
   backendChoice,
   pathMappings,
   rootDirMode = "create",
+  disabled = false,
   onAddPathMapping,
   onRemovePathMapping,
   onUpdatePathMapping,
@@ -131,6 +133,7 @@ export default function AgentBackendFields({
         initialValue={DEFAULT_BACKEND}
       >
         <Select
+          disabled={disabled}
           loading={backendsLoading}
           options={backendSelectOptions}
           placeholder={t("experts.backendPlaceholder")}
@@ -169,7 +172,7 @@ export default function AgentBackendFields({
           >
             <RootDirSelect
               treeRoot={treeRoot}
-              disabled={rootDirMode === "edit"}
+              disabled={disabled || rootDirMode === "edit"}
             />
           </Form.Item>
           <div style={{ margin: "-8px 0 12px" }}>
@@ -218,7 +221,7 @@ export default function AgentBackendFields({
             label={t("experts.backendModes.compositeDefault")}
             initialValue={DEFAULT_BACKEND}
           >
-            <Select options={routeBackendOptions} />
+            <Select disabled={disabled} options={routeBackendOptions} />
           </Form.Item>
 
           <div style={{ marginBottom: 16 }}>
@@ -245,6 +248,7 @@ export default function AgentBackendFields({
                 }}
               >
                 <Input
+                  disabled={disabled}
                   placeholder="/data"
                   value={mapping.path}
                   status={pathHasError(mapping.path) ? "error" : undefined}
@@ -254,6 +258,7 @@ export default function AgentBackendFields({
                   style={{ flex: 1 }}
                 />
                 <Select
+                  disabled={disabled}
                   placeholder={t("experts.backendModes.routeBackend")}
                   options={routeBackendOptions}
                   value={mapping.backend || undefined}
@@ -262,6 +267,7 @@ export default function AgentBackendFields({
                 />
                 <button
                   type="button"
+                  disabled={disabled}
                   onClick={() => onRemovePathMapping(i)}
                   style={{
                     background: "none",
@@ -278,6 +284,7 @@ export default function AgentBackendFields({
             <button
               type="button"
               className={styles.cardBtn}
+              disabled={disabled}
               onClick={onAddPathMapping}
             >
               {t("experts.addPathMapping")}

--- a/dashboard/src/pages/Experts/components/EditAgentDrawer.tsx
+++ b/dashboard/src/pages/Experts/components/EditAgentDrawer.tsx
@@ -789,6 +789,7 @@ function EditAgentDrawerBody({
                 backendChoice={backendChoice}
                 pathMappings={pathMappings}
                 rootDirMode="edit"
+                disabled
                 onAddPathMapping={addPathMapping}
                 onRemovePathMapping={removePathMapping}
                 onUpdatePathMapping={updatePathMapping}

--- a/dashboard/src/utils/parseWriteTodos.test.ts
+++ b/dashboard/src/utils/parseWriteTodos.test.ts
@@ -4,6 +4,7 @@ import {
   isWriteTodosToolName,
   parsePartialTodoPayload,
   parseWriteTodosToolData,
+  sortTodoItems,
 } from "./parseWriteTodos";
 
 describe("parseWriteTodosToolData", () => {
@@ -81,5 +82,34 @@ describe("collectWriteTodosFromMessages", () => {
     expect(items).toEqual([
       { id: "1", content: "Plan", status: "in_progress" },
     ]);
+  });
+
+  it("keeps original id order instead of grouping by status", () => {
+    const items = collectWriteTodosFromMessages([
+      {
+        toolData: {
+          name: "write_todos",
+          arguments: JSON.stringify({
+            todos: [
+              { id: "1", content: "调研", status: "completed" },
+              { id: "2", content: "实现", status: "in_progress" },
+              { id: "3", content: "测试", status: "pending" },
+            ],
+          }),
+        },
+      },
+    ]);
+    expect(items.map((item) => item.content)).toEqual(["调研", "实现", "测试"]);
+  });
+});
+
+describe("sortTodoItems", () => {
+  it("orders numeric ids naturally so 10 follows 2", () => {
+    const items = sortTodoItems([
+      { id: "10", content: "步骤10", status: "pending" },
+      { id: "2", content: "步骤2", status: "completed" },
+      { id: "1", content: "步骤1", status: "in_progress" },
+    ]);
+    expect(items.map((item) => item.id)).toEqual(["1", "2", "10"]);
   });
 });

--- a/dashboard/src/utils/parseWriteTodos.ts
+++ b/dashboard/src/utils/parseWriteTodos.ts
@@ -20,13 +20,6 @@ export interface WriteTodosMessageSource {
   status?: string;
 }
 
-const STATUS_ORDER: Record<string, number> = {
-  in_progress: 0,
-  pending: 1,
-  completed: 2,
-  cancelled: 3,
-};
-
 function toolNameBase(name: string): string {
   const trimmed = name.trim();
   const slash = trimmed.lastIndexOf("/");
@@ -165,11 +158,9 @@ export function countCompletedTodos(items: readonly TodoListItem[]): number {
   return items.filter((item) => item.status === "completed").length;
 }
 
+/** Keep plan order: numeric ids (``2`` before ``10``), not status. */
 export function sortTodoItems(items: TodoListItem[]): TodoListItem[] {
-  return [...items].sort((a, b) => {
-    const left = STATUS_ORDER[a.status] ?? 99;
-    const right = STATUS_ORDER[b.status] ?? 99;
-    if (left !== right) return left - right;
-    return a.id.localeCompare(b.id);
-  });
+  return [...items].sort((a, b) =>
+    a.id.localeCompare(b.id, undefined, { numeric: true, sensitivity: "base" }),
+  );
 }

--- a/src/octop/api/routers/chat/routes.py
+++ b/src/octop/api/routers/chat/routes.py
@@ -17,8 +17,6 @@ from octop.i18n.domains.stream import format_stream_error
 from octop.infra.agents.experts.catalog import (
     default_welcome_payload,
     read_workspace_manifest_welcome,
-    welcome_payload_from_expert,
-    welcome_payload_has_content,
 )
 from octop.infra.agents.profile import welcome_from_row
 from octop.infra.errors import ErrorCode, OctopError
@@ -60,8 +58,7 @@ async def get_chat_welcome(
     Resolution order:
     1. Agent row ``welcome_message`` (instance-owned; set at create/edit).
     2. Agent workspace ``.octop/manifest.json`` (seeded at create; quick cards + fallback copy).
-    3. Bundled expert catalog entry for ``template_name`` (legacy agents).
-    4. Default quick cards (``general-assistant`` or a small built-in set).
+    3. Default quick cards (``general-assistant`` or a small built-in set).
     """
     assert_agent_access(server, agent_id, user)
     assert server.app_runtime is not None
@@ -74,14 +71,6 @@ async def get_chat_welcome(
         payload = await read_workspace_manifest_welcome(workspace)
 
     row = registry.get_row(agent_id)
-    template = (row.template_name if row else None) or ""
-    if payload is None and catalog is not None and template:
-        expert = catalog.get(template)
-        if expert is not None:
-            candidate = welcome_payload_from_expert(expert)
-            if welcome_payload_has_content(candidate):
-                payload = candidate
-
     if payload is None:
         payload = default_welcome_payload(catalog)
 

--- a/src/octop/api/routers/experts.py
+++ b/src/octop/api/routers/experts.py
@@ -557,6 +557,7 @@ async def install_expert_hub_item(
                 color=body.color,
                 agent_id=body.agent_id,
                 welcome_message=body.welcome_message,
+                skill_package_ids=package_ids,
                 **runtime_field_updates(body, exclude_unset=False),
             ),
         )
@@ -564,8 +565,6 @@ async def install_expert_hub_item(
         raise _map_skillhub_error(exc) from exc
 
     row = result.row
-    if package_ids is not None:
-        await server.app_runtime.agent_registry.persist_skill_package_ids(row.agent_id, package_ids)
     return {
         "id": row.id,
         "agent_id": row.agent_id,
@@ -646,10 +645,9 @@ async def create_agent_from_expert(
         agent_id=body.agent_id,
         color=body.color,
         welcome_message=body.welcome_message,
+        skill_package_ids=package_ids,
     )
     row = await server.app_runtime.agent_registry.create(spec, defer_bootstrap=True)
-    if package_ids is not None:
-        await server.app_runtime.agent_registry.persist_skill_package_ids(row.agent_id, package_ids)
     return {
         "id": row.id,
         "agent_id": row.agent_id,

--- a/src/octop/infra/agents/default_agent.py
+++ b/src/octop/infra/agents/default_agent.py
@@ -11,12 +11,22 @@ from typing import Any
 
 from octop.infra.agents.experts.catalog import ExpertCatalog, build_create_spec_from_expert
 from octop.infra.errors import ErrorCode, OctopError
+from octop.infra.utils.host_dirs import host_home_dir, host_path_text
 from octop.infra.utils.locale import normalize_locale
 
 logger = logging.getLogger(__name__)
 
 DEFAULT_EXPERT_ID = "general-assistant"
 SETUP_DEFAULT_AGENT_ID = "main"
+
+
+def default_home_local_backend() -> dict[str, Any]:
+    """Same local backend as the dashboard create-from-expert default (home-scoped)."""
+    return {
+        "type": "local_shell",
+        "root_dir": host_path_text(host_home_dir()),
+        "virtual_mode": True,
+    }
 
 
 async def bootstrap_default_agent(
@@ -51,6 +61,7 @@ async def bootstrap_default_agent(
         user_id=user_id,
         agent_id=agent_id,
         locale=loc,
+        config_extra={"backend": default_home_local_backend()},
     )
     return await registry.create(spec, defer_bootstrap=True)
 

--- a/src/octop/infra/agents/experts/catalog.py
+++ b/src/octop/infra/agents/experts/catalog.py
@@ -481,6 +481,7 @@ def build_create_spec_from_expert(
     color: str | None = None,
     welcome_message: str | None = None,
     published_expert_id: str | None = None,
+    skill_package_ids: list[str] | None = None,
 ) -> AgentCreateSpec:
     """Build :class:`AgentCreateSpec` for ``AgentManager.create`` from a catalog entry."""
     resolved_name = resolve_expert_agent_name(expert, expert_id, locale=locale, override=name)
@@ -521,6 +522,7 @@ def build_create_spec_from_expert(
         icon_name=icon_name or extra_icon_name or expert.summary.icon_name,
         icon_url=icon_url or extra_icon_url,
         color=color or extra_color or expert.summary.color,
+        skill_package_ids=skill_package_ids,
         published_expert_id=published_expert_id,
         welcome_message=welcome_message,
     )

--- a/src/octop/infra/agents/experts/library/general-assistant/skills/octop-assistant/SKILL.md
+++ b/src/octop/infra/agents/experts/library/general-assistant/skills/octop-assistant/SKILL.md
@@ -10,6 +10,12 @@ metadata:
   octop:
     emoji: "⚙️"
     requires: {}
+    label:
+      zh: "Octop 配置助手"
+      en: "Octop Assistant"
+    summary:
+      zh: "通过 CLI 配置模型、通道、Skill、定时任务，以及备份与升级。"
+      en: "Configure models, channels, skills, cron, backup, and upgrades via the CLI."
 ---
 
 # Octop Assistant ⚙️

--- a/src/octop/infra/agents/experts/market_creation.py
+++ b/src/octop/infra/agents/experts/market_creation.py
@@ -48,6 +48,7 @@ class SkillHubMarketAgentCreateOptions:
     color: str | None = None
     agent_id: str | None = None
     welcome_message: str | None = None
+    skill_package_ids: list[str] | None = None
     max_iters: int | None = None
     max_input_length: int | None = None
     temperature: float | None = None
@@ -311,6 +312,7 @@ async def create_agent_from_skillhub_skillset(
         icon_url=item.icon_url or None,
         color=options.color,
         welcome_message=(options.welcome_message if customized_welcome else None),
+        skill_package_ids=options.skill_package_ids,
     )
     row = await server.app_runtime.agent_registry.create(spec, defer_bootstrap=True)
 

--- a/src/octop/infra/agents/experts/published_creation.py
+++ b/src/octop/infra/agents/experts/published_creation.py
@@ -13,7 +13,11 @@ from typing import Any, cast
 from psycopg import IntegrityError as PsycopgIntegrityError
 
 from octop.infra.agents.avatar import bind_workspace_avatar_icon_url
-from octop.infra.agents.experts.catalog import MANIFEST_FILENAME, seed_expert_directory
+from octop.infra.agents.experts.catalog import (
+    MANIFEST_FILENAME,
+    read_workspace_manifest_welcome,
+    seed_expert_directory,
+)
 from octop.infra.agents.experts.publish import (
     PublishedExpertSnapshotMeta,
     assert_can_mutate_published,
@@ -79,6 +83,12 @@ def _manifest_quick_prompts(manifest: dict[str, Any]) -> tuple[dict[str, Any], .
         if isinstance(item, dict):
             out.append(item)
     return tuple(out)
+
+
+async def _workspace_quick_prompts(workspace: Any) -> tuple[dict[str, Any], ...]:
+    """Quick cards configured on the source agent, so publishing never drops them."""
+    payload = await read_workspace_manifest_welcome(workspace)
+    return _manifest_quick_prompts(payload) if payload is not None else ()
 
 
 def _agent_color(registry: Any, agent_id: str) -> str | None:
@@ -154,6 +164,7 @@ async def publish_agent_expert(
     expert_id = new_ulid()
     snapshot_dir = _snapshot_dir(services, expert_id)
     resolved_description = description or source.description or ""
+    resolved_quick_prompts = quick_prompts or await _workspace_quick_prompts(workspace)
     color = _agent_color(registry, source.agent_id) or ""
     icon_name = getattr(source, "icon_name", None) or source.icon or ""
     try:
@@ -167,7 +178,7 @@ async def publish_agent_expert(
                 color=color or None,
                 welcome_message_zh=welcome_message_zh,
                 welcome_message_en=welcome_message_en,
-                quick_prompts=quick_prompts,
+                quick_prompts=resolved_quick_prompts,
             ),
             manifest_id=resolved_slug,
         )
@@ -230,7 +241,9 @@ async def refresh_published_expert(
     resolved_welcome_en = (
         welcome_message_en if welcome_message_en is not None else existing_welcome_en
     )
-    resolved_quick_prompts = quick_prompts if quick_prompts is not None else existing_quick_prompts
+    resolved_quick_prompts = quick_prompts
+    if resolved_quick_prompts is None:
+        resolved_quick_prompts = await _workspace_quick_prompts(workspace) or existing_quick_prompts
     await export_agent_workspace_to_dir(
         workspace=workspace,
         dest=snapshot_dir,
@@ -293,6 +306,10 @@ async def install_published_expert(
     if options.backend:
         config_extra["backend"] = options.backend
 
+    async def seed_snapshot(created_row: Any, workspace: Any) -> None:
+        await seed_expert_directory(expert_dir=snapshot_dir, workspace=workspace)
+        await bind_workspace_avatar_icon_url(registry, created_row.agent_id, workspace)
+
     created = await registry.create(
         AgentCreateSpec(
             name=options.name,
@@ -306,18 +323,13 @@ async def install_published_expert(
             icon_name=row.icon_name or None,
             icon_url=options.icon_url,
             color=options.color or row.color or None,
+            skill_package_ids=package_ids,
             published_expert_id=row.id,
             welcome_message=options.welcome_message,
-        )
+        ),
+        defer_bootstrap=True,
+        workspace_initializer=seed_snapshot,
     )
-    workspace = registry.workspace_for_agent(created.agent_id)
-    if workspace is None:
-        raise OctopError(ErrorCode.AGENT_NOT_FOUND, f"agent {created.agent_id!r} not found")
-    await seed_expert_directory(expert_dir=snapshot_dir, workspace=workspace)
-    await bind_workspace_avatar_icon_url(registry, created.agent_id, workspace)
-    if package_ids is not None:
-        await registry.persist_skill_package_ids(created.agent_id, package_ids)
-    await registry.reload(created.agent_id)
     return {
         "id": created.id,
         "agent_id": created.agent_id,

--- a/src/octop/infra/agents/manager.py
+++ b/src/octop/infra/agents/manager.py
@@ -7,7 +7,7 @@ import json
 import logging
 import re
 import shutil
-from collections.abc import AsyncIterator, Callable, Sequence
+from collections.abc import AsyncIterator, Awaitable, Callable, Sequence
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field, fields, replace
 from pathlib import Path
@@ -477,7 +477,13 @@ class AgentManager:
     # CRUD — persist agent rows and sync harness runtime
     # ------------------------------------------------------------------
 
-    async def create(self, spec: AgentCreateSpec, *, defer_bootstrap: bool = False) -> AgentRow:
+    async def create(
+        self,
+        spec: AgentCreateSpec,
+        *,
+        defer_bootstrap: bool = False,
+        workspace_initializer: Callable[[AgentRow, Any], Awaitable[None]] | None = None,
+    ) -> AgentRow:
         """Create a new agent, persist to DB, and register with harness."""
         async with self._lock:
             self._assert_agent_name_available(spec.user_id, spec.name)
@@ -551,8 +557,15 @@ class AgentManager:
                 assert row is not None
             if spec.template_name:
                 await self._seed_expert_template(row, spec.template_name)
+            if workspace_initializer is not None:
+                workspace = self._backend_workspace_for_row(row)
+                await workspace_initializer(row, workspace)
+                row = self._repos.agent_repo.get(agent_id)
+                assert row is not None
             if defer_bootstrap:
                 self._repos.agent_repo.set_state(agent_id, "starting")
+                row = self._repos.agent_repo.get(agent_id)
+                assert row is not None
                 asyncio.create_task(
                     self._complete_create_bootstrap(row),
                     name=f"bootstrap-agent-{agent_id}",

--- a/src/octop/launch.py
+++ b/src/octop/launch.py
@@ -4,11 +4,49 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import sys
+from contextlib import suppress
 from typing import Any
 
 from octop.infra.server import OctopServer
 
 logger = logging.getLogger(__name__)
+
+
+def _ensure_linux_bubblewrap() -> None:
+    """Best-effort startup provisioning; never fail the ``octop run`` process."""
+    try:
+        from octop.infra.utils.bwrap import ensure_bubblewrap
+
+        result = ensure_bubblewrap()
+    except Exception:
+        logger.warning("background bubblewrap provisioning failed", exc_info=True)
+        return
+    status = result.get("status")
+    detail = result.get("detail")
+    if status == "degraded":
+        logger.warning("background bubblewrap provisioning degraded: %s", detail or "unknown")
+    else:
+        logger.info("background bubblewrap provisioning status=%s", status)
+
+
+def _schedule_linux_bubblewrap_ensure() -> asyncio.Task[None] | None:
+    """Run bubblewrap provisioning once in the background on Linux."""
+    if not sys.platform.startswith("linux"):
+        return None
+    return asyncio.create_task(
+        asyncio.to_thread(_ensure_linux_bubblewrap),
+        name="ensure-linux-bubblewrap",
+    )
+
+
+async def _cancel_background_task(task: asyncio.Task[None] | None) -> None:
+    """Drop a startup background task on shutdown; never raise."""
+    if task is None or task.done():
+        return
+    task.cancel()
+    with suppress(asyncio.CancelledError):
+        await task
 
 
 async def _serve(server: Any) -> None:
@@ -35,6 +73,7 @@ async def run_foreground(
 
     srv = OctopServer()
     await srv.start()
+    bwrap_task = _schedule_linux_bubblewrap_ensure()
     # Greenfield deferral leaves services unset until /setup/database binds.
     cfg = srv.services.config if srv.services is not None else srv.config
     assert cfg is not None
@@ -108,6 +147,7 @@ async def run_foreground(
     try:
         await asyncio.gather(*(_serve(s) for s in servers))
     finally:
+        await _cancel_background_task(bwrap_task)
         await srv.stop()
 
 

--- a/tests/integration/test_e2e_golden_path.py
+++ b/tests/integration/test_e2e_golden_path.py
@@ -215,8 +215,8 @@ async def test_expert_to_chat_golden_path(env: Any) -> None:
     body = r.json()
     agent_id = body["agent_id"]
     assert body["expert_id"] == "general-assistant"
-    # Agent starts in non-running state (autostart=False)
-    assert body["state"] in {"running", "failed", "stopped", "unknown"}
+    assert body["state"] == "starting"
+    assert body["bootstrap_pending"] is True
 
     # Verify config stored correctly
     rows = (await c.get("/api/agents", headers=bob_auth)).json()

--- a/tests/integration/test_experts_api.py
+++ b/tests/integration/test_experts_api.py
@@ -180,11 +180,16 @@ async def test_hub_install_mounts_skill_packages(env: Any, monkeypatch: pytest.M
         )
     ).json()["id"]
     row = await server.app_runtime.agent_registry.create(
-        AgentCreateSpec(name="hub-packaged-expert", user_id=1),
+        AgentCreateSpec(
+            name="hub-packaged-expert",
+            user_id=1,
+            skill_package_ids=[package_id],
+        ),
         defer_bootstrap=True,
     )
 
-    async def fake_create_skillhub_market_agent(**_kwargs: Any) -> Any:
+    async def fake_create_skillhub_market_agent(**kwargs: Any) -> Any:
+        assert kwargs["options"].skill_package_ids == [package_id]
         return SimpleNamespace(
             row=row,
             expert_id="hub-expert",

--- a/tests/integration/test_invites_api.py
+++ b/tests/integration/test_invites_api.py
@@ -2,9 +2,14 @@
 
 from __future__ import annotations
 
+import json
+
+from octop.infra.agents.default_agent import default_home_local_backend
+from octop.infra.utils.host_dirs import host_home_dir, host_path_text
+
 
 async def test_invite_create_list_redeem_and_one_time(env) -> None:
-    c, _srv, auth = env
+    c, srv, auth = env
 
     r = await c.post(
         "/api/users/invites",
@@ -62,6 +67,13 @@ async def test_invite_create_list_redeem_and_one_time(env) -> None:
     assert len(bob_agents) == 1
     assert bob_agents[0]["template_name"] == "general-assistant"
     assert bob_agents[0]["agent_id"] != "main"
+    assert srv.app_runtime is not None
+    bob_row = srv.app_runtime.agent_registry.get_row(bob_agents[0]["agent_id"])
+    assert bob_row is not None
+    bob_cfg = json.loads(bob_row.config_json or "{}")
+    assert bob_cfg["backend"] == default_home_local_backend()
+    assert bob_cfg["backend"]["root_dir"] == host_path_text(host_home_dir())
+    assert bob_cfg["workspace_dir"] == f"/.octop/workspaces/{bob_agents[0]['agent_id']}"
 
     again = await c.post(
         "/api/auth/invite/redeem",

--- a/tests/integration/test_memory_api.py
+++ b/tests/integration/test_memory_api.py
@@ -49,7 +49,7 @@ def _seed_memory(srv: Any, agent_id: str) -> None:
         RawEvent,
     )
 
-    workspace = srv.services.paths.ensure_agent_workspace(agent_id)
+    workspace = srv.app_runtime.agent_registry.resolve_workspace_dir(agent_id)
     row = srv.services.agent_repo.get(agent_id)
     cfg: dict[str, Any] = {}
     if row is not None and row.config_json:

--- a/tests/integration/test_published_experts.py
+++ b/tests/integration/test_published_experts.py
@@ -58,6 +58,8 @@ async def test_publish_list_install_and_unpublish_preserves_installed_fork(
         json={"name": "Peer installed expert", "description": "Peer copy"},
     )
     assert installed.status_code == 201, installed.text
+    assert installed.json()["state"] == "starting"
+    assert installed.json()["bootstrap_pending"] is True
     installed_agent_id = installed.json()["agent_id"]
     assert installed.json()["user_id"] != expert["created_by"]
 
@@ -109,6 +111,60 @@ async def test_install_published_expert_accepts_create_options(
     assert body.get("max_iters") == 12
     config = body.get("config") or {}
     assert (config.get("backend") or {}).get("type") == "local_shell"
+
+
+@posix_only
+async def test_install_keeps_source_quick_prompts_when_publish_body_omits_them(
+    env: tuple[Any, Any, dict[str, str]],
+) -> None:
+    client, _server, admin_auth = env
+    owner_auth = await create_user(client, admin_auth, username="quickcard_owner")
+    peer_auth = await create_user(client, admin_auth, username="quickcard_peer")
+    created = await client.post(
+        "/api/agents/from-expert/ai-coding-coach",
+        headers=owner_auth,
+        json={"name": "quickcard-source"},
+    )
+    assert created.status_code == 201, created.text
+    source_agent_id = created.json()["agent_id"]
+
+    source_welcome = await client.get(
+        f"/api/agents/{source_agent_id}/chat/welcome",
+        headers=owner_auth,
+    )
+    assert source_welcome.status_code == 200, source_welcome.text
+    source_prompts = source_welcome.json()["quick_prompts"]
+    assert source_prompts
+
+    published = await client.post(
+        f"/api/agents/{source_agent_id}/publish-expert",
+        headers=owner_auth,
+        json={
+            "name": "Quick card expert",
+            "welcome_message": {"zh": "开始写代码吧", "en": "Let's write code"},
+        },
+    )
+    assert published.status_code == 201, published.text
+
+    installed = await client.post(
+        f"/api/experts/published/{published.json()['id']}/install",
+        headers=peer_auth,
+        json={"name": "Quick card fork"},
+    )
+    assert installed.status_code == 201, installed.text
+
+    unpublished = await client.delete(
+        f"/api/experts/published/{published.json()['id']}",
+        headers=owner_auth,
+    )
+    assert unpublished.status_code == 204, unpublished.text
+
+    fork_welcome = await client.get(
+        f"/api/agents/{installed.json()['agent_id']}/chat/welcome",
+        headers=peer_auth,
+    )
+    assert fork_welcome.status_code == 200, fork_welcome.text
+    assert fork_welcome.json()["quick_prompts"] == source_prompts
 
 
 async def test_creator_can_refresh_published_expert(

--- a/tests/integration/test_setup_bootstrap.py
+++ b/tests/integration/test_setup_bootstrap.py
@@ -102,24 +102,26 @@ async def test_main_agent_seeds_general_assistant_workspace(patched_app_client: 
     """Finish creates main with expert files even when no provider is configured yet."""
     c, _srv, home = patched_app_client
     await bootstrap_admin(c, home)
-    ws = home / "agents" / "main"
+    ws = home / "workspaces" / "main"
     assert (ws / "SOUL.md").is_file()
     # New agents use system_files_path=.octop — BackendWorkspace remaps skills/.
     assert (ws / ".octop" / "skills" / "octop-assistant" / "SKILL.md").is_file()
 
 
-async def test_main_agent_config_has_no_workspace_scoped_backend(patched_app_client: Any) -> None:
-    """Default main must use harness DEFAULT_BACKEND_SPEC (no virtual root = workspace_dir)."""
+async def test_main_agent_uses_home_scoped_backend(patched_app_client: Any) -> None:
+    """Default main uses the same home-scoped local backend as dashboard-created agents."""
     c, srv, home = patched_app_client
     await bootstrap_admin(c, home)
     assert srv.app_runtime is not None
     row = srv.app_runtime.agent_registry.get_row("main")
     assert row is not None
     cfg = json.loads(row.config_json or "{}")
-    assert cfg.get("backend") is None
-    ws = home / "agents" / "main"
-    nested = list(ws.glob("Users")) + list(ws.glob("private"))
-    assert not nested, f"unexpected nested workspace under main: {nested}"
+    assert cfg["backend"] == {
+        "type": "local_shell",
+        "root_dir": home.parent.resolve().as_posix(),
+        "virtual_mode": True,
+    }
+    assert cfg["workspace_dir"] == "/.octop/workspaces/main"
 
 
 async def test_main_agent_uses_general_assistant_template(patched_app_client: Any) -> None:

--- a/tests/integration/test_skill_packages_api.py
+++ b/tests/integration/test_skill_packages_api.py
@@ -172,7 +172,21 @@ async def test_import_skill_url_into_package(env: Any, monkeypatch: pytest.Monke
 
 
 async def test_delete_package_strips_agent_mounts(env_with_main_agent: Any) -> None:
-    client, server, auth, agent_id = env_with_main_agent
+    client, server, auth, _main_agent_id = env_with_main_agent
+    created = await client.post(
+        "/api/agents/from-expert/general-assistant",
+        headers=auth,
+        json={
+            "name": "Package Mount Agent",
+            "backend": {
+                "type": "local_shell",
+                "root_dir": "/",
+                "virtual_mode": True,
+            },
+        },
+    )
+    assert created.status_code == 201, created.text
+    agent_id = created.json()["agent_id"]
     package_id = (
         await client.post(
             "/api/skill-packages",

--- a/tests/support/harness.py
+++ b/tests/support/harness.py
@@ -70,6 +70,9 @@ def build_harness_manager_mock(
             virtual_mode = True
             if isinstance(backend_cfg, dict):
                 virtual_mode = bool(backend_cfg.get("virtual_mode", True))
+                root_dir = str(backend_cfg.get("root_dir") or "").strip()
+                if virtual_mode and root_dir not in {"", "/", "\\"}:
+                    ws_dir = Path(root_dir) / str(ws_dir).lstrip("/\\")
             entry_agent.use_workspace_dir(Path(str(ws_dir)), virtual_mode=virtual_mode)
         if isinstance(entry_agent, FakeHarnessAgent):
             _sync_fake_skill_dirs(entry_agent, config)

--- a/tests/unit/agents/test_agent_registry.py
+++ b/tests/unit/agents/test_agent_registry.py
@@ -975,6 +975,40 @@ async def test_on_provider_changed_removes_stale_provider(tmp_path: Path, monkey
 
 
 @pytest.mark.asyncio
+async def test_deferred_create_initializes_workspace_before_bootstrap(
+    tmp_path: Path, monkeypatch
+) -> None:
+    services = _make_services(tmp_path)
+    registry = _make_registry(services)
+    events: list[str] = []
+    bootstrapped = asyncio.Event()
+
+    async def initialize(row: Any, workspace: Any) -> None:
+        assert row.last_state != "starting"
+        await workspace.awrite_text("seeded.txt", "ready", force=True)
+        events.append("initialized")
+
+    async def bootstrap(row: Any) -> None:
+        workspace = registry._backend_workspace_for_row(row)
+        assert await workspace.aread_text("seeded.txt") == "ready"
+        events.append("bootstrapped")
+        bootstrapped.set()
+
+    monkeypatch.setattr(registry, "_complete_create_bootstrap", bootstrap)
+
+    row = await registry.create(
+        AgentCreateSpec(name="deferred-seed"),
+        defer_bootstrap=True,
+        workspace_initializer=initialize,
+    )
+
+    assert row.last_state == "starting"
+    assert events == ["initialized"]
+    await asyncio.wait_for(bootstrapped.wait(), timeout=1)
+    assert events == ["initialized", "bootstrapped"]
+
+
+@pytest.mark.asyncio
 async def test_create_with_template_writes_files(tmp_path: Path) -> None:
     """create() with template_name uploads expert files to the agent backend."""
     from octop.infra.agents.experts.catalog import (  # noqa: PLC0415

--- a/tests/unit/agents/test_default_agent.py
+++ b/tests/unit/agents/test_default_agent.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -10,6 +11,7 @@ from octop.infra.agents.default_agent import (
     DEFAULT_EXPERT_ID,
     SETUP_DEFAULT_AGENT_ID,
     bootstrap_default_agent,
+    default_home_local_backend,
 )
 from octop.infra.agents.experts.catalog import ExpertCatalog, default_library_root
 from octop.infra.errors import OctopError
@@ -48,7 +50,10 @@ async def test_bootstrap_skips_when_main_exists(catalog: ExpertCatalog) -> None:
     registry.create.assert_not_called()
 
 
-async def test_bootstrap_creates_general_assistant(catalog: ExpertCatalog) -> None:
+async def test_bootstrap_creates_general_assistant(
+    catalog: ExpertCatalog,
+    _isolated_user_home: Path,
+) -> None:
     registry = MagicMock()
     registry.get_row.return_value = None
     registry.list_agents.return_value = []
@@ -61,7 +66,30 @@ async def test_bootstrap_creates_general_assistant(catalog: ExpertCatalog) -> No
     assert spec.user_id == 3
     assert spec.agent_id is None
     assert spec.template_name == DEFAULT_EXPERT_ID
+    assert spec.config["backend"] == default_home_local_backend()
+    assert spec.config["backend"]["root_dir"] == _isolated_user_home.resolve().as_posix()
     assert registry.create.await_args.kwargs["defer_bootstrap"] is True
+
+
+async def test_bootstrap_main_uses_home_backend(
+    catalog: ExpertCatalog,
+    _isolated_user_home: Path,
+) -> None:
+    registry = MagicMock()
+    registry.get_row.return_value = None
+    registry.list_agents.return_value = []
+    registry.create = AsyncMock(return_value=object())
+
+    await bootstrap_default_agent(
+        registry,
+        catalog,
+        user_id=1,
+        agent_id=SETUP_DEFAULT_AGENT_ID,
+    )
+
+    spec = registry.create.await_args.args[0]
+    assert spec.config["backend"] == default_home_local_backend()
+    assert spec.config["backend"]["root_dir"] == _isolated_user_home.resolve().as_posix()
 
 
 async def test_bootstrap_requires_catalog() -> None:

--- a/tests/unit/api/test_setup_main_agent.py
+++ b/tests/unit/api/test_setup_main_agent.py
@@ -1,4 +1,4 @@
-"""Regression: bootstrap ``main`` agent must not use workspace-scoped virtual backend."""
+"""Regression coverage for setup's default ``main`` agent."""
 
 from __future__ import annotations
 
@@ -10,28 +10,6 @@ from harness_agent.backends import resolve_backend
 from harness_agent.backends.workspace import BackendWorkspace
 
 from octop.infra.agents.experts.catalog import ExpertCatalog, default_library_root
-
-
-def test_bootstrap_main_spec_has_no_custom_backend() -> None:
-    """setup._bootstrap_default_agent must not pin virtual_mode without root_dir='/'."""
-    from octop.infra.agents.experts.catalog import (
-        build_create_spec_from_expert,
-    )
-
-    catalog = ExpertCatalog(default_library_root())
-    catalog.refresh()
-    expert = catalog.get("general-assistant")
-    assert expert is not None
-    spec = build_create_spec_from_expert(
-        expert_id="general-assistant",
-        expert=expert,
-        user_id=1,
-        agent_id="main",
-        locale="zh",
-    )
-    assert "backend" not in spec.config
-    assert spec.template_name == "general-assistant"
-    assert "expert_id" not in spec.config
 
 
 def test_bootstrap_main_spec_en_locale_uses_english_label() -> None:

--- a/tests/unit/test_launch_bwrap.py
+++ b/tests/unit/test_launch_bwrap.py
@@ -1,0 +1,68 @@
+"""Tests for non-blocking bubblewrap provisioning in ``octop run``."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+
+import pytest
+
+from octop import launch
+
+
+@pytest.mark.parametrize("platform", ["darwin", "win32"])
+def test_schedule_skips_non_linux(
+    monkeypatch: pytest.MonkeyPatch,
+    platform: str,
+) -> None:
+    monkeypatch.setattr(launch.sys, "platform", platform)
+    assert launch._schedule_linux_bubblewrap_ensure() is None
+
+
+@pytest.mark.asyncio
+async def test_schedule_runs_linux_ensure_in_background(monkeypatch: pytest.MonkeyPatch) -> None:
+    started = threading.Event()
+    release = threading.Event()
+
+    def ensure() -> None:
+        started.set()
+        release.wait(timeout=5)
+
+    monkeypatch.setattr(launch.sys, "platform", "linux")
+    monkeypatch.setattr(launch, "_ensure_linux_bubblewrap", ensure)
+
+    task = launch._schedule_linux_bubblewrap_ensure()
+    assert task is not None
+    try:
+        assert await asyncio.to_thread(started.wait, 1)
+        assert not task.done()
+    finally:
+        release.set()
+    await task
+
+
+@pytest.mark.asyncio
+async def test_cancel_background_task_is_noop_when_missing() -> None:
+    await launch._cancel_background_task(None)
+
+
+@pytest.mark.asyncio
+async def test_cancel_background_task_drops_pending() -> None:
+    started = asyncio.Event()
+
+    async def hang() -> None:
+        started.set()
+        await asyncio.sleep(60)
+
+    task = asyncio.create_task(hang())
+    await started.wait()
+    await launch._cancel_background_task(task)
+    assert task.cancelled() or task.done()
+
+
+def test_background_ensure_swallows_failures(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fail() -> dict[str, str]:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr("octop.infra.utils.bwrap.ensure_bubblewrap", fail)
+    launch._ensure_linux_bubblewrap()


### PR DESCRIPTION
## Summary
- Linux `octop run` 后台预装 bubblewrap，失败不阻塞启动；退出时取消该任务。
- 向导 `main` 与邀请默认专家使用与仪表盘一致的 home-scoped `local_shell`（工作区 `{home}/.octop/workspaces/<id>`）。
- 聊天页任务进度按原始数字 id 排序，不再按状态重排。
- 顺带：编辑专家时锁定 backend 字段、市场安装带上 skill packages、发布专家欢迎语/快捷卡片与安装态字段对齐。

## Test plan
- [ ] `octop run` 在 Linux 上不阻塞；无 bwrap 时日志 degraded，创建专家流程仍可用
- [ ] 新安装向导创建的 `main` 与仪表盘新建专家均为 home `root_dir`，工作区在 `~/.octop/workspaces/...`
- [ ] 邀请兑换用户的默认专家同样为 home-scoped
- [ ] 聊天任务进度：已完成步骤仍按计划序号显示；超过 9 条时 10 在 2 之后
- [ ] 编辑已有专家时无法改 backend / root_dir


Made with [Cursor](https://cursor.com)