### PR TITLE
docs: document default admin credentials for Docker/FnOS first run

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ This roadmap may shift as the community grows; treat it as indicative only.
 
 Octop can be installed on FnOS (飞牛 NAS) devices via the App Center as a `.fpk` package, either as a Docker-backed app or as a native (non-Docker) app. See [`fnos/README.md`](fnos/README.md) for the full packaging guide, the FPK build helper (`scripts/build-fpk.sh`), and the CI pipeline template (`.github/workflows/fnos-build-fpk.yml`).
 
-For non-root FnOS installs, the WeCom/Feishu connector CLIs require the fix in [PR #406](https://github.com/TencentCloud/Octop/pull/406) (user-level npm fallback).
+Initial admin credentials: `admin` / `Octop123` (change after first login). For non-root FnOS installs, the WeCom/Feishu connector CLIs require the fix in [PR #406](https://github.com/TencentCloud/Octop/pull/406) (user-level npm fallback).
 
 ## 🚀 Quick Start
 
@@ -226,7 +226,7 @@ octop run --host 0.0.0.0 --port 8088
 octop service start
 ```
 
-Open **http://127.0.0.1:8088**. Interactive `octop init` / the setup wizard asks you to choose a password (≥8 characters, letters and digits). Docker first-run credentials are written to `~/octop-login.txt`.
+Open **http://127.0.0.1:8088**. With Docker first-run defaults, sign in as `admin` / `Octop123` and change the password immediately. Interactive `octop init` / the setup wizard asks you to choose a password (≥8 characters, letters and digits).
 
 ### Docker (recommended for production)
 
@@ -240,17 +240,18 @@ docker run -d \
   -p 8088:8088 \
   -v octop-data:/data/.octop \
   -e HOME=/data \
+  -e OCTOP_DEFAULT_PASSWORD=Octop123 \
   octop:latest
 ```
 
-Open `http://localhost:8088`. First-boot credentials are written to `~/octop-login.txt` (`/data/octop-login.txt` in the container); set `OCTOP_DEFAULT_PASSWORD` if you want to choose the initial password yourself.
+Open `http://localhost:8088`. First boot creates an admin account with fixed default credentials `admin` / `Octop123` (written to `/data/.octop/credential.txt` in the container) — **not** a randomly generated password. Override the defaults via `OCTOP_ADMIN_USERNAME` / `OCTOP_DEFAULT_PASSWORD`.
 
 > **Password policy:** at least 8 characters with letters and digits.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `OCTOP_PORT` | `8088` | HTTP listen port |
-| `OCTOP_DEFAULT_PASSWORD` | — | Optional first-run admin password (Docker bootstrap) |
+| `OCTOP_DEFAULT_PASSWORD` | `Octop123` | First-run admin password (Docker bootstrap) |
 | `OCTOP_ADMIN_USERNAME` | `admin` | First-run admin username |
 | `OCTOP_DATA` | `~/.octop` | Host data directory (compose bind mount) |
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -222,7 +222,7 @@ octop run --host 0.0.0.0 --port 8088
 octop service start
 ```
 
-打开 **http://127.0.0.1:8088**。交互式 `octop init` / 设置向导会让你自行设置密码（至少 8 位，且同时包含字母和数字）。Docker 首次启动的凭据会写入 `~/octop-login.txt`。
+打开 **http://127.0.0.1:8088**。Docker 首次初始化默认账号为 `admin` / `Octop123`，请立即修改密码。交互式 `octop init` / 设置向导会让你自行设置密码（至少 8 位，且同时包含字母和数字）。
 
 ### Docker（推荐用于生产部署）
 
@@ -236,17 +236,18 @@ docker run -d \
   -p 8088:8088 \
   -v octop-data:/data/.octop \
   -e HOME=/data \
+  -e OCTOP_DEFAULT_PASSWORD=Octop123 \
   octop:latest
 ```
 
-打开 `http://localhost:8088`。首次启动的凭据会写入 `~/octop-login.txt`（容器内为 `/data/octop-login.txt`）；若要自行指定初始密码，设置 `OCTOP_DEFAULT_PASSWORD`。
+打开 `http://localhost:8088`。首次初始化会以固定默认凭据创建管理员：`admin` / `Octop123`（并写入容器内 `/data/.octop/credential.txt`）——**并非随机生成**。可通过 `OCTOP_ADMIN_USERNAME` / `OCTOP_DEFAULT_PASSWORD` 覆盖默认值。
 
 > **密码策略：** 至少 8 位，且同时包含字母和数字。
 
 | 变量 | 默认值 | 说明 |
 |------|--------|------|
 | `OCTOP_PORT` | `8088` | HTTP 监听端口 |
-| `OCTOP_DEFAULT_PASSWORD` | — | 可选，首次运行管理员密码（Docker 引导） |
+| `OCTOP_DEFAULT_PASSWORD` | `Octop123` | 首次运行管理员密码（Docker 引导） |
 | `OCTOP_ADMIN_USERNAME` | `admin` | 首次运行管理员用户名 |
 | `OCTOP_DATA` | `~/.octop` | 宿主机数据目录（compose 挂载） |
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -26,7 +26,7 @@ From the repository root:
 docker compose -f docker/docker-compose.yml up -d --build
 ```
 
-Open `http://localhost:8088`. First-boot credentials are written to `~/octop-login.txt` (`/data/octop-login.txt` in the container; override with `OCTOP_DEFAULT_PASSWORD`). Password must be ≥8 characters with letters and digits.
+Open `http://localhost:8088`. Default credentials: `admin` / `Octop123` (applied only on first init; change immediately). Password must be ≥8 characters with letters and digits. A future release may randomize the first-boot password and write it only to `credential.txt`.
 
 **Option 2: Build script**
 
@@ -58,7 +58,7 @@ bash docker/docker_build.sh
 |----------|---------|-------------|
 | `HOME` | `/data` | Must be `/data` so `~/.octop` maps to the data volume |
 | `OCTOP_PORT` | `8088` | HTTP listen port |
-| `OCTOP_DEFAULT_PASSWORD` | — | Optional first-run admin password (≥8 chars, letters + digits) |
+| `OCTOP_DEFAULT_PASSWORD` | `Octop123` | First-run admin password (≥8 chars, letters + digits) |
 | `OCTOP_ADMIN_USERNAME` | `admin` | Initial admin username |
 | `OCTOP_DATABASE_URL` | — | PostgreSQL DSN (or other `OCTOP_DATABASE_*`; see [configuration.md](../docs/configuration.md)) |
 | `OCTOP_DATABASE_DRIVER` | — | `sqlite` \| `postgresql` when overriding defaults via env |
@@ -71,7 +71,7 @@ For Compose, put these in `docker/.env`. Values only reach the container if list
 
 - Compose mounts host `~/.octop` → container `/data/.octop`
 - `docker run` example uses named volume `octop-data`
-- First boot runs `octop init`; credentials are written to `~/octop-login.txt` (`/data/octop-login.txt` in the container; override with `OCTOP_DEFAULT_PASSWORD`).
+- First boot runs `octop init`; credentials are written to `/data/.octop/credential.txt` (default password `Octop123` unless `OCTOP_DEFAULT_PASSWORD` is set). Future: may randomize on first boot instead of a fixed default.
 
 ### Health check
 

--- a/docker/README_CN.md
+++ b/docker/README_CN.md
@@ -26,7 +26,7 @@
 docker compose -f docker/docker-compose.yml up -d --build
 ```
 
-访问 `http://localhost:8088`。首次启动的凭据写入 `~/octop-login.txt`（容器内为 `/data/octop-login.txt`，可用 `OCTOP_DEFAULT_PASSWORD` 覆盖）。密码须 ≥8 位且同时包含字母和数字。
+访问 `http://localhost:8088`。默认凭据：`admin` / `Octop123`（仅在首次初始化时生效，请立即修改密码）。密码须 ≥8 位且同时包含字母和数字。后续版本可能改为首次启动随机生成并仅写入 `credential.txt`。
 
 **方式二：构建脚本**
 
@@ -58,7 +58,7 @@ bash docker/docker_build.sh
 |------|--------|------|
 | `HOME` | `/data` | 必须为 `/data`，数据目录映射到 `~/.octop` |
 | `OCTOP_PORT` | `8088` | HTTP 服务端口 |
-| `OCTOP_DEFAULT_PASSWORD` | — | 可选，首次管理员密码（≥8 位，字母+数字） |
+| `OCTOP_DEFAULT_PASSWORD` | `Octop123` | 首次管理员密码（≥8 位，字母+数字） |
 | `OCTOP_ADMIN_USERNAME` | `admin` | 首次管理员用户名 |
 | `OCTOP_DATABASE_URL` | — | PostgreSQL DSN（或其他 `OCTOP_DATABASE_*`，见 [configuration.md](../docs/configuration.md)） |
 | `OCTOP_DATABASE_DRIVER` | — | 通过环境变量覆盖时：`sqlite` \| `postgresql` |
@@ -71,7 +71,7 @@ Compose 可在 `docker/.env` 中配置上述变量。注意：`.env` 只参与 C
 
 - Compose 默认将宿主机 `~/.octop` 挂载到容器 `/data/.octop`
 - `docker run` 示例使用命名卷 `octop-data`
-- 首次启动会自动执行 `octop init`，凭据写入 `~/octop-login.txt`（容器内为 `/data/octop-login.txt`，可用 `OCTOP_DEFAULT_PASSWORD` 覆盖）。
+- 首次启动会自动执行 `octop init`，凭据写入容器内 `/data/.octop/credential.txt`（默认密码 `Octop123`，可用 `OCTOP_DEFAULT_PASSWORD` 覆盖）。后续计划改为首次启动随机生成密码。
 
 ### 健康检查
 

--- a/fnos/README.md
+++ b/fnos/README.md
@@ -2,6 +2,17 @@
 
 本目录包含将 [TencentCloud/Octop](https://github.com/TencentCloud/Octop) 打包为飞牛 fnOS `.fpk` 安装包所需的全部文件，并附带自动同步上游 + 自动构建的 GitHub Actions。
 
+## 首次使用（初始账号）
+
+安装完成后打开应用（Docker 版：`http://<设备IP>:8088`，本地版：`http://<设备IP>:8089`），使用**初始管理员账号**登录：
+
+| 字段 | 值 |
+|------|-----|
+| 用户名 | `admin` |
+| 密码 | `Octop123` |
+
+> 该密码是固定初始值（与官方 Docker 镜像默认一致），并非随机生成。**首次登录后请立即在头像菜单 →「修改密码」中更换**。若安装时通过环境变量自定义了 `OCTOP_ADMIN_USERNAME` / `OCTOP_DEFAULT_PASSWORD`，则以自定义值为准。
+
 ## 两种安装包
 
 仓库同时产出 **两款** `.fpk`，用于满足不同部署偏好：


### PR DESCRIPTION
## Summary

- Clarify across `README.md`, `README_CN.md`, `docker/README.md`, `docker/README_CN.md`, and `fnos/README.md` that first-run admin credentials for Docker-based installs are the fixed defaults `admin` / `Octop123` (not random), overridable via `OCTOP_ADMIN_USERNAME` / `OCTOP_DEFAULT_PASSWORD`.
- Document `OCTOP_DEFAULT_PASSWORD` as defaulting to `Octop123` in the env-var tables, add it explicitly to the `docker run` example, and note first-run credentials are written to `/data/.octop/credential.txt` inside the container.
- Add a new "首次使用（初始账号）" section to `fnos/README.md` with the initial-login table, and advise users to change the default password right after first login.

## Target branch

- [x] Base is **`develop`** (feature / fix — default)
- [ ] Base is **`main`** (`release/*` or `hotfix/*` only)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Refactor / chore
- [ ] Release / hotfix

## Test plan

Docs-only change; no code paths affected, so no automated tests or `make all` run required.

- [ ] `make all` passes locally
- [ ] Added/updated tests

## Checklist

- [ ] Updated `CHANGELOG.md` (if user-facing)
- [x] README / docs updated (if needed)