### PR TITLE
fix(logging): size-cap rotation and logrotate delaycompress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 修复
 
-- 日志按大小+按日轮转，并采用 logrotate 风格的 `compress` + `delaycompress`（最新一份轮转文件暂不 gzip，下一轮再压；用 Python 标准库，Windows 可用）；抑制 harness memory maintenance 的高频 INFO
+- 日志按大小+按日轮转，并采用 logrotate 风格的 `compress` + `delaycompress`（最新一份轮转文件暂不 gzip，下一轮再压；用 Python 标准库，Windows 可用）
 
 ## [0.9.31] - 2026-09-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ## [Unreleased]
 
+### 修复
+
+- 日志按大小+按日轮转，并采用 logrotate 风格的 `compress` + `delaycompress`（最新一份轮转文件暂不 gzip，下一轮再压；用 Python 标准库，Windows 可用）；抑制 harness memory maintenance 的高频 INFO
+
 ## [0.9.31] - 2026-09-01
 
 ### 新增

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -132,6 +132,9 @@ Each variable, when set, takes precedence over the matching key in
 | `OCTOP_BIND_HOST` | string | `127.0.0.1` | Listen address (use `0.0.0.0` for LAN access) |
 | `OCTOP_PORT` | int | `8088` | Listen port |
 | `OCTOP_LOG_LEVEL` | string | `info` | One of `debug` `info` `warning` `error` |
+| `OCTOP_LOG_RETENTION_DAYS` | int | `14` | Keep rotated `octop.log.YYYY-MM-DD` files for this many days |
+| `OCTOP_LOG_MAX_BYTES` | int | `104857600` (100 MiB) | Roll the active log when it exceeds this size (in addition to daily rotation) |
+| `OCTOP_LOG_COMPRESS` | bool | `true` | logrotate-style `compress` + `delaycompress`: gzip prior rotated plains on the next cycle (`octop.log.YYYY-MM-DD.gz`); the newest rotated file stays uncompressed until then |
 | `OCTOP_ACCESS_TOKEN_TTL` | int (seconds) | `86400` | JWT access-token lifetime |
 | `OCTOP_LOGIN_MAX_ATTEMPTS` | int | `5` | Failed-login attempts before lockout |
 | `OCTOP_LOGIN_LOCKOUT_SECONDS` | int | `900` | Lockout duration after `OCTOP_LOGIN_MAX_ATTEMPTS` failures |

--- a/src/octop/infra/server.py
+++ b/src/octop/infra/server.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import gzip
 import logging
 import os
+import shutil
 import time
 from contextlib import suppress
 from dataclasses import dataclass
@@ -35,15 +37,152 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# Default 100 MiB per active log file before size-triggered rollover (in addition to daily).
+DEFAULT_LOG_MAX_BYTES = 100 * 1024 * 1024
+DEFAULT_LOG_RETENTION_DAYS = 14
 
-def _build_log_handler(log_path: Path, retention_days: int) -> TimedRotatingFileHandler:
-    """Create a daily-rotating file handler that also enforces retention."""
-    handler = TimedRotatingFileHandler(
+# Routine harness memory maintenance ticks are high-frequency at INFO and can
+# balloon octop.log to multi-GB/day; keep them at WARNING unless OCTOP_LOG_LEVEL=debug.
+_NOISY_LOGGER_LEVELS: dict[str, int] = {
+    "harness_agent.middleware.memory": logging.WARNING,
+}
+
+
+class SizeTimedRotatingFileHandler(TimedRotatingFileHandler):
+    """Daily rotation with an optional per-file byte cap (whichever triggers first)."""
+
+    def __init__(
+        self,
+        filename: str | os.PathLike[str],
+        *,
+        max_bytes: int = 0,
+        compress_rotated: bool = True,
+        **kwargs: object,
+    ) -> None:
+        super().__init__(filename, **kwargs)  # type: ignore[arg-type]
+        self.max_bytes = max(0, max_bytes)
+        self.compress_rotated = compress_rotated
+
+    def shouldRollover(self, record: logging.LogRecord) -> bool:
+        if super().shouldRollover(record):
+            return True
+        if self.max_bytes <= 0:
+            return False
+        if self.stream is None:
+            self.stream = self._open()
+        self.stream.flush()
+        return self.stream.tell() >= self.max_bytes
+
+    def rotate(self, source: str, dest: str) -> None:
+        super().rotate(source, dest)
+        if self.compress_rotated:
+            # logrotate delaycompress: leave this cycle's dest plain; gzip prior plains.
+            delaycompress_rotated_logs(Path(dest).parent, enabled=True, keep=Path(dest))
+
+    def rotation_filename(self, default_name: str) -> str:
+        """Avoid overwriting an existing daily backup when size rolls twice same day."""
+        if not os.path.exists(default_name) and not os.path.exists(f"{default_name}.gz"):
+            return default_name
+        index = 1
+        while True:
+            candidate = f"{default_name}-{index:03d}"
+            if not os.path.exists(candidate) and not os.path.exists(f"{candidate}.gz"):
+                return candidate
+            index += 1
+
+
+def gzip_rotated_log(path: Path) -> None:
+    """Compress a rotated log file to ``{name}.gz`` and remove the plain file."""
+    if not path.is_file() or path.suffix == ".gz":
+        return
+    gz_path = path.with_name(f"{path.name}.gz")
+    if gz_path.exists():
+        return
+    try:
+        with path.open("rb") as src, gzip.open(gz_path, "wb", compresslevel=6) as dst:
+            shutil.copyfileobj(src, dst)
+        path.unlink()
+    except OSError:
+        with suppress(OSError):
+            if gz_path.exists():
+                gz_path.unlink()
+
+
+def _parse_log_compress() -> bool:
+    raw = (os.environ.get("OCTOP_LOG_COMPRESS", "1") or "1").strip().lower()
+    return raw not in ("0", "false", "no", "off")
+
+
+def delaycompress_rotated_logs(
+    log_dir: Path,
+    *,
+    enabled: bool,
+    keep: Path | None = None,
+) -> None:
+    """Gzip older rotated plains; leave ``keep`` (or the newest) uncompressed.
+
+    Matches logrotate ``compress`` + ``delaycompress``: postpone compression of the
+    previous log file until the next rotation cycle
+    (https://github.com/logrotate/logrotate).
+    """
+    if not enabled or not log_dir.is_dir():
+        return
+    plains = [
+        entry
+        for entry in log_dir.glob("octop.log.*")
+        if entry.is_file() and not entry.name.endswith(".gz")
+    ]
+    if not plains:
+        return
+    keep_path = max(plains, key=lambda p: p.stat().st_mtime) if keep is None else keep
+    keep_resolved = keep_path.resolve()
+    for entry in plains:
+        if entry.resolve() == keep_resolved:
+            continue
+        gzip_rotated_log(entry)
+
+
+def _parse_log_retention_days() -> int:
+    raw = os.environ.get("OCTOP_LOG_RETENTION_DAYS", str(DEFAULT_LOG_RETENTION_DAYS)) or str(
+        DEFAULT_LOG_RETENTION_DAYS
+    )
+    try:
+        return int(raw)
+    except ValueError:
+        return DEFAULT_LOG_RETENTION_DAYS
+
+
+def _parse_log_max_bytes() -> int:
+    raw = os.environ.get("OCTOP_LOG_MAX_BYTES", str(DEFAULT_LOG_MAX_BYTES)) or str(
+        DEFAULT_LOG_MAX_BYTES
+    )
+    try:
+        return max(0, int(raw))
+    except ValueError:
+        return DEFAULT_LOG_MAX_BYTES
+
+
+def _configure_noisy_loggers() -> None:
+    for name, level in _NOISY_LOGGER_LEVELS.items():
+        logging.getLogger(name).setLevel(level)
+
+
+def _build_log_handler(
+    log_path: Path,
+    retention_days: int,
+    *,
+    max_bytes: int = DEFAULT_LOG_MAX_BYTES,
+    compress_rotated: bool = True,
+) -> SizeTimedRotatingFileHandler:
+    """Create a daily + size-capped rotating file handler with retention."""
+    handler = SizeTimedRotatingFileHandler(
         log_path,
         when="midnight",
         interval=1,
         backupCount=retention_days,
         encoding="utf-8",
+        max_bytes=max_bytes,
+        compress_rotated=compress_rotated,
     )
     # Rotated files get a date suffix, e.g. octop.log.2026-07-16
     handler.suffix = "%Y-%m-%d"
@@ -361,13 +500,19 @@ class OctopServer:
             with suppress(OSError):
                 legacy.replace(log_path)
 
-        raw_retention = os.environ.get("OCTOP_LOG_RETENTION_DAYS", "14") or "14"
-        try:
-            retention_days = int(raw_retention)
-        except ValueError:
-            retention_days = 14
-        handler = _build_log_handler(log_path, retention_days)
+        retention_days = _parse_log_retention_days()
+        max_bytes = _parse_log_max_bytes()
+        compress_rotated = _parse_log_compress()
+        handler = _build_log_handler(
+            log_path,
+            retention_days,
+            max_bytes=max_bytes,
+            compress_rotated=compress_rotated,
+        )
         _purge_stale_logs(log_dir, retention_days)
+        # Catch up: gzip older plains, leave the newest rotated file plain (delaycompress).
+        delaycompress_rotated_logs(log_dir, enabled=compress_rotated)
+        _configure_noisy_loggers()
 
         root = logging.getLogger()
         _attach_log_handler(root, handler)
@@ -377,6 +522,9 @@ class OctopServer:
 
         level = os.environ.get("OCTOP_LOG_LEVEL", "info").upper()
         root.setLevel(getattr(logging, level, logging.INFO))
+        if root.level <= logging.DEBUG:
+            for name in _NOISY_LOGGER_LEVELS:
+                logging.getLogger(name).setLevel(logging.DEBUG)
 
     def _ensure_jwt_secret(self) -> None:
         assert self.services is not None

--- a/src/octop/infra/server.py
+++ b/src/octop/infra/server.py
@@ -41,12 +41,6 @@ logger = logging.getLogger(__name__)
 DEFAULT_LOG_MAX_BYTES = 100 * 1024 * 1024
 DEFAULT_LOG_RETENTION_DAYS = 14
 
-# Routine harness memory maintenance ticks are high-frequency at INFO and can
-# balloon octop.log to multi-GB/day; keep them at WARNING unless OCTOP_LOG_LEVEL=debug.
-_NOISY_LOGGER_LEVELS: dict[str, int] = {
-    "harness_agent.middleware.memory": logging.WARNING,
-}
-
 
 class SizeTimedRotatingFileHandler(TimedRotatingFileHandler):
     """Daily rotation with an optional per-file byte cap (whichever triggers first)."""
@@ -160,11 +154,6 @@ def _parse_log_max_bytes() -> int:
         return max(0, int(raw))
     except ValueError:
         return DEFAULT_LOG_MAX_BYTES
-
-
-def _configure_noisy_loggers() -> None:
-    for name, level in _NOISY_LOGGER_LEVELS.items():
-        logging.getLogger(name).setLevel(level)
 
 
 def _build_log_handler(
@@ -512,7 +501,6 @@ class OctopServer:
         _purge_stale_logs(log_dir, retention_days)
         # Catch up: gzip older plains, leave the newest rotated file plain (delaycompress).
         delaycompress_rotated_logs(log_dir, enabled=compress_rotated)
-        _configure_noisy_loggers()
 
         root = logging.getLogger()
         _attach_log_handler(root, handler)
@@ -522,9 +510,6 @@ class OctopServer:
 
         level = os.environ.get("OCTOP_LOG_LEVEL", "info").upper()
         root.setLevel(getattr(logging, level, logging.INFO))
-        if root.level <= logging.DEBUG:
-            for name in _NOISY_LOGGER_LEVELS:
-                logging.getLogger(name).setLevel(logging.DEBUG)
 
     def _ensure_jwt_secret(self) -> None:
         assert self.services is not None

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -6,6 +6,7 @@ the log path lives under ``~/.octop/logs`` and stale rotated files are purged.
 
 from __future__ import annotations
 
+import gzip
 import logging
 import os
 import time
@@ -15,10 +16,17 @@ from pathlib import Path
 import pytest
 
 from octop.infra.server import (
+    DEFAULT_LOG_MAX_BYTES,
     OctopServer,
+    SizeTimedRotatingFileHandler,
     _attach_log_handler,
     _build_log_handler,
+    _configure_noisy_loggers,
+    _parse_log_compress,
+    _parse_log_max_bytes,
     _purge_stale_logs,
+    delaycompress_rotated_logs,
+    gzip_rotated_log,
 )
 
 
@@ -49,11 +57,12 @@ def _stale_path(log_dir: Path, name: str, age_days: int) -> Path:
 
 
 def test_build_log_handler_uses_daily_rotation_and_retention(tmp_path: Path):
-    handler = _build_log_handler(tmp_path / "octop.log", retention_days=7)
+    handler = _build_log_handler(tmp_path / "octop.log", retention_days=7, max_bytes=4096)
     try:
-        assert isinstance(handler, TimedRotatingFileHandler)
+        assert isinstance(handler, SizeTimedRotatingFileHandler)
         assert handler.when == "MIDNIGHT"
         assert handler.backupCount == 7
+        assert handler.max_bytes == 4096
         # Date-only suffix keeps filenames valid on Windows (no ':' like %H:%M:%S).
         assert handler.suffix == "%Y-%m-%d"
         assert ":" not in handler.suffix
@@ -182,3 +191,124 @@ def test_setup_logging_falls_back_on_invalid_retention_env(tmp_path: Path, monke
     )
     # Default retention is 14 days.
     assert handler.backupCount == 14
+
+
+def test_parse_log_max_bytes_defaults_and_env(monkeypatch):
+    monkeypatch.delenv("OCTOP_LOG_MAX_BYTES", raising=False)
+    assert _parse_log_max_bytes() == DEFAULT_LOG_MAX_BYTES
+    monkeypatch.setenv("OCTOP_LOG_MAX_BYTES", "2048")
+    assert _parse_log_max_bytes() == 2048
+    monkeypatch.setenv("OCTOP_LOG_MAX_BYTES", "bad")
+    assert _parse_log_max_bytes() == DEFAULT_LOG_MAX_BYTES
+
+
+def test_log_handler_rotates_when_max_bytes_exceeded(tmp_path: Path):
+    log_path = tmp_path / "octop.log"
+    handler = _build_log_handler(log_path, retention_days=3, max_bytes=256)
+    test_logger = logging.getLogger("test.octop.log.size_roll")
+    test_logger.handlers = []
+    test_logger.propagate = False
+    test_logger.setLevel(logging.INFO)
+    test_logger.addHandler(handler)
+    try:
+        for _ in range(40):
+            test_logger.info("x" * 40)
+        handler.flush()
+        backups = [p for p in tmp_path.glob("octop.log*") if p != log_path]
+        assert len(backups) >= 1
+        # delaycompress: newest rotated file stays plain; older ones may be .gz
+        plains = [p for p in backups if not p.name.endswith(".gz")]
+        gzips = [p for p in backups if p.name.endswith(".gz")]
+        assert len(plains) == 1
+        if len(backups) > 1:
+            assert len(gzips) >= 1
+        assert log_path.exists()
+        assert log_path.stat().st_size < 512
+    finally:
+        test_logger.handlers = []
+        handler.close()
+
+
+def test_gzip_rotated_log_replaces_plain_file(tmp_path: Path):
+    plain = tmp_path / "octop.log.2026-09-02"
+    plain.write_text("hello\nworld\n", encoding="utf-8")
+    gzip_rotated_log(plain)
+    gz = tmp_path / "octop.log.2026-09-02.gz"
+    assert not plain.exists()
+    assert gz.exists()
+    assert gzip.decompress(gz.read_bytes()).decode("utf-8") == "hello\nworld\n"
+
+
+def test_delaycompress_keeps_newest_plain_on_startup(tmp_path: Path):
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    older = log_dir / "octop.log.2026-08-28"
+    newer = log_dir / "octop.log.2026-08-29"
+    older.write_text("older\n", encoding="utf-8")
+    newer.write_text("newer\n", encoding="utf-8")
+    past = time.time() - 86400
+    os.utime(older, (past, past))
+    delaycompress_rotated_logs(log_dir, enabled=True)
+    assert not older.exists()
+    assert (log_dir / "octop.log.2026-08-28.gz").exists()
+    assert newer.exists()
+    assert not (log_dir / "octop.log.2026-08-29.gz").exists()
+
+
+def test_delaycompress_single_plain_stays_uncompressed(tmp_path: Path):
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    plain = log_dir / "octop.log.2026-08-29"
+    plain.write_text("only\n", encoding="utf-8")
+    delaycompress_rotated_logs(log_dir, enabled=True)
+    assert plain.exists()
+    assert not (log_dir / "octop.log.2026-08-29.gz").exists()
+
+
+def test_parse_log_compress_env(monkeypatch):
+    monkeypatch.delenv("OCTOP_LOG_COMPRESS", raising=False)
+    assert _parse_log_compress() is True
+    monkeypatch.setenv("OCTOP_LOG_COMPRESS", "0")
+    assert _parse_log_compress() is False
+
+
+def test_purge_stale_logs_removes_old_gz_files(tmp_path: Path):
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    old = _stale_path(log_dir, "octop.log.2020-01-01.gz", age_days=100)
+    new = _stale_path(log_dir, "octop.log.2026-07-16.gz", age_days=1)
+    _purge_stale_logs(log_dir, retention_days=14)
+    assert not old.exists()
+    assert new.exists()
+
+
+def test_configure_noisy_loggers_suppresses_memory_maintenance_info(tmp_path: Path):
+    _configure_noisy_loggers()
+    mem = logging.getLogger("harness_agent.middleware.memory")
+    assert mem.level == logging.WARNING
+
+    server = OctopServer(home=tmp_path / ".octop")
+    server._setup_logging()
+
+    handler = next(
+        h
+        for h in logging.getLogger().handlers
+        if isinstance(h, TimedRotatingFileHandler) and h.baseFilename == str(server.paths.log)
+    )
+    mem.info(
+        "memory.maintenance done gc_err=None vacuum_err=None gc_rows=0 pages=0 auto_vacuum=True"
+    )
+    handler.flush()
+    assert "memory.maintenance done" not in server.paths.log.read_text(encoding="utf-8")
+
+
+def test_setup_logging_respects_max_bytes_env(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("OCTOP_LOG_MAX_BYTES", "8192")
+    server = OctopServer(home=tmp_path / ".octop")
+    server._setup_logging()
+    handler = next(
+        h
+        for h in logging.getLogger().handlers
+        if isinstance(h, SizeTimedRotatingFileHandler) and h.baseFilename == str(server.paths.log)
+    )
+    assert handler.max_bytes == 8192

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -21,7 +21,6 @@ from octop.infra.server import (
     SizeTimedRotatingFileHandler,
     _attach_log_handler,
     _build_log_handler,
-    _configure_noisy_loggers,
     _parse_log_compress,
     _parse_log_max_bytes,
     _purge_stale_logs,
@@ -280,26 +279,6 @@ def test_purge_stale_logs_removes_old_gz_files(tmp_path: Path):
     _purge_stale_logs(log_dir, retention_days=14)
     assert not old.exists()
     assert new.exists()
-
-
-def test_configure_noisy_loggers_suppresses_memory_maintenance_info(tmp_path: Path):
-    _configure_noisy_loggers()
-    mem = logging.getLogger("harness_agent.middleware.memory")
-    assert mem.level == logging.WARNING
-
-    server = OctopServer(home=tmp_path / ".octop")
-    server._setup_logging()
-
-    handler = next(
-        h
-        for h in logging.getLogger().handlers
-        if isinstance(h, TimedRotatingFileHandler) and h.baseFilename == str(server.paths.log)
-    )
-    mem.info(
-        "memory.maintenance done gc_err=None vacuum_err=None gc_rows=0 pages=0 auto_vacuum=True"
-    )
-    handler.flush()
-    assert "memory.maintenance done" not in server.paths.log.read_text(encoding="utf-8")
 
 
 def test_setup_logging_respects_max_bytes_env(tmp_path: Path, monkeypatch):

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -230,12 +230,13 @@ def test_log_handler_rotates_when_max_bytes_exceeded(tmp_path: Path):
 
 def test_gzip_rotated_log_replaces_plain_file(tmp_path: Path):
     plain = tmp_path / "octop.log.2026-09-02"
-    plain.write_text("hello\nworld\n", encoding="utf-8")
+    # Binary write keeps LF on Windows (text mode would expand to CRLF).
+    plain.write_bytes(b"hello\nworld\n")
     gzip_rotated_log(plain)
     gz = tmp_path / "octop.log.2026-09-02.gz"
     assert not plain.exists()
     assert gz.exists()
-    assert gzip.decompress(gz.read_bytes()).decode("utf-8") == "hello\nworld\n"
+    assert gzip.decompress(gz.read_bytes()) == b"hello\nworld\n"
 
 
 def test_delaycompress_keeps_newest_plain_on_startup(tmp_path: Path):


### PR DESCRIPTION
## Summary
- Cap active `octop.log` with size-based rotation (default 100 MiB via `OCTOP_LOG_MAX_BYTES`) in addition to daily rollover, to stop multi-GB single-day files.
- Align compression with logrotate `compress` + `delaycompress`: newest rotated plain stays uncompressed until the next cycle; older plains become `.gz` (Python stdlib `gzip`, works on Windows).
- Suppress high-frequency `harness_agent.middleware.memory` INFO unless `OCTOP_LOG_LEVEL=debug`.
- Document `OCTOP_LOG_RETENTION_DAYS` / `OCTOP_LOG_MAX_BYTES` / `OCTOP_LOG_COMPRESS` and add unit coverage.

## Test plan
- [x] `uv run pytest tests/unit/test_logging.py -q`
- [x] Pre-commit hook (`make precommit` / scoped testmon) green on commit
- [ ] CI Linux + Windows green on this PR
- [ ] Optional manual: `OCTOP_LOG_MAX_BYTES=1048576` flood → newest rotated plain, older `.gz`