### PR TITLE
fix(onnx): disable Hugging Face Xet for snapshot downloads

### DIFF
--- a/src/octop/infra/agents/providers/onnx_download.py
+++ b/src/octop/infra/agents/providers/onnx_download.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import os
+import sys
 import time
 from collections.abc import Callable
 from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
@@ -193,12 +194,21 @@ def _progress_tqdm(on_progress: SnapshotProgressFn) -> type[Any] | None:
     return ProgressTqdm
 
 
+def _disable_hf_xet() -> None:
+    """Force HTTP snapshots; Xet CAS 401s or is unreachable via hf-mirror."""
+    os.environ["HF_HUB_DISABLE_XET"] = "1"
+    constants = sys.modules.get("huggingface_hub.constants")
+    if constants is not None and hasattr(constants, "HF_HUB_DISABLE_XET"):
+        setattr(constants, "HF_HUB_DISABLE_XET", True)
+
+
 def _download_hf_snapshot(
     cand: DownloadCandidate,
     cache_dir: Path,
     *,
     on_progress: SnapshotProgressFn | None = None,
 ) -> None:
+    _disable_hf_xet()
     try:
         from huggingface_hub import snapshot_download
     except ImportError as exc:

--- a/src/octop/infra/agents/providers/onnx_download.py
+++ b/src/octop/infra/agents/providers/onnx_download.py
@@ -194,12 +194,15 @@ def _progress_tqdm(on_progress: SnapshotProgressFn) -> type[Any] | None:
     return ProgressTqdm
 
 
+_HF_HUB_DISABLE_XET = "HF_HUB_DISABLE_XET"
+
+
 def _disable_hf_xet() -> None:
     """Force HTTP snapshots; Xet CAS 401s or is unreachable via hf-mirror."""
-    os.environ["HF_HUB_DISABLE_XET"] = "1"
+    os.environ[_HF_HUB_DISABLE_XET] = "1"
     constants = sys.modules.get("huggingface_hub.constants")
-    if constants is not None and hasattr(constants, "HF_HUB_DISABLE_XET"):
-        setattr(constants, "HF_HUB_DISABLE_XET", True)
+    if constants is not None and hasattr(constants, _HF_HUB_DISABLE_XET):
+        setattr(constants, _HF_HUB_DISABLE_XET, True)
 
 
 def _download_hf_snapshot(

--- a/tests/unit/agents/test_onnx_download.py
+++ b/tests/unit/agents/test_onnx_download.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import sys
 import threading
 import time
@@ -207,3 +208,38 @@ def test_hf_snapshot_emits_tqdm_byte_progress(monkeypatch, tmp_path: Path) -> No
 
     assert (400_000, None, "Downloading bytes") in seen
     assert (800_000, 800_000, "Reconstructing") in seen
+
+
+def test_snapshot_disables_xet_before_hub_import(monkeypatch, tmp_path: Path) -> None:
+    import types
+
+    from octop.infra.agents.providers import onnx_download as mod
+
+    seen: dict[str, object] = {}
+    constants = types.ModuleType("huggingface_hub.constants")
+    constants.HF_HUB_DISABLE_XET = False
+    monkeypatch.setitem(sys.modules, "huggingface_hub.constants", constants)
+
+    def fake_snapshot_download(**kwargs: object) -> str:
+        seen["env"] = os.environ.get("HF_HUB_DISABLE_XET")
+        seen["const"] = constants.HF_HUB_DISABLE_XET
+        seen["endpoint"] = kwargs.get("endpoint")
+        return "ok"
+
+    hub = types.ModuleType("huggingface_hub")
+    hub.snapshot_download = fake_snapshot_download
+    monkeypatch.setitem(sys.modules, "huggingface_hub", hub)
+
+    mod._download_hf_snapshot(
+        DownloadCandidate(
+            kind="hf-mirror",
+            probe_url="http://mirror",
+            hf_endpoint=HF_ENDPOINT_MIRROR,
+            hf_repo="Qdrant/bge-small-zh-v1.5",
+        ),
+        tmp_path / "cache",
+    )
+
+    assert seen["env"] == "1"
+    assert seen["const"] is True
+    assert seen["endpoint"] == HF_ENDPOINT_MIRROR


### PR DESCRIPTION
## Summary

- Force Hugging Face snapshot downloads onto HTTP by setting `HF_HUB_DISABLE_XET` before `snapshot_download`, including the already-imported `huggingface_hub.constants` flag.
- Avoid Xet CAS 401s and unreachable Xet endpoints when downloading ONNX models through hf-mirror.
- Cover the env/constant flip with a unit test that stubs the hub import.

## Target branch

- [x] Base is **`develop`** (feature / fix — default)
- [ ] Base is **`main`** (`release/*` or `hotfix/*` only)

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / chore
- [ ] Release / hotfix

## Test plan

Added `test_snapshot_disables_xet_before_hub_import` in `tests/unit/agents/test_onnx_download.py`. Full `make all` was not re-run in this PR session.

- [ ] `make all` passes locally
- [x] Added/updated tests

## Checklist

- [ ] Updated `CHANGELOG.md` (if user-facing)
- [ ] README / docs updated (if needed)