### PR TITLE
fix(ci): repair FnOS workflow parse error and stop re-running CI per release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,9 @@
 name: CI
 
+# Pull requests only. GitHub runs PR checks on the merge result, so a push
+# build on main would re-test content that the release / feature PR already
+# proved green.
 on:
-  push:
-    branches: [main]
   pull_request:
 
 concurrency:
@@ -13,6 +14,9 @@ jobs:
   quality:
     name: "Python ${{ matrix.python-version }}"
     runs-on: ubuntu-latest
+    # Post-release main → develop sync PRs carry main's already-tested tree and
+    # are auto-merged by the bot before checks finish. See sync-main-to-develop.
+    if: ${{ !startsWith(github.head_ref, 'chore/sync-develop-after-') }}
     strategy:
       fail-fast: false
       matrix:
@@ -40,6 +44,7 @@ jobs:
   test-windows:
     name: Windows / Python 3.12
     runs-on: windows-latest
+    if: ${{ !startsWith(github.head_ref, 'chore/sync-develop-after-') }}
     steps:
       - uses: actions/checkout@v4
 
@@ -65,8 +70,8 @@ jobs:
     runs-on: ubuntu-latest
     # Only the main repo may access secrets; fork PRs get none and must skip.
     if: >-
-      github.event_name == 'push' ||
-      github.event.pull_request.head.repo.full_name == github.repository
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      !startsWith(github.head_ref, 'chore/sync-develop-after-')
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/fnos-build-fpk.yml
+++ b/.github/workflows/fnos-build-fpk.yml
@@ -303,5 +303,3 @@ jobs:
           prerelease: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,7 +148,8 @@ jobs:
         run: |
           gh workflow run sync-main-to-develop.yml \
             --repo "${{ github.repository }}" \
-            --ref main
+            --ref main \
+            -f version="${{ github.ref_name }}"
 
   # FnOS FPK：复用本 Release 的 wheel + docker-publish 的 GHCR 镜像。
   # 与 sync-develop 并行；失败不阻断发版。

--- a/.github/workflows/sync-main-to-develop.yml
+++ b/.github/workflows/sync-main-to-develop.yml
@@ -19,6 +19,11 @@ on:
     types:
       - completed
   workflow_dispatch:
+    inputs:
+      version:
+        description: "Release tag being synced, e.g. v0.9.31. Blank = read main's pyproject.toml."
+        required: false
+        type: string
   release:
     types:
       - published
@@ -47,14 +52,24 @@ jobs:
       - name: Sync develop onto main
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ github.event.release.tag_name || github.event.workflow_run.head_branch || 'manual' }}
+          TAG: ${{ inputs.version || github.event.release.tag_name || github.event.workflow_run.head_branch }}
         run: |
           set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          version="${TAG#v}"
-          sync_branch="chore/sync-develop-after-${version}"
           git fetch origin main develop
+
+          # Release dispatches this workflow with GITHUB_TOKEN, so the release /
+          # workflow_run payloads are empty. Fall back to main's shipped version
+          # rather than a constant, or every release would reuse (and force-push)
+          # the same sync branch.
+          version="${TAG#v}"
+          if [ -z "$version" ]; then
+            version="$(git show origin/main:pyproject.toml \
+              | sed -nE 's/^version = "([^"]+)".*/\1/p' | head -1)"
+          fi
+          : "${version:?could not resolve the version being synced}"
+          sync_branch="chore/sync-develop-after-${version}"
 
           if git merge-base --is-ancestor origin/main origin/develop; then
             echo "develop already contains main tip; nothing to sync."
@@ -118,7 +133,7 @@ jobs:
               --base develop \
               --head "${sync_branch}" \
               --title "chore: sync develop onto main after ${version}" \
-              --body "Post-release sync so \`main\` stays an ancestor of \`develop\` (${TAG}). Merge when CI is green."
+              --body "Post-release sync so \`main\` stays an ancestor of \`develop\` (v${version}). Carries main's already-tested tree, so CI is skipped for this branch."
           )"
           echo "Created sync PR: ${url}"
 


### PR DESCRIPTION
## Summary

三处流水线问题，均为 CI 配置，无产品代码改动。

**1. FnOS 打包 workflow 从 8/31 起完全没跑。** `fnos-build-fpk.yml` 在 e91521a 删除「Publish rolling release」步骤时留下了它的 `env:` 块，导致最后一个步骤有两个 `env:`，GitHub 拒绝解析整个文件。Release 的 `Trigger FnOS FPK build` 报 `HTTP 422 ... failed to parse workflow: (Line: 306, Col: 9): 'env' is already defined`，但该 job 是 `continue-on-error`，所以 Release 整体显示成功、问题被吞掉。旁证：`gh workflow list` 里这个 workflow 显示为文件路径而非 `Build Octop FPK`，且每次 push 都产生一条 0 秒失败记录。0.9.31 因此没有 fpk 产物（按约定不补跑，下个版本自然生效）。

**2. 一次发布重复跑三遍完整测试套件。** release PR 21m + main push 24m + 回灌 PR 18m，三者内容完全相同。去掉 CI 的 `push: branches: [main]`（PR 检查跑的就是合并结果，main 上重跑是冗余），并对 `chore/sync-develop-after-*` 分支跳过 CI —— 上次那条回灌 PR 在 CI 启动前 1 分钟就被 bot 自动合并了，那 18 分钟纯属空转。develop / main 均无 required status checks（只有 `pull_request` 规则），跳过不会阻塞合并。

**3. 回灌分支名恒为 `chore/sync-develop-after-manual` 且被强推覆盖。** Release 用 `workflow_dispatch` 触发 sync，`github.event.release.tag_name` 与 `workflow_run.head_branch` 都为空，回落到常量 `'manual'`。上次发布直接 force-push 覆盖了 0.9.30 留下的同名分支。现在 Release 把 tag 作为 input 传下去，并在 input 缺失时回退读 main 的 `pyproject.toml`，分支名变为 `chore/sync-develop-after-0.9.31`。

## Test plan

- [x] 严格模式（禁止重复键）解析 `.github/workflows/*.yml` 全部通过，`fnos-build-fpk.yml` 正确解析出 `name: Build Octop FPK`
- [x] 确认 develop / main 无 required status checks，跳过回灌 PR 的 CI 不阻塞自动合并
- [ ] 本 PR 自身的 CI 通过（验证 `pull_request` 触发与 `if` 表达式无误）
- [ ] 合入后手动 `gh workflow run fnos-build-fpk.yml --ref develop` 冒烟一次，确认 dispatch 不再 422
- [ ] 下次发布时观察：CI 只跑 release PR 一次；回灌分支名为 `chore/sync-develop-after-<version>`；FnOS 自动触发


Made with [Cursor](https://cursor.com)