### PR TITLE
fix(ci): attach FnOS fpk to the v* GitHub Release

### DIFF
--- a/.github/workflows/auto-tag-on-release.yml
+++ b/.github/workflows/auto-tag-on-release.yml
@@ -67,7 +67,8 @@ jobs:
       # dispatch Release / Docker Publish / Desktop Package (workflow_dispatch
       # is exempt). FnOS FPK is cascaded from Release after the GitHub Release
       # exists (reuses Release wheel + waits for GHCR image from Docker Publish).
-      # Desktop builds in parallel; its release job upserts zips onto the same v*.
+      # Desktop and FnOS upsert their packages onto the same v* GitHub Release
+      # after it exists (FnOS is dispatched from Release.yml).
       - name: Trigger Release, Docker Publish, and Desktop Package
         if: steps.check_tag.outputs.should_publish == 'true'
         env:

--- a/.github/workflows/fnos-build-fpk.yml
+++ b/.github/workflows/fnos-build-fpk.yml
@@ -3,18 +3,19 @@ name: Build Octop FPK
 # FnOS (飞牛 NAS) 安装包流水线。
 #
 # 触发：
-#   - Release 工作流在 GitHub Release 创建成功后自动 dispatch（推荐）
-#   - 亦可手动 workflow_dispatch（需对应版本镜像已在 GHCR）
+#   - Release 工作流在 GitHub Release（v*）创建成功后自动 dispatch（推荐）
+#   - 亦可手动 workflow_dispatch（需对应版本镜像已在 GHCR，且 v* Release 已存在）
 #
 # 制品复用：
 #   - Docker 镜像：不再重建，等待 docker-publish 推送的
 #     ghcr.io/tencentcloud/octop:{version|latest}
 #   - Native wheel：优先从同版本 GitHub Release（v*）下载；
 #     缺失时再回退到本仓源码构建
+#   - 产物挂到同一个 v* GitHub Release（与 wheel / 桌面包并列），不再单独打 fnos-* tag
 #
 # Jobs：
 #   version → ensure-image → fpk（Docker 版 .fpk，仅打包 compose）
-#           ↘ native（本地版 .fpk）→ release（按版本号发布 fnos-<ver>）
+#           ↘ native（本地版 .fpk）→ release（把 .fpk 挂到已有的 v* GitHub Release）
 
 on:
   workflow_dispatch:
@@ -48,9 +49,9 @@ jobs:
           IMAGE="ghcr.io/$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')"
           echo "version=$VER" >> "$GITHUB_OUTPUT"
           echo "image=$IMAGE" >> "$GITHUB_OUTPUT"
-          echo "tag=fnos-${VER}" >> "$GITHUB_OUTPUT"
+          echo "tag=v${VER}" >> "$GITHUB_OUTPUT"
           echo "pkg_ver=${VER}" >> "$GITHUB_OUTPUT"
-          echo "[version] VER=$VER, TAG=fnos-${VER}"
+          echo "[version] VER=$VER, TAG=v${VER}"
 
   # 复用 docker-publish 已推送的镜像，不在此重新 build/push。
   ensure-image:
@@ -256,50 +257,28 @@ jobs:
           cp artifacts/docker-fpk/*.fpk dist/ || true
           cp artifacts/native-fpk/*.fpk dist/ || true
           ls -lh dist
+          if ! ls dist/*.fpk >/dev/null 2>&1; then
+            echo "::error::No .fpk files to attach."
+            exit 1
+          fi
 
-      - name: Generate changelog
-        id: changelog
+      - name: Require existing v* GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.version.outputs.tag }}
         run: |
-          VER="${{ needs.version.outputs.version }}"
-          IMAGE="${{ needs.version.outputs.image }}"
-          PREV_TAG=""
-          for t in $(git tag --list "fnos-*" --sort=-creatordate); do
-            [ "$t" = "fnos-latest" ] && continue
-            if git merge-base --is-ancestor "$t" HEAD 2>/dev/null; then
-              PREV_TAG="$t"
-              break
-            fi
-          done
-          echo "prev_tag=$PREV_TAG" >> "$GITHUB_OUTPUT"
-          {
-            echo "## 安装说明"
-            echo ""
-            echo "1. 飞牛应用中心 → 设置 → 手动安装应用，选择对应 .fpk。"
-            echo "2. Docker 版 **Octop-fnos-docker-${VER}.fpk**（约 80KB）：飞牛自动从 GHCR 拉取 \`${IMAGE}:latest\`。"
-            echo "3. 本地版 **Octop-fnos-native-${VER}.fpk**（约 200MB）：非 Docker，原生运行在飞牛主机；安装时自动关联系统 Python 3.12 开发工具；浏览器、远程桌面等附加组件在 Octop 应用内按需安装。"
-            echo ""
-            echo "---"
-            echo "按版本号下载对应 .fpk 即可（如 \`Octop-fnos-docker-${VER}.fpk\` / \`Octop-fnos-native-${VER}.fpk\`）。"
-            echo ""
-            echo "## 本次更新（v${VER}）"
-            echo ""
-            if [ -n "$PREV_TAG" ]; then
-              git log --oneline --no-merges "$PREV_TAG"..HEAD | head -30
-            else
-              git log --oneline --no-merges -30 HEAD
-            fi
-          } > /tmp/release-body.md
-          cat /tmp/release-body.md
+          set -euo pipefail
+          if ! gh release view "$TAG" --repo "${{ github.repository }}" >/dev/null; then
+            echo "::error::GitHub Release ${TAG} does not exist yet. Run this after Release.yml creates it."
+            exit 1
+          fi
 
-      - name: Publish versioned release
+      - name: Attach fpk to GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ needs.version.outputs.tag }}
-          target_commitish: ${{ github.sha }}
-          name: Octop (FnOS) v${{ needs.version.outputs.pkg_ver }}
-          body_path: /tmp/release-body.md
           files: dist/*.fpk
-          draft: false
-          prerelease: false
+          fail_on_unmatched_files: true
+          generate_release_notes: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/fnos/README.md
+++ b/fnos/README.md
@@ -19,13 +19,13 @@ After install, open the app (Docker: `http://<device-ip>:8088`, native: `http://
 
 | 版本 | 包名 | 体积 | 运行方式 | 依赖 |
 |------|------|------|----------|------|
-| **Docker 版** | `octop-<ver>.fpk` | ~8 KB | 飞牛自动从 GHCR 拉取 `ghcr.io/tencentcloud/octop:latest` 镜像运行 | 宿主需有 Docker 运行时 |
-| **本地版（非 Docker）** | `octop-native-<ver>.fpk` | ~560 MB | 自带 Python 3.12 运行时 + 前端 + 全部附加组件 + Chromium，原生运行在飞牛主机 | 无需 Docker |
+| **Docker 版** | `Octop-fnos-docker-<ver>.fpk` | ~80 KB | 飞牛自动从 GHCR 拉取 `ghcr.io/tencentcloud/octop:latest` 镜像运行 | 宿主需有 Docker 运行时 |
+| **本地版（非 Docker）** | `Octop-fnos-native-<ver>.fpk` | ~200 MB | 自带 Python 3.12 运行时 + 前端，原生运行在飞牛主机 | 无需 Docker |
 
 - **Docker 版**实现为 FnOS `docker-project`：包体只含 `docker-compose.yaml` 与向导配置，运行时由飞牛从 GHCR 拉取镜像。镜像已内置全部附加组件（`browser` 浏览器自动化 + `desktop` 桌面控制）与前端。
 - **本地版**实现为 FnOS 原生 `app`：包内自带独立 Python 3.12 运行时、Octop 全部依赖、前端构建产物、Playwright Chromium，以及 `data-share` 共享数据目录，直接以进程方式运行，不依赖 Docker。
 
-> 两款包都在滚动发布 **`fnos-latest`**：<https://github.com/TencentCloud/Octop/releases/tag/fnos-latest>
+> 两款包随正式版一起挂在 **`v*` GitHub Release** 上（例如 [v0.9.31](https://github.com/TencentCloud/Octop/releases/latest)）：`Octop-fnos-docker-<ver>.fpk` / `Octop-fnos-native-<ver>.fpk`。
 
 ## 目录结构
 
@@ -66,14 +66,14 @@ fnos/
 1. **发版链路**：`v*` tag → `release.yml`（PyPI + GitHub Release）与 `docker-publish.yml`（GHCR / Hub）并行；Release 成功后自动 `workflow_dispatch` 本工作流。
 2. **镜像复用**：不再重新 build 镜像；`ensure-image` 轮询等待 `ghcr.io/tencentcloud/octop:{version}`（由 docker-publish 推送）。Docker 版 `.fpk` 仅打包 compose，运行时拉取该镜像。
 3. **Wheel 复用**：Native 版优先从同版本 GitHub Release（`v*`）下载 `octop-*.whl`；若缺失再回退源码构建前端 + wheel。
-4. **安装包构建**：`fpk` / `native` job 用 `scripts/build-fpk.sh` 打包，产物按版本号发布为 `Octop-fnos-docker-<ver>.fpk` / `Octop-fnos-native-<ver>.fpk`（Release tag `fnos-<ver>`）。
+4. **安装包构建**：`fpk` / `native` job 用 `scripts/build-fpk.sh` 打包，产物 `Octop-fnos-docker-<ver>.fpk` / `Octop-fnos-native-<ver>.fpk` 挂到同一个 `v*` GitHub Release（与 wheel、桌面包并列）。
 
 ## 本地构建 .fpk（无需 Docker）
 
 ```bash
-bash scripts/build-fpk.sh            # 仅 Docker 版  → dist/octop-<version>.fpk
+bash scripts/build-fpk.sh            # 仅 Docker 版  → dist/Octop-fnos-docker-<version>.fpk
 bash scripts/build-fpk.sh docker     # 仅 Docker 版
-bash scripts/build-fpk.sh native     # 仅本地版      → dist/octop-native-<version>.fpk
+bash scripts/build-fpk.sh native     # 仅本地版      → dist/Octop-fnos-native-<version>.fpk
 ```
 
 `.fpk` 为「双层 gzip tar」：外层含 `app.tgz / cmd / config / wizard / ICON.PNG / ICON_256.PNG / LICENSE / manifest`，内层 `app.tgz` 含 `app/` 内容。
@@ -81,8 +81,8 @@ bash scripts/build-fpk.sh native     # 仅本地版      → dist/octop-native-<
 ## 在飞牛上安装
 
 1. 飞牛「应用中心 → 设置 → 手动安装应用」选择对应 `.fpk`：
-   - 想用 Docker 跑、主机已装 Docker → 选 `octop-<version>.fpk`
-   - 不想依赖 Docker、希望自带运行时原生运行 → 选 `octop-native-<version>.fpk`
+   - 想用 Docker 跑、主机已装 Docker → 选 `Octop-fnos-docker-<version>.fpk`
+   - 不想依赖 Docker、希望自带运行时原生运行 → 选 `Octop-fnos-native-<version>.fpk`
 2. 安装向导中设置管理员账号/密码、日志级别、LLM 密钥（可选）。
 3. 安装完成后桌面出现「Octop AI 助手」图标，浏览器打开 `http://<设备IP>:8088`。
 4. Docker 版镜像首次会从 GHCR `ghcr.io/tencentcloud/octop:latest` 拉取；请确保该包为 Public（首次推送后可在 GitHub Packages 设置）。本地版无需联网拉镜像，首次启动会按需要补装 Chromium 系统库（需 root 权限，已尽力处理）。


### PR DESCRIPTION
## Summary

飞牛 `.fpk` 以前打独立 tag `fnos-<ver>`、独立 Release 页，和 wheel / 桌面包不在一起。改为 **upsert 到同一个 `v*` GitHub Release**，文件名仍是 `Octop-fnos-docker-<ver>.fpk` / `Octop-fnos-native-<ver>.fpk`。

- 不再创建 `fnos-*` tag，也不改 Release 标题/说明（避免覆盖正式版 changelog）
- `v*` 还不存在时直接失败，避免误开一个空的 Release
- 发版链路不变：`Release.yml` 建好 `v*` 后再 dispatch 本工作流

## Test plan

- [ ] 本 PR 合入 develop 后：`gh workflow run fnos-build-fpk.yml --ref develop`（当前 pyproject 仍是 0.9.31，会挂到已有的 v0.9.31）
- [ ] 确认 v0.9.31 页面出现两个 `.fpk`，且原有 wheel / 桌面包和 release notes 还在
- [ ] 下次正式发版时不再出现新的 `fnos-<ver>` Release


Made with [Cursor](https://cursor.com)