### PR TITLE
fix(ci): fail release cascade, attach desktop from any ref, drop duplicate sync triggers

### DIFF
--- a/.github/workflows/octop-desktop.yml
+++ b/.github/workflows/octop-desktop.yml
@@ -1,10 +1,8 @@
 name: Octop Desktop Package
 
-# 正式发版：Auto Tag 在打 v* 后与 Release / Docker Publish 一并 dispatch（GITHUB_TOKEN
-# 打的 tag 不会触发 push workflow）。产物由本 workflow 的 release job upsert 到同一
-# GitHub Release。workflow_dispatch 保留给手工补包 / 按平台重跑。
-# 不要对任意分支 push 跑六平台矩阵。
-# pull_request（desktop/**）打 darwin-* + windows-*，不跑 linux。
+# 正式发版：Auto Tag 在打 v* 后与 Release / Docker Publish 一并 dispatch。
+# 产物 upsert 到同一 GitHub Release。手工补包：workflow_dispatch + release_tag
+# （不必跑在 v* ref 上）。attach_from_run 只挂已有 artifact、不重打。
 
 on:
   push:
@@ -22,12 +20,12 @@ on:
         default: "all"
         type: string
       attach_release:
-        description: "If running on a v* tag, also upload zips to that GitHub Release"
+        description: "Upload artifacts to a GitHub Release (v* ref, or pass release_tag)"
         required: false
         default: true
         type: boolean
       release_tag:
-        description: "GitHub Release tag to attach to (e.g. v0.9.27). Defaults to the current v* tag ref."
+        description: "GitHub Release tag to attach to (e.g. v0.9.31). Used when not running on a v* ref."
         required: false
         default: ""
         type: string
@@ -40,9 +38,15 @@ on:
 permissions:
   contents: read
 
+# Builds on the same ref cancel each other (PR retrigger / accidental double
+# dispatch). Attach-only runs use a different group so they cannot cancel an
+# in-flight six-platform package on develop.
 concurrency:
-  group: green-portable-${{ github.ref }}
-  cancel-in-progress: true
+  group: >-
+    green-portable-${{
+      github.event.inputs.attach_from_run != '' && 'attach' || 'build'
+    }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.attach_from_run == '' }}
 
 env:
   # Prefer GitHub upstream on Actions runners (npmmirror is for CN local builds).
@@ -263,6 +267,9 @@ jobs:
       (
         (github.event_name == 'workflow_dispatch' &&
          github.event.inputs.attach_from_run != '') ||
+        (github.event_name == 'workflow_dispatch' &&
+         github.event.inputs.attach_release == 'true' &&
+         github.event.inputs.release_tag != '') ||
         (startsWith(github.ref, 'refs/tags/v') &&
          (github.event_name == 'push' ||
           (github.event_name == 'workflow_dispatch' &&

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,13 +134,12 @@ jobs:
   # started via GITHUB_TOKEN workflow_dispatch (Auto Tag). Explicitly cascade.
   #
   # This job intentionally has no checkout: pass --repo so `gh` does not need a
-  # local .git (bare runner → "fatal: not a git repository"). continue-on-error
-  # keeps a cascade miss from marking PyPI/GitHub release as failed.
+  # local .git (bare runner → "fatal: not a git repository"). Dispatch failure
+  # must fail this workflow so a missed sync is visible.
   sync-develop:
     name: Trigger sync main into develop
     needs: github-release
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - name: Dispatch Sync Main Into Develop
         env:
@@ -152,12 +151,11 @@ jobs:
             -f version="${{ github.ref_name }}"
 
   # FnOS FPK：复用本 Release 的 wheel + docker-publish 的 GHCR 镜像。
-  # 与 sync-develop 并行；失败不阻断发版。
+  # 与 sync-develop 并行。Dispatch 失败必须让本 workflow 变红（PyPI 已发布仍如此）。
   trigger-fnos:
     name: Trigger FnOS FPK build
     needs: github-release
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - name: Dispatch Build Octop FPK
         env:

--- a/.github/workflows/sync-main-to-develop.yml
+++ b/.github/workflows/sync-main-to-develop.yml
@@ -2,31 +2,21 @@ name: Sync Main Into Develop
 
 # After Release succeeds, sync main → develop.
 #
-# Primary trigger: Release.yml explicitly dispatches this workflow (see
-# sync-develop job). Do not rely only on `release: published` or
-# `workflow_run` — when Auto Tag starts Release with GITHUB_TOKEN, those
-# events often never create a Sync run. workflow_dispatch remains for
-# manual catch-up; workflow_run / release are kept as best-effort backups.
+# Only trigger: Release.yml (and humans) dispatch this workflow. Do not also
+# listen for `release: published` or `workflow_run` — those duplicate the
+# explicit dispatch and force-push the same sync branch.
 #
 # Strategy: keep main an ancestor of develop. Try merge first; on conflict,
 # rebuild on main and open a PR (develop is often branch-protected against
 # force-push). Never use head=main merge PRs — that pattern conflicts when
 # main was updated via a bulk develop merge (#150-style divergence).
 on:
-  workflow_run:
-    workflows:
-      - Release
-    types:
-      - completed
   workflow_dispatch:
     inputs:
       version:
         description: "Release tag being synced, e.g. v0.9.31. Blank = read main's pyproject.toml."
         required: false
         type: string
-  release:
-    types:
-      - published
 
 permissions:
   contents: write
@@ -35,12 +25,6 @@ permissions:
 jobs:
   sync:
     name: Sync main into develop
-    if: >
-      github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'release' && startsWith(github.event.release.tag_name, 'v')) ||
-      (github.event_name == 'workflow_run' &&
-       github.event.workflow_run.conclusion == 'success' &&
-       startsWith(github.event.workflow_run.head_branch, 'v'))
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -52,17 +36,16 @@ jobs:
       - name: Sync develop onto main
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ inputs.version || github.event.release.tag_name || github.event.workflow_run.head_branch }}
+          TAG: ${{ inputs.version }}
         run: |
           set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git fetch origin main develop
 
-          # Release dispatches this workflow with GITHUB_TOKEN, so the release /
-          # workflow_run payloads are empty. Fall back to main's shipped version
-          # rather than a constant, or every release would reuse (and force-push)
-          # the same sync branch.
+          # Prefer the version input from Release.yml. Fall back to main's
+          # shipped pyproject so a blank dispatch still gets a unique branch
+          # name instead of colliding across releases.
           version="${TAG#v}"
           if [ -z "$version" ]; then
             version="$(git show origin/main:pyproject.toml \


### PR DESCRIPTION
## Summary

按发版流水线评估里优先的三件改：

1. **级联失败必须红。** `Release.yml` 里 FnOS / Sync 的 `gh workflow run` 去掉 `continue-on-error`。Dispatch 失败时 Release 工作流变红（PyPI 已经发出去了也一样），不再出现 FnOS 连续两版没打、Release 仍显示成功。
2. **桌面补包一步挂 Release。** `workflow_dispatch` 只要 `attach_release=true` 且提供了 `release_tag`，就会把本 run 的制品 upsert 到该 `v*`，不必再 `--ref v*` 或第二趟 `attach_from_run`。`attach_from_run` 走单独 concurrency group，且不 `cancel-in-progress`，避免在 develop 上把正在打的六平台包取消掉。
3. **Sync 只留 `workflow_dispatch`。** 删掉 `workflow_run` 和 `release: published`，避免和 Release 的显式 dispatch 双跑、强推同一条回灌分支。

## Test plan

- [ ] 本 PR 的 CI 通过
- [ ] 合入后桌面补包可用一条命令：`gh workflow run octop-desktop.yml --ref develop -f platforms=all -f release_tag=v0.9.31`
- [ ] 下次正式发版：若 FnOS dispatch 失败，Release 工作流应为红色；Sync 只出现一次 `workflow_dispatch` run


Made with [Cursor](https://cursor.com)