### PR TITLE
fix(ci): unify desktop and portable release artifact names

### DIFF
--- a/.github/workflows/octop-desktop.yml
+++ b/.github/workflows/octop-desktop.yml
@@ -139,6 +139,13 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      - name: Read package version
+        run: |
+          set -euo pipefail
+          VER=$(sed -nE 's/^version[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/p' pyproject.toml | head -1)
+          echo "OCTOP_VERSION=${VER}" >> "$GITHUB_ENV"
+          echo "version=${VER}"
+
       - uses: actions/download-artifact@v5
         with:
           name: dashboard-dist
@@ -224,15 +231,15 @@ jobs:
         run: >-
           wails3 task package
           ARCH=${{ matrix.arch }}
-          PORTABLE_ZIP=../portable/release/Octop-${{ matrix.plat }}.zip
+          VERSION=${{ env.OCTOP_VERSION }}
+          PORTABLE_ZIP=../portable/release/Octop-portable-${{ matrix.plat }}-${{ env.OCTOP_VERSION }}.zip
 
       # archive: false — upload the prebuilt zip as-is. Default archive=true would
-      # wrap it again, so Actions UI / "Download artifact" becomes zip-in-zip
-      # (Octop-<plat>.zip containing another Octop-<plat>.zip). Affects every plat.
+      # wrap it again, so Actions UI / "Download artifact" becomes zip-in-zip.
       # With archive:false, artifact name is the filename (name: is ignored).
       - uses: actions/upload-artifact@v7
         with:
-          path: desktop/portable/release/Octop-${{ matrix.plat }}.zip
+          path: desktop/portable/release/Octop-portable-${{ matrix.plat }}-${{ env.OCTOP_VERSION }}.zip
           archive: false
           if-no-files-found: error
           retention-days: 14
@@ -240,7 +247,7 @@ jobs:
       - name: Upload bundled desktop package
         uses: actions/upload-artifact@v7
         with:
-          path: desktop/src/bin/Octop-Desktop-${{ matrix.plat }}.*
+          path: desktop/src/bin/Octop-desktop-${{ matrix.plat }}-${{ env.OCTOP_VERSION }}.*
           archive: false
           if-no-files-found: error
           retention-days: 14
@@ -281,7 +288,7 @@ jobs:
           echo "tag=${tag}" >> "$GITHUB_OUTPUT"
 
       # v8 required for archive:false artifacts. skip-decompress keeps the
-      # uploaded .zip / .tar / .dmg / .exe intact — default unzip turns portable
+      # uploaded .zip / .tar.gz / .dmg / .exe intact — default unzip turns portable
       # zips into directories, so files: release-assets/* would skip them.
       - uses: actions/download-artifact@v8
         with:

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -38,7 +38,7 @@ the final native package:
 
 ```bash
 desktop/package-release.sh
-# Reuse an existing desktop/portable/release/Octop-<plat>.zip:
+# Reuse an existing desktop/portable/release/Octop-portable-<plat>-<version>.zip:
 desktop/package-release.sh darwin-arm64 --reuse-portable
 ```
 
@@ -56,8 +56,8 @@ go install github.com/wailsapp/wails/v3/cmd/wails3@v3.0.0-beta.13
 cd desktop/src
 go mod tidy
 wails3 build            # development binary under desktop/src/bin/
-wails3 task package ARCH=arm64 \
-  PORTABLE_ZIP=../portable/release/Octop-darwin-arm64.zip
+wails3 task package ARCH=arm64 VERSION=<version> \
+  PORTABLE_ZIP=../portable/release/Octop-portable-darwin-arm64-<version>.zip
 ```
 
 Dev against an already-running Octop (skips the bundled green zip):
@@ -71,11 +71,16 @@ Without `OCTOP_DESKTOP_URL`, first launch uses `~/.octop/portable/` if valid,
 otherwise extracts the matching zip shipped with the desktop package (embedded
 in the Windows and Linux binaries, under `Contents/Resources` on macOS). The
 Wails shell never downloads Octop. For local runtime debugging, set
-`OCTOP_DESKTOP_PORTABLE_ZIP=/absolute/path/Octop-<plat>.zip`.
+`OCTOP_DESKTOP_PORTABLE_ZIP=/absolute/path/Octop-portable-<plat>-<version>.zip`.
 
-Desktop outputs are native GUI packages: `Octop-Desktop-<plat>.dmg` (macOS),
-`Octop-Desktop-<plat>.exe` (Windows), and `Octop-Desktop-<plat>.tar` (Linux).
-The Linux tar contains only the GUI binary; it has no separate portable zip or
+GitHub Release names follow `Octop-<kind>-<os>-<arch>-<version>.<ext>`:
+
+- Desktop GUI: `Octop-desktop-<plat>-<version>.dmg` (macOS),
+  `.exe` (Windows), `.tar.gz` (Linux)
+- Green runtime zip: `Octop-portable-<plat>-<version>.zip`
+- PyPI wheels stay `octop-<version>-py3-none-any.whl` (PEP 427)
+
+The Linux tar.gz contains only the GUI binary; it has no separate portable zip or
 server terminal process. Runtime upgrades remain owned by Octop:
 the shell sets `OCTOP_GREEN_PACKAGES`, so `octop update` upgrades the extracted
 `packages/` directory through Octop's existing `--target` logic.

--- a/desktop/package-release.sh
+++ b/desktop/package-release.sh
@@ -22,7 +22,7 @@ Platforms:
   windows-arm64 windows-amd64
 
 The platform defaults to the current native host. --reuse-portable skips
-rebuilding desktop/portable/release/Octop-<platform>.zip when it already exists.
+rebuilding desktop/portable/release/Octop-portable-<platform>-<version>.zip when it already exists.
 EOF
 }
 
@@ -61,7 +61,8 @@ if ! command -v wails3 >/dev/null 2>&1; then
 fi
 
 arch="${plat##*-}"
-portable_zip="${REPO_ROOT}/desktop/portable/release/Octop-${plat}.zip"
+ver="$(octop_version)"
+portable_zip="${REPO_ROOT}/desktop/portable/release/$(portable_zip_basename "$plat")"
 
 echo "[desktop-release] platform=${plat}"
 echo "[desktop-release] building Dashboard"
@@ -99,14 +100,10 @@ PYTHONNOUSERSITE=1 "$portable_python" \
 echo "[desktop-release] packaging Wails application"
 (
   cd "${REPO_ROOT}/desktop/src"
-  wails3 task package "ARCH=${arch}" "PORTABLE_ZIP=${portable_zip}"
+  wails3 task package "ARCH=${arch}" "PORTABLE_ZIP=${portable_zip}" "VERSION=${ver}"
 )
 
-case "$plat" in
-  darwin-*) output="${REPO_ROOT}/desktop/src/bin/Octop-Desktop-${plat}.dmg" ;;
-  windows-*) output="${REPO_ROOT}/desktop/src/bin/Octop-Desktop-${plat}.exe" ;;
-  linux-*) output="${REPO_ROOT}/desktop/src/bin/Octop-Desktop-${plat}.tar" ;;
-esac
+output="${REPO_ROOT}/desktop/src/bin/$(desktop_pkg_basename "$plat")"
 if [[ ! -s "$output" ]]; then
   echo "desktop release was not created: ${output}" >&2
   exit 1

--- a/desktop/portable/AGENT_ELECTRON_INTEGRATION.md
+++ b/desktop/portable/AGENT_ELECTRON_INTEGRATION.md
@@ -9,7 +9,7 @@ path (no system Python, no `PYTHONPATH=packages`).
 CI / `make -f desktop/portable/Makefile green` produces:
 
 ```
-desktop/portable/release/Octop-<plat>.zip
+desktop/portable/release/Octop-portable-<plat>-<version>.zip
 ```
 
 Platforms: `darwin-arm64` `darwin-amd64` `linux-amd64` `linux-arm64`

--- a/desktop/portable/README.md
+++ b/desktop/portable/README.md
@@ -29,6 +29,8 @@ make -f desktop/portable/Makefile green
 
 ## 产物布局
 
+公开文件名：`Octop-portable-<plat>-<version>.zip`。zip 内目录仍是：
+
 ```
 Octop-<plat>/
   runtime/       # python-build-standalone
@@ -112,5 +114,5 @@ Actions 使用 GitHub 上游 PBS（`PBS_BASE_URL`），本机构建默认 npmmir
 
 ## Electron 壳
 
-壳只消费 `Octop-<plat>.zip`，不要把绿包编进 asar。步骤见
+壳只消费 `Octop-portable-<plat>-<version>.zip`（zip 内仍是 `Octop-<plat>/`），不要把绿包编进 asar。步骤见
 [`AGENT_ELECTRON_INTEGRATION.md`](AGENT_ELECTRON_INTEGRATION.md)。

--- a/desktop/portable/_common.sh
+++ b/desktop/portable/_common.sh
@@ -23,6 +23,33 @@ ALL_PLATS=(
   windows-arm64
 )
 
+# Public GitHub Release names: Octop-<kind>-<os>-<arch>-<version>.<ext>
+# Zip payload directory stays Octop-<plat>/ (the desktop unzip strips the first
+# path component). PyPI wheels keep the PEP 427 name and are not renamed here.
+octop_version() {
+  sed -nE 's/^version[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/p' \
+    "${REPO_ROOT}/pyproject.toml" | head -1
+}
+
+portable_zip_basename() {
+  echo "Octop-portable-${1}-$(octop_version).zip"
+}
+
+desktop_pkg_basename() {
+  local plat="$1"
+  local ver
+  ver="$(octop_version)"
+  case "$plat" in
+    darwin-*) echo "Octop-desktop-${plat}-${ver}.dmg" ;;
+    windows-*) echo "Octop-desktop-${plat}-${ver}.exe" ;;
+    linux-*) echo "Octop-desktop-${plat}-${ver}.tar.gz" ;;
+    *)
+      echo "unknown platform: ${plat}" >&2
+      return 1
+      ;;
+  esac
+}
+
 # Map GitHub Actions RUNNER_ARCH (X64/ARM64/...) → green arch suffix.
 runner_arch_to_green() {
   case "$(printf '%s' "${1:-}" | tr '[:lower:]' '[:upper:]')" in

--- a/desktop/portable/package.sh
+++ b/desktop/portable/package.sh
@@ -16,6 +16,8 @@
 #     packages/    site-packages (uv --target, relocatable)
 #     start.sh / start.bat
 #     README.txt
+#
+# Public filename is Octop-portable-<plat>-<version>.zip (see portable_zip_basename).
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
@@ -83,7 +85,7 @@ assemble_one() {
   local runtime="${GREEN_RUNTIMES}/${plat}"
   local wheel_dir="${GREEN_WHEELS}/${plat}"
   local staging="${GREEN_RELEASE}/Octop-${plat}"
-  local zip_path="${GREEN_RELEASE}/Octop-${plat}.zip"
+  local zip_path="${GREEN_RELEASE}/$(portable_zip_basename "$plat")"
   local pyplat
 
   if ! pyplat="$(uv_platform "$plat")"; then
@@ -254,10 +256,13 @@ assemble_one() {
 
   rm -f "$zip_path"
   echo "[package] ${plat}: zipping → ${zip_path}"
+  local zip_name zip_stem
+  zip_name="$(basename "$zip_path")"
+  zip_stem="${zip_name%.zip}"
   (
     cd "$GREEN_RELEASE"
     if command -v zip >/dev/null 2>&1; then
-      zip -qry "Octop-${plat}.zip" "Octop-${plat}"
+      zip -qry "$zip_name" "Octop-${plat}"
     else
       # Windows runners often have `python` but not `python3` / `zip`.
       py=""
@@ -270,7 +275,7 @@ assemble_one() {
         echo "[package] need zip or python to create archive" >&2
         exit 1
       fi
-      "$py" -c "import shutil; shutil.make_archive('Octop-${plat}', 'zip', '.', 'Octop-${plat}')"
+      "$py" -c "import shutil; shutil.make_archive('${zip_stem}', 'zip', '.', 'Octop-${plat}')"
     fi
   )
   echo "[package] wrote ${zip_path}"

--- a/desktop/src/build/darwin/Taskfile.yml
+++ b/desktop/src/build/darwin/Taskfile.yml
@@ -33,16 +33,20 @@ tasks:
           PRODUCTION: "true"
     cmds:
       - task: create:app:bundle
-      - rm -rf {{.DMG_ROOT}} {{.ARCHIVE}} {{.BIN_DIR}}/{{.APP_NAME}}-Desktop-darwin-{{.ARCH}}.zip
+        vars:
+          PORTABLE_ZIP: "{{.PORTABLE_ZIP}}"
+          ARCH: "{{.ARCH}}"
+      - rm -rf {{.DMG_ROOT}} {{.ARCHIVE}} {{.BIN_DIR}}/{{.APP_NAME}}-Desktop-darwin-{{.ARCH}}.zip {{.BIN_DIR}}/{{.APP_NAME}}-Desktop-darwin-{{.ARCH}}.dmg
       - mkdir -p {{.DMG_ROOT}}
       - ditto {{.BIN_DIR}}/{{.APP_NAME}}.app {{.DMG_ROOT}}/{{.APP_NAME}}.app
       - hdiutil create -volname {{.APP_NAME}} -srcfolder {{.DMG_ROOT}} -ov -format UDRO {{.ARCHIVE}}
       - rm -rf {{.DMG_ROOT}}
     vars:
       ARCH: "{{.ARCH | default ARCH}}"
-      PORTABLE_ZIP: '{{.PORTABLE_ZIP | default (printf "../portable/release/Octop-darwin-%s.zip" .ARCH)}}'
+      VERSION: '{{.VERSION | default "dev"}}'
+      PORTABLE_ZIP: '{{.PORTABLE_ZIP | default (printf "../portable/release/Octop-portable-darwin-%s-%s.zip" .ARCH .VERSION)}}'
       DMG_ROOT: '{{.BIN_DIR}}/dmg-darwin-{{.ARCH}}'
-      ARCHIVE: '{{.BIN_DIR}}/{{.APP_NAME}}-Desktop-darwin-{{.ARCH}}.dmg'
+      ARCHIVE: '{{.BIN_DIR}}/{{.APP_NAME}}-desktop-darwin-{{.ARCH}}-{{.VERSION}}.dmg'
 
   create:app:bundle:
     summary: Creates an .app bundle
@@ -50,7 +54,8 @@ tasks:
       - test -f {{.PORTABLE_ZIP}}
       - mkdir -p {{.BIN_DIR}}/{{.APP_NAME}}.app/Contents/{MacOS,Resources}
       - cp build/darwin/icons.icns {{.BIN_DIR}}/{{.APP_NAME}}.app/Contents/Resources
-      - cp {{.PORTABLE_ZIP}} {{.BIN_DIR}}/{{.APP_NAME}}.app/Contents/Resources/
+      # Stable name inside the signed .app; GitHub Release uses the versioned portable zip.
+      - cp {{.PORTABLE_ZIP}} {{.BIN_DIR}}/{{.APP_NAME}}.app/Contents/Resources/Octop-darwin-{{.ARCH}}.zip
       - cp {{.BIN_DIR}}/{{.APP_NAME}} {{.BIN_DIR}}/{{.APP_NAME}}.app/Contents/MacOS
       - cp build/darwin/Info.plist {{.BIN_DIR}}/{{.APP_NAME}}.app/Contents
       - codesign --force --deep --sign - {{.BIN_DIR}}/{{.APP_NAME}}.app

--- a/desktop/src/build/linux/Taskfile.yml
+++ b/desktop/src/build/linux/Taskfile.yml
@@ -30,11 +30,12 @@ tasks:
         vars:
           PRODUCTION: "true"
       - rm -f {{.ARCHIVE}} bundled/portable.zip
-      - tar -C {{.BIN_DIR}} -cf {{.ARCHIVE}} {{.APP_NAME}}
+      - tar -C {{.BIN_DIR}} -czf {{.ARCHIVE}} {{.APP_NAME}}
     vars:
       ARCH: "{{.ARCH | default ARCH}}"
-      PORTABLE_ZIP: '{{.PORTABLE_ZIP | default (printf "../portable/release/Octop-linux-%s.zip" .ARCH)}}'
-      ARCHIVE: '{{.BIN_DIR}}/{{.APP_NAME}}-Desktop-linux-{{.ARCH}}.tar'
+      VERSION: '{{.VERSION | default "dev"}}'
+      PORTABLE_ZIP: '{{.PORTABLE_ZIP | default (printf "../portable/release/Octop-portable-linux-%s-%s.zip" .ARCH .VERSION)}}'
+      ARCHIVE: '{{.BIN_DIR}}/{{.APP_NAME}}-desktop-linux-{{.ARCH}}-{{.VERSION}}.tar.gz'
 
   stage:portable:
     summary: Copies the matching green zip for go:embed
@@ -43,7 +44,7 @@ tasks:
       - mkdir -p bundled
       - cp {{.PORTABLE_ZIP}} bundled/portable.zip
     vars:
-      PORTABLE_ZIP: '{{.PORTABLE_ZIP | default (printf "../portable/release/Octop-linux-%s.zip" (.ARCH | default ARCH))}}'
+      PORTABLE_ZIP: '{{.PORTABLE_ZIP | default (printf "../portable/release/Octop-portable-linux-%s-%s.zip" (.ARCH | default ARCH) (.VERSION | default "dev"))}}'
 
   run:
     cmds:

--- a/desktop/src/build/windows/Taskfile.yml
+++ b/desktop/src/build/windows/Taskfile.yml
@@ -36,7 +36,7 @@ tasks:
           New-Item -ItemType Directory -Force bundled | Out-Null;
           Copy-Item -Force '{{.PORTABLE_ZIP}}' 'bundled/portable.zip'"
     vars:
-      PORTABLE_ZIP: '{{.PORTABLE_ZIP | default (printf "../portable/release/Octop-windows-%s.zip" (.ARCH | default ARCH))}}'
+      PORTABLE_ZIP: '{{.PORTABLE_ZIP | default (printf "../portable/release/Octop-portable-windows-%s-%s.zip" (.ARCH | default ARCH) (.VERSION | default "dev"))}}'
 
   package:
     summary: Packages a single production exe with the portable runtime embedded
@@ -53,13 +53,15 @@ tasks:
           powershell -NoProfile -Command
           "Remove-Item -Force '{{.ARCHIVE}}' -ErrorAction SilentlyContinue;
           Remove-Item -Force '{{.BIN_DIR}}/{{.APP_NAME}}-Desktop-windows-{{.ARCH}}.zip' -ErrorAction SilentlyContinue;
+          Remove-Item -Force '{{.BIN_DIR}}/{{.APP_NAME}}-Desktop-windows-{{.ARCH}}.exe' -ErrorAction SilentlyContinue;
           Remove-Item -Recurse -Force '{{.BIN_DIR}}/{{.APP_NAME}}-Desktop-windows-{{.ARCH}}' -ErrorAction SilentlyContinue;
           Copy-Item '{{.BIN_DIR}}/{{.APP_NAME}}.exe' '{{.ARCHIVE}}';
           Remove-Item -Force 'bundled/portable.zip' -ErrorAction SilentlyContinue"
     vars:
       ARCH: "{{.ARCH | default ARCH}}"
-      PORTABLE_ZIP: '{{.PORTABLE_ZIP | default (printf "../portable/release/Octop-windows-%s.zip" .ARCH)}}'
-      ARCHIVE: '{{.BIN_DIR}}/{{.APP_NAME}}-Desktop-windows-{{.ARCH}}.exe'
+      VERSION: '{{.VERSION | default "dev"}}'
+      PORTABLE_ZIP: '{{.PORTABLE_ZIP | default (printf "../portable/release/Octop-portable-windows-%s-%s.zip" .ARCH .VERSION)}}'
+      ARCHIVE: '{{.BIN_DIR}}/{{.APP_NAME}}-desktop-windows-{{.ARCH}}-{{.VERSION}}.exe'
 
   run:
     cmds:

--- a/desktop/src/download.go
+++ b/desktop/src/download.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strings"
 	"time"
 )
@@ -70,7 +71,6 @@ func extractPortable(root string) error {
 }
 
 func bundledPortableZip() (string, error) {
-	name := fmt.Sprintf("Octop-%s.zip", greenPlat())
 	if override := os.Getenv("OCTOP_DESKTOP_PORTABLE_ZIP"); override != "" {
 		if _, err := os.Stat(override); err != nil {
 			return "", fmt.Errorf("bundled portable package: %w", err)
@@ -82,17 +82,25 @@ func bundledPortableZip() (string, error) {
 		return "", err
 	}
 	dir := filepath.Dir(exe)
-	candidates := []string{
-		filepath.Join(dir, name),
-		filepath.Join(dir, "..", "Resources", name),
+	plat := greenPlat()
+	legacy := fmt.Sprintf("Octop-%s.zip", plat)
+	searchDirs := []string{
+		dir,
+		filepath.Join(dir, "..", "Resources"),
 	}
-	for _, candidate := range candidates {
-		candidate = filepath.Clean(candidate)
-		if _, err := os.Stat(candidate); err == nil {
-			return candidate, nil
+	for _, search := range searchDirs {
+		search = filepath.Clean(search)
+		legacyPath := filepath.Join(search, legacy)
+		if _, err := os.Stat(legacyPath); err == nil {
+			return legacyPath, nil
+		}
+		matches, _ := filepath.Glob(filepath.Join(search, "Octop-portable-"+plat+"-*.zip"))
+		if len(matches) > 0 {
+			sort.Strings(matches)
+			return matches[len(matches)-1], nil
 		}
 	}
-	return "", fmt.Errorf("bundled portable package %s not found beside application", name)
+	return "", fmt.Errorf("bundled portable package %s not found beside application", legacy)
 }
 
 func unzipGreen(zipPath, dest string) error {

--- a/desktop/src/embed_portable.go
+++ b/desktop/src/embed_portable.go
@@ -2,6 +2,7 @@
 
 package main
 
-// Development builds look for Octop-<plat>.zip beside the executable. macOS
-// production keeps the zip in the signed .app Resources directory.
+// Development builds look for Octop-<plat>.zip or Octop-portable-<plat>-*.zip
+// beside the executable. macOS production copies the zip into Resources as
+// Octop-<plat>.zip.
 var embeddedPortable []byte


### PR DESCRIPTION
## Summary

GitHub Release 上的桌面/绿色包文件名不统一：wheel 带版本，`Octop-<os>-<arch>.zip` 和 `Octop-Desktop-*` 不带版本，Linux 桌面还是裸 `.tar`。公开制品改为：

```
Octop-<kind>-<os>-<arch>-<version>.<ext>
```

- 桌面 GUI：`Octop-desktop-darwin-arm64-0.9.31.dmg` / `.exe` / `.tar.gz`
- 绿色运行时：`Octop-portable-windows-amd64-0.9.31.zip`
- PyPI wheel / sdist **不改**（PEP 427）
- 飞牛 `Octop-fnos-{docker,native}-<ver>.fpk` **不改**

zip **内部目录**仍是 `Octop-<plat>/`（桌面解压剥第一层）。macOS `.app` 的 Resources 里仍复制为 `Octop-darwin-<arch>.zip`，避免签名包内路径跟着版本号变。Linux/Windows 继续 embed 成 `bundled/portable.zip`。桌面壳会再认 `Octop-portable-<plat>-*.zip`，方便本地把公开文件名的 zip 放在可执行文件旁边。

## Test plan

- [x] `portable_zip_basename` / `desktop_pkg_basename` 对当前 pyproject `0.9.31` 产出预期文件名
- [x] `octop-desktop.yml` YAML 可解析
- [ ] 本 PR 的 CI 通过（desktop path 会跑 darwin/windows 打包；Linux 桌面 `.tar.gz` 要等发版矩阵）
- [ ] 下次发版检查 GitHub Release 资源名为新格式，且 macOS 安装包仍能解出内嵌运行时


Made with [Cursor](https://cursor.com)