### PR TITLE
feat(chat): expand process summary while streaming

### DIFF
--- a/dashboard/src/pages/Chat/components/AssistantProcessSummary.tsx
+++ b/dashboard/src/pages/Chat/components/AssistantProcessSummary.tsx
@@ -1,4 +1,4 @@
-import { memo, useMemo, useState } from "react";
+import { memo, useEffect, useMemo, useRef, useState } from "react";
 import { ChevronRight } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import Markdown from "../../../components/Markdown/LazyMarkdown";
@@ -31,11 +31,21 @@ function AssistantProcessSummary({
   agentId = null,
 }: AssistantProcessSummaryProps) {
   const { t } = useTranslation();
-  const [expanded, setExpanded] = useState(false);
+  const [expanded, setExpanded] = useState(isStreaming);
+  const prevStreaming = useRef(isStreaming);
   const { toolCount, thinkingCount } = useMemo(
     () => countProcessStats(statsSplit ?? split),
     [statsSplit, split],
   );
+
+  // Follow the stream: expand while generating, collapse once the turn ends.
+  // Manual toggles hold until the next streaming transition; history renders
+  // with isStreaming=false and therefore stays collapsed.
+  useEffect(() => {
+    if (prevStreaming.current === isStreaming) return;
+    prevStreaming.current = isStreaming;
+    setExpanded(isStreaming);
+  }, [isStreaming]);
 
   if (toolCount === 0 && thinkingCount === 0) return null;
 


### PR DESCRIPTION
## Summary
- 聊天页思考/工具过程汇总条在流式输出期间默认展开，用户仍可手动收起。
- 本轮回答结束后自动收起；加载历史记录仍保持收起。
- 单条工具卡片的参数/结果详情折叠未改，仍需手动展开。

## Test plan
- [ ] 新发一条会触发思考或工具调用的消息：流式过程中汇总条默认展开，能看到思考正文和工具状态。
- [ ] 流式过程中手动收起：在本轮结束前保持收起，不被重新弹开。
- [ ] 回答完成后汇总条自动收起。
- [ ] 刷新或打开历史会话：历史消息的过程汇总仍为收起。
- [ ] 工具卡片内的参数/结果仍默认收起。


Made with [Cursor](https://cursor.com)