### PR TITLE
feat(release): append templated download links to GitHub Release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,6 +122,9 @@ jobs:
               echo '```'
             } > .release-notes.md
           fi
+          if ! grep -q '^## 下载地址' .release-notes.md; then
+            python3 scripts/release_download_links.py "$version" >> .release-notes.md
+          fi
 
       - name: Create release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,7 +122,7 @@ jobs:
               echo '```'
             } > .release-notes.md
           fi
-          if ! grep -q '^## 下载地址' .release-notes.md; then
+          if ! grep -q '^## Downloads' .release-notes.md; then
             python3 scripts/release_download_links.py "$version" >> .release-notes.md
           fi
 

--- a/scripts/release_download_links.py
+++ b/scripts/release_download_links.py
@@ -43,50 +43,50 @@ def portable_name(os_name: str, arch: str, version: str) -> str:
 
 def render_download_section(raw_version: str) -> str:
     tag, version = split_tag(raw_version)
-    win64 = md_link("64位(常用)", tag, desktop_name("windows", "amd64", version, "exe"))
+    win64 = md_link("64-bit (Recommended)", tag, desktop_name("windows", "amd64", version, "exe"))
     win_arm = md_link("ARM64", tag, desktop_name("windows", "arm64", version, "exe"))
-    win64_zip = md_link("64位", tag, portable_name("windows", "amd64", version))
+    win64_zip = md_link("64-bit", tag, portable_name("windows", "amd64", version))
     win_arm_zip = md_link("ARM64", tag, portable_name("windows", "arm64", version))
     mac_arm = md_link("Apple Silicon", tag, desktop_name("darwin", "arm64", version, "dmg"))
     mac_intel = md_link("Intel", tag, desktop_name("darwin", "amd64", version, "dmg"))
     mac_arm_zip = md_link("Apple Silicon", tag, portable_name("darwin", "arm64", version))
     mac_intel_zip = md_link("Intel", tag, portable_name("darwin", "amd64", version))
-    linux64 = md_link("64位", tag, desktop_name("linux", "amd64", version, "tar.gz"))
+    linux64 = md_link("64-bit", tag, desktop_name("linux", "amd64", version, "tar.gz"))
     linux_arm = md_link("ARM64", tag, desktop_name("linux", "arm64", version, "tar.gz"))
-    linux64_zip = md_link("64位", tag, portable_name("linux", "amd64", version))
+    linux64_zip = md_link("64-bit", tag, portable_name("linux", "amd64", version))
     linux_arm_zip = md_link("ARM64", tag, portable_name("linux", "arm64", version))
-    fnos_docker = md_link("Docker 版", tag, f"Octop-fnos-docker-{version}.fpk")
-    fnos_native = md_link("本地版", tag, f"Octop-fnos-native-{version}.fpk")
+    fnos_docker = md_link("Docker", tag, f"Octop-fnos-docker-{version}.fpk")
+    fnos_native = md_link("Native", tag, f"Octop-fnos-native-{version}.fpk")
     return "\n".join(
         [
             "",
-            "## 下载地址",
+            "## Downloads",
             "",
             "### Windows",
             "",
-            "#### 桌面安装包(推荐)",
+            "#### Desktop installer (Recommended)",
             f"- {win64} | {win_arm}",
             "",
-            "#### 便携版",
+            "#### Portable",
             f"- {win64_zip} | {win_arm_zip}",
             "",
             "### macOS",
             "",
-            "#### 桌面安装包(推荐)",
+            "#### Desktop installer (Recommended)",
             f"- {mac_arm} | {mac_intel}",
             "",
-            "#### 便携版",
+            "#### Portable",
             f"- {mac_arm_zip} | {mac_intel_zip}",
             "",
             "### Linux",
             "",
-            "#### 桌面安装包(推荐)",
+            "#### Desktop installer (Recommended)",
             f"- {linux64} | {linux_arm}",
             "",
-            "#### 便携版",
+            "#### Portable",
             f"- {linux64_zip} | {linux_arm_zip}",
             "",
-            "### 飞牛 NAS",
+            "### fnOS NAS",
             f"- {fnos_docker} | {fnos_native}",
             "",
         ]

--- a/scripts/release_download_links.py
+++ b/scripts/release_download_links.py
@@ -1,0 +1,105 @@
+"""Build GitHub Release download-section markdown from a version tag.
+
+Same pattern as clash-verge-rev: interpolate TAG / VERSION into a fixed
+filename table. Do not scrape the assets list.
+
+    python3 scripts/release_download_links.py 0.9.31
+    python3 scripts/release_download_links.py v0.9.31
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+GITHUB_REPO = "TencentCloud/Octop"
+DOWNLOAD_BASE = f"https://github.com/{GITHUB_REPO}/releases/download"
+
+
+def split_tag(raw: str) -> tuple[str, str]:
+    """Return ``(tag, version)`` — tag always has a leading ``v``."""
+    text = raw.strip()
+    if not text:
+        raise ValueError("version is empty")
+    version = text[1:] if text.startswith("v") else text
+    return f"v{version}", version
+
+
+def asset_url(tag: str, filename: str) -> str:
+    return f"{DOWNLOAD_BASE}/{tag}/{filename}"
+
+
+def md_link(label: str, tag: str, filename: str) -> str:
+    return f"[{label}]({asset_url(tag, filename)})"
+
+
+def desktop_name(os_name: str, arch: str, version: str, ext: str) -> str:
+    return f"Octop-desktop-{os_name}-{arch}-{version}.{ext}"
+
+
+def portable_name(os_name: str, arch: str, version: str) -> str:
+    return f"Octop-portable-{os_name}-{arch}-{version}.zip"
+
+
+def render_download_section(raw_version: str) -> str:
+    tag, version = split_tag(raw_version)
+    win64 = md_link("64位(常用)", tag, desktop_name("windows", "amd64", version, "exe"))
+    win_arm = md_link("ARM64", tag, desktop_name("windows", "arm64", version, "exe"))
+    win64_zip = md_link("64位", tag, portable_name("windows", "amd64", version))
+    win_arm_zip = md_link("ARM64", tag, portable_name("windows", "arm64", version))
+    mac_arm = md_link("Apple Silicon", tag, desktop_name("darwin", "arm64", version, "dmg"))
+    mac_intel = md_link("Intel", tag, desktop_name("darwin", "amd64", version, "dmg"))
+    mac_arm_zip = md_link("Apple Silicon", tag, portable_name("darwin", "arm64", version))
+    mac_intel_zip = md_link("Intel", tag, portable_name("darwin", "amd64", version))
+    linux64 = md_link("64位", tag, desktop_name("linux", "amd64", version, "tar.gz"))
+    linux_arm = md_link("ARM64", tag, desktop_name("linux", "arm64", version, "tar.gz"))
+    linux64_zip = md_link("64位", tag, portable_name("linux", "amd64", version))
+    linux_arm_zip = md_link("ARM64", tag, portable_name("linux", "arm64", version))
+    fnos_docker = md_link("Docker 版", tag, f"Octop-fnos-docker-{version}.fpk")
+    fnos_native = md_link("本地版", tag, f"Octop-fnos-native-{version}.fpk")
+    return "\n".join(
+        [
+            "",
+            "## 下载地址",
+            "",
+            "### Windows",
+            "",
+            "#### 桌面安装包(推荐)",
+            f"- {win64} | {win_arm}",
+            "",
+            "#### 便携版",
+            f"- {win64_zip} | {win_arm_zip}",
+            "",
+            "### macOS",
+            "",
+            "#### 桌面安装包(推荐)",
+            f"- {mac_arm} | {mac_intel}",
+            "",
+            "#### 便携版",
+            f"- {mac_arm_zip} | {mac_intel_zip}",
+            "",
+            "### Linux",
+            "",
+            "#### 桌面安装包(推荐)",
+            f"- {linux64} | {linux_arm}",
+            "",
+            "#### 便携版",
+            f"- {linux64_zip} | {linux_arm_zip}",
+            "",
+            "### 飞牛 NAS",
+            f"- {fnos_docker} | {fnos_native}",
+            "",
+        ]
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Print Octop GitHub Release download markdown.")
+    parser.add_argument("version", help="Package version, with or without a leading v")
+    args = parser.parse_args(argv)
+    sys.stdout.write(render_download_section(args.version))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_release_download_links.py
+++ b/tests/unit/test_release_download_links.py
@@ -1,0 +1,44 @@
+"""tests/unit/test_release_download_links.py"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+_SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "release_download_links.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("release_download_links", _SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_split_tag_accepts_with_or_without_v() -> None:
+    mod = _load()
+    assert mod.split_tag("0.9.31") == ("v0.9.31", "0.9.31")
+    assert mod.split_tag("v0.9.31") == ("v0.9.31", "0.9.31")
+
+
+def test_render_download_section_matches_github_asset_names() -> None:
+    mod = _load()
+    body = mod.render_download_section("0.9.31")
+    base = "https://github.com/TencentCloud/Octop/releases/download/v0.9.31"
+    assert f"{base}/Octop-desktop-windows-amd64-0.9.31.exe" in body
+    assert f"{base}/Octop-desktop-windows-arm64-0.9.31.exe" in body
+    assert f"{base}/Octop-portable-windows-amd64-0.9.31.zip" in body
+    assert f"{base}/Octop-portable-windows-arm64-0.9.31.zip" in body
+    assert f"{base}/Octop-desktop-darwin-arm64-0.9.31.dmg" in body
+    assert f"{base}/Octop-desktop-darwin-amd64-0.9.31.dmg" in body
+    assert f"{base}/Octop-portable-darwin-arm64-0.9.31.zip" in body
+    assert f"{base}/Octop-portable-darwin-amd64-0.9.31.zip" in body
+    assert f"{base}/Octop-desktop-linux-amd64-0.9.31.tar.gz" in body
+    assert f"{base}/Octop-desktop-linux-arm64-0.9.31.tar.gz" in body
+    assert f"{base}/Octop-portable-linux-amd64-0.9.31.zip" in body
+    assert f"{base}/Octop-portable-linux-arm64-0.9.31.zip" in body
+    assert f"{base}/Octop-fnos-docker-0.9.31.fpk" in body
+    assert f"{base}/Octop-fnos-native-0.9.31.fpk" in body
+    assert "pip install" not in body
+    assert "## 下载地址" in body

--- a/tests/unit/test_release_download_links.py
+++ b/tests/unit/test_release_download_links.py
@@ -41,4 +41,4 @@ def test_render_download_section_matches_github_asset_names() -> None:
     assert f"{base}/Octop-fnos-docker-0.9.31.fpk" in body
     assert f"{base}/Octop-fnos-native-0.9.31.fpk" in body
     assert "pip install" not in body
-    assert "## 下载地址" in body
+    assert "## Downloads" in body


### PR DESCRIPTION
## Summary

- Append a versioned `## 下载地址` section to GitHub Release notes from a fixed filename table (desktop installers, portable zips, and FnOS `.fpk` files).
- Interpolate `TAG` / `VERSION` into GitHub asset URLs instead of scraping the release assets list, matching the clash-verge-rev pattern.
- Skip the section when changelog notes already include `## 下载地址`.

## Target branch

- [x] Base is **`develop`** (feature / fix — default)
- [ ] Base is **`main`** (`release/*` or `hotfix/*` only)

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / chore
- [ ] Release / hotfix

## Test plan

<!-- How did you verify this? Include commands run (e.g. `make all`). -->

- `uv run pytest tests/unit/test_release_download_links.py -q` — 2 passed
- `python3 scripts/release_download_links.py 0.9.31` — URLs match the published v0.9.31 asset names

- [ ] `make all` passes locally
- [x] Added/updated tests

## Checklist

- [ ] Updated `CHANGELOG.md` (if user-facing)
- [ ] README / docs updated (if needed)