### PR TITLE
feat(chat): show human-readable HITL approval cards

### DIFF
--- a/dashboard/src/locales/en.json
+++ b/dashboard/src/locales/en.json
@@ -1167,12 +1167,96 @@
       "emptyResult": "Model returned an empty result"
     },
     "hitl": {
-      "title": "Tool approval required",
+      "title": "Confirm this action",
       "approve": "Approve",
       "reject": "Reject",
       "approved": "Approved",
       "rejectedLabel": "Rejected",
-      "rejected": "Rejected by user"
+      "rejected": "Rejected by user",
+      "args": {
+        "action": "Action",
+        "level": "Detail",
+        "url": "URL",
+        "command": "Command",
+        "cmd": "Command",
+        "path": "Path",
+        "file": "File",
+        "file_path": "File path",
+        "query": "Query",
+        "pattern": "Pattern",
+        "content": "Content",
+        "text": "Text",
+        "selector": "Selector",
+        "ref": "Element",
+        "key": "Key",
+        "value": "Value",
+        "direction": "Direction",
+        "amount": "Amount",
+        "prompt": "Prompt",
+        "old_string": "Original",
+        "new_string": "Replacement",
+        "timeout": "Timeout",
+        "method": "Method",
+        "body": "Body",
+        "code": "Script",
+        "wait": "Wait",
+        "element_ref": "Element",
+        "full_page": "Full page",
+        "tab_id": "Tab"
+      },
+      "bool": {
+        "true": "Yes",
+        "false": "No"
+      },
+      "browser": {
+        "actions": {
+          "navigate": "Open a page",
+          "open": "Open a page",
+          "snapshot": "Capture a page snapshot",
+          "dom_tree": "Read the page structure",
+          "screenshot": "Take a screenshot",
+          "click": "Click a page element",
+          "type": "Type into the page",
+          "fill": "Fill a form field",
+          "press": "Press a key",
+          "wait": "Wait for the page",
+          "select": "Choose a dropdown option",
+          "scroll": "Scroll the page",
+          "hover": "Hover over an element",
+          "eval_js": "Run a script on the page",
+          "go_back": "Go back",
+          "go_forward": "Go forward",
+          "reload": "Reload the page",
+          "new_tab": "Open a new tab",
+          "switch_tab": "Switch tabs",
+          "close_tab": "Close a tab",
+          "list_tabs": "List tabs",
+          "close_session": "Close the browser session"
+        },
+        "levels": {
+          "minimal": "Minimal structure",
+          "interactive": "Interactive elements only",
+          "full": "Full structure",
+          "structured": "Structured content"
+        },
+        "directions": {
+          "up": "Up",
+          "down": "Down",
+          "left": "Left",
+          "right": "Right"
+        }
+      },
+      "summaries": {
+        "domTreeInteractive": "Read the interactive structure of the current page",
+        "domTree": "Read the structure of the current page",
+        "screenshot": "Take a screenshot of the current page",
+        "openUrl": "Open {{url}}",
+        "runCommand": "Run command: {{command}}",
+        "writeFile": "Write file {{path}}",
+        "readFile": "Read file {{path}}",
+        "editFile": "Edit file {{path}}",
+        "fetchUrl": "Fetch {{url}}"
+      }
     },
     "ask": {
       "title": "A few questions first",

--- a/dashboard/src/locales/zh.json
+++ b/dashboard/src/locales/zh.json
@@ -1167,12 +1167,96 @@
       "emptyResult": "模型未返回润色结果"
     },
     "hitl": {
-      "title": "需要审批工具调用",
+      "title": "需要确认这次操作",
       "approve": "批准",
       "reject": "拒绝",
       "approved": "已批准",
       "rejectedLabel": "已拒绝",
-      "rejected": "用户已拒绝"
+      "rejected": "用户已拒绝",
+      "args": {
+        "action": "操作",
+        "level": "范围",
+        "url": "网址",
+        "command": "命令",
+        "cmd": "命令",
+        "path": "路径",
+        "file": "文件",
+        "file_path": "文件路径",
+        "query": "查询",
+        "pattern": "匹配",
+        "content": "内容",
+        "text": "文字",
+        "selector": "选择器",
+        "ref": "元素",
+        "key": "按键",
+        "value": "值",
+        "direction": "方向",
+        "amount": "幅度",
+        "prompt": "提示词",
+        "old_string": "原文",
+        "new_string": "替换为",
+        "timeout": "超时",
+        "method": "方法",
+        "body": "内容",
+        "code": "脚本",
+        "wait": "等待",
+        "element_ref": "目标元素",
+        "full_page": "整页",
+        "tab_id": "标签页"
+      },
+      "bool": {
+        "true": "是",
+        "false": "否"
+      },
+      "browser": {
+        "actions": {
+          "navigate": "打开网页",
+          "open": "打开网页",
+          "snapshot": "获取页面快照",
+          "dom_tree": "获取网页结构",
+          "screenshot": "截取网页截图",
+          "click": "点击页面元素",
+          "type": "在页面中输入文字",
+          "fill": "填写表单",
+          "press": "按下按键",
+          "wait": "等待页面就绪",
+          "select": "选择下拉选项",
+          "scroll": "滚动页面",
+          "hover": "悬停在元素上",
+          "eval_js": "在页面中执行脚本",
+          "go_back": "返回上一页",
+          "go_forward": "前进到下一页",
+          "reload": "刷新页面",
+          "new_tab": "打开新标签页",
+          "switch_tab": "切换标签页",
+          "close_tab": "关闭标签页",
+          "list_tabs": "列出标签页",
+          "close_session": "关闭浏览器会话"
+        },
+        "levels": {
+          "minimal": "精简结构",
+          "interactive": "仅交互元素",
+          "full": "完整结构",
+          "structured": "结构化内容"
+        },
+        "directions": {
+          "up": "向上",
+          "down": "向下",
+          "left": "向左",
+          "right": "向右"
+        }
+      },
+      "summaries": {
+        "domTreeInteractive": "获取当前网页的可交互元素结构",
+        "domTree": "获取当前网页结构",
+        "screenshot": "截取当前网页截图",
+        "openUrl": "打开网页 {{url}}",
+        "runCommand": "执行命令：{{command}}",
+        "writeFile": "写入文件 {{path}}",
+        "readFile": "读取文件 {{path}}",
+        "editFile": "编辑文件 {{path}}",
+        "fetchUrl": "抓取网页 {{url}}"
+      }
     },
     "ask": {
       "title": "先问几个问题",

--- a/dashboard/src/pages/Chat/chatMessages.partial.less
+++ b/dashboard/src/pages/Chat/chatMessages.partial.less
@@ -198,6 +198,12 @@
   }
 }
 
+.hitlSegment {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
 /* Legacy grouped bubbles (kept for compatibility) */
 .assistantGroup {
   display: flex;
@@ -660,36 +666,6 @@
   flex-wrap: wrap;
   gap: 8px;
   margin-top: 4px;
-}
-
-.hitlCard {
-  border: 1px solid var(--fn-border);
-  border-radius: 8px;
-  padding: 12px;
-  background: var(--fn-bg-elevated, var(--fn-bg-container));
-}
-
-.hitlTitle {
-  font-weight: 600;
-  margin-bottom: 8px;
-}
-
-.hitlAction {
-  margin-bottom: 8px;
-}
-
-.hitlResolved {
-  margin-top: 4px;
-  font-size: 13px;
-  font-weight: 500;
-}
-
-.hitlResolvedApproved {
-  color: var(--fn-color-success, #389e0d);
-}
-
-.hitlResolvedRejected {
-  color: var(--fn-color-error, #cf1322);
 }
 
 /* ---------- Assistant turn process summary (tools + thinking) ---------- */

--- a/dashboard/src/pages/Chat/components/AssistantTurnView.tsx
+++ b/dashboard/src/pages/Chat/components/AssistantTurnView.tsx
@@ -165,7 +165,7 @@ export default function AssistantTurnView({
           idx === segmentProcess.length - 1 &&
           hitlLayout.trailingMessages.length === 0;
         return (
-          <div key={hitl.id}>
+          <div key={hitl.id} className={styles.hitlSegment}>
             {showProcess ? (
               <>
                 <TurnProcessBlocks

--- a/dashboard/src/pages/Chat/components/HitlApprovalCard.module.less
+++ b/dashboard/src/pages/Chat/components/HitlApprovalCard.module.less
@@ -1,0 +1,198 @@
+.card {
+  border: 1px solid
+    color-mix(
+      in srgb,
+      var(--fn-color-warning, #d48806) 42%,
+      var(--fn-border-primary)
+    );
+  border-radius: var(--fn-radius-lg);
+  padding: 14px 16px;
+  background: color-mix(
+    in srgb,
+    var(--fn-color-warning, #d48806) 7%,
+    var(--fn-bg-primary)
+  );
+  box-shadow: var(--fn-shadow-xs);
+  box-sizing: border-box;
+  width: 100%;
+  max-width: var(--chat-column-max, 960px);
+}
+
+.titleRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+
+.iconWrap {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 28px;
+  height: 28px;
+  border-radius: var(--fn-radius-full);
+  color: var(--fn-color-warning, #d48806);
+  background: color-mix(
+    in srgb,
+    var(--fn-color-warning, #d48806) 16%,
+    transparent
+  );
+}
+
+.title {
+  font-weight: 600;
+  font-size: 14px;
+  color: var(--fn-text-primary);
+}
+
+.action + .action {
+  margin-top: 12px;
+  padding-top: 12px;
+  border-top: 1px solid var(--fn-border-secondary);
+}
+
+.toolName {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--fn-text-brand, var(--fn-color-brand));
+  margin-bottom: 4px;
+}
+
+.summary {
+  margin: 0 0 10px;
+  font-size: 14px;
+  line-height: 1.55;
+  color: var(--fn-text-primary);
+}
+
+.rows {
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.row {
+  display: grid;
+  grid-template-columns: minmax(64px, 72px) minmax(0, 1fr);
+  gap: 10px;
+  align-items: start;
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.row dt {
+  margin: 0;
+  color: var(--fn-text-tertiary);
+  font-weight: 400;
+}
+
+.row dd {
+  margin: 0;
+  color: var(--fn-text-primary);
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+}
+
+.mono {
+  font-family: var(
+    --fn-font-mono,
+    ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    monospace
+  );
+  font-size: 12px;
+}
+
+.actions {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 6px;
+  padding-top: 12px;
+  border-top: 1px solid var(--fn-border-secondary);
+}
+
+.actionButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 68px;
+  height: 34px;
+  padding: 0 15px;
+  border: 1px solid transparent;
+  border-radius: var(--fn-radius-md);
+  font: inherit;
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 1;
+  cursor: pointer;
+  transition:
+    color var(--fn-transition-fast),
+    background var(--fn-transition-fast),
+    border-color var(--fn-transition-fast),
+    box-shadow var(--fn-transition-fast),
+    transform var(--fn-transition-fast);
+
+  &:active:not(:disabled) {
+    transform: scale(0.97);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--fn-color-brand);
+    outline-offset: 2px;
+  }
+}
+
+.primaryAction {
+  color: var(--fn-color-on-brand);
+  background: var(--fn-color-brand);
+  border-color: var(--fn-color-brand);
+  box-shadow: 0 1px 2px var(--fn-color-brand-shadow);
+
+  &:hover:not(:disabled) {
+    background: var(--fn-color-brand-hover);
+    border-color: var(--fn-color-brand-hover);
+    box-shadow: var(--fn-shadow-brand);
+  }
+}
+
+.dangerAction {
+  color: var(--fn-color-error, #cf1322);
+  background: var(--fn-bg-primary);
+  border-color: var(--fn-color-error-border, #ffa39e);
+
+  &:hover:not(:disabled) {
+    background: var(--fn-color-error-bg, #fff2f0);
+    border-color: var(--fn-color-error, #cf1322);
+  }
+}
+
+.resolved {
+  margin-top: 8px;
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.approved {
+  color: var(--fn-color-success, #389e0d);
+}
+
+.rejected {
+  color: var(--fn-color-error, #cf1322);
+}
+
+@media (max-width: 767px) {
+  .card {
+    padding: 12px;
+  }
+
+  .row {
+    grid-template-columns: 1fr;
+    gap: 2px;
+  }
+}

--- a/dashboard/src/pages/Chat/components/HitlApprovalCard.test.tsx
+++ b/dashboard/src/pages/Chat/components/HitlApprovalCard.test.tsx
@@ -1,0 +1,58 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import HitlApprovalCard from "./HitlApprovalCard";
+
+describe("HitlApprovalCard", () => {
+  it("does not dump raw JSON arguments", () => {
+    render(
+      <HitlApprovalCard
+        actions={[
+          {
+            name: "browser_use",
+            args: { action: "dom_tree", level: "interactive" },
+          },
+        ]}
+        status="pending"
+        onDecision={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByText("Read the interactive structure of the current page"),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/"action"/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/\{\s*"action"/)).not.toBeInTheDocument();
+    expect(document.querySelector("svg")).toBeTruthy();
+  });
+
+  it("approves and rejects through the decision callback", () => {
+    const onDecision = vi.fn();
+    render(
+      <HitlApprovalCard
+        actions={[{ name: "execute", args: { command: "ls" } }]}
+        status="pending"
+        onDecision={onDecision}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Approve" }));
+    expect(onDecision).toHaveBeenCalledWith([{ type: "approve" }]);
+
+    fireEvent.click(screen.getByRole("button", { name: "Reject" }));
+    expect(onDecision).toHaveBeenCalledWith([
+      { type: "reject", message: "Rejected by user" },
+    ]);
+  });
+
+  it("does not treat a pending card without a callback as rejected", () => {
+    render(
+      <HitlApprovalCard
+        actions={[{ name: "execute", args: { command: "ls" } }]}
+        status="pending"
+      />,
+    );
+
+    expect(screen.queryByText("Rejected")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+});

--- a/dashboard/src/pages/Chat/components/HitlApprovalCard.tsx
+++ b/dashboard/src/pages/Chat/components/HitlApprovalCard.tsx
@@ -1,0 +1,104 @@
+import { ShieldAlert } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import type { HitlActionRequest } from "../../../api/types/hitl";
+import { useToolDisplayNames } from "../hooks/toolDisplayNames";
+import {
+  summarizeHitlAction,
+  type HitlTranslate,
+} from "../utils/summarizeHitlAction";
+import styles from "./HitlApprovalCard.module.less";
+
+export interface HitlApprovalCardProps {
+  actions: HitlActionRequest[];
+  status: "pending" | "approved" | "rejected";
+  onDecision?: (decisions: Array<{ type: string; message?: string }>) => void;
+}
+
+export default function HitlApprovalCard({
+  actions,
+  status,
+  onDecision,
+}: HitlApprovalCardProps) {
+  const { t } = useTranslation();
+  const toolLabelOf = useToolDisplayNames();
+  const interactive = status === "pending" && Boolean(onDecision);
+
+  return (
+    <div className={styles.card} role="status">
+      <div className={styles.titleRow}>
+        <span className={styles.iconWrap} aria-hidden="true">
+          <ShieldAlert size={18} strokeWidth={2} />
+        </span>
+        <div className={styles.title}>
+          {t("chat.hitl.title", "Confirm this action")}
+        </div>
+      </div>
+      {actions.map((action, idx) => {
+        const view = summarizeHitlAction(
+          action.name,
+          action.args,
+          t as HitlTranslate,
+          toolLabelOf(action.name),
+          action.description,
+        );
+        return (
+          <div key={`${action.name}-${idx}`} className={styles.action}>
+            <div className={styles.toolName}>{view.toolLabel}</div>
+            {view.summary && view.summary !== view.toolLabel ? (
+              <p className={styles.summary}>{view.summary}</p>
+            ) : null}
+            {view.rows.length > 0 ? (
+              <dl className={styles.rows}>
+                {view.rows.map((row, rowIdx) => (
+                  <div key={`${row.label}-${rowIdx}`} className={styles.row}>
+                    <dt>{row.label}</dt>
+                    <dd className={row.mono ? styles.mono : undefined}>
+                      {row.value}
+                    </dd>
+                  </div>
+                ))}
+              </dl>
+            ) : null}
+          </div>
+        );
+      })}
+      {interactive ? (
+        <div className={styles.actions}>
+          <button
+            type="button"
+            className={`${styles.actionButton} ${styles.primaryAction}`}
+            onClick={() =>
+              onDecision?.(actions.map(() => ({ type: "approve" })))
+            }
+          >
+            {t("chat.hitl.approve", "Approve")}
+          </button>
+          <button
+            type="button"
+            className={`${styles.actionButton} ${styles.dangerAction}`}
+            onClick={() =>
+              onDecision?.(
+                actions.map(() => ({
+                  type: "reject",
+                  message: t("chat.hitl.rejected", "Rejected by user"),
+                })),
+              )
+            }
+          >
+            {t("chat.hitl.reject", "Reject")}
+          </button>
+        </div>
+      ) : status !== "pending" ? (
+        <div
+          className={`${styles.resolved} ${
+            status === "approved" ? styles.approved : styles.rejected
+          }`}
+        >
+          {status === "approved"
+            ? t("chat.hitl.approved", "Approved")
+            : t("chat.hitl.rejectedLabel", "Rejected")}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/dashboard/src/pages/Chat/components/MessageBubble.tsx
+++ b/dashboard/src/pages/Chat/components/MessageBubble.tsx
@@ -1,5 +1,5 @@
 import { memo, useMemo, useState, useCallback, useRef, useEffect } from "react";
-import { Image, Button, Tooltip } from "antd";
+import { Image, Tooltip } from "antd";
 import { message as antMessage } from "@/utils/antdMessage";
 
 import Markdown from "../../../components/Markdown/LazyMarkdown";
@@ -39,6 +39,7 @@ import {
 } from "../../../utils/chatStreamError";
 import { MessageFileCard } from "./MessageFileCard";
 import AskQuestionCard from "./AskQuestionCard";
+import HitlApprovalCard from "./HitlApprovalCard";
 import { extractAskQuestions, isAskHitl } from "../../../api/types/hitl";
 import styles from "../index.module.less";
 import {
@@ -616,58 +617,11 @@ function MessageBubble({
           compact ? styles.compact : ""
         }`}
       >
-        <div className={styles.hitlCard}>
-          <div className={styles.hitlTitle}>
-            {t("chat.hitl.title", "Tool approval required")}
-          </div>
-          {actions.map((action, idx) => (
-            <div key={`${action.name}-${idx}`} className={styles.hitlAction}>
-              <code>{action.name}</code>
-              {action.args && Object.keys(action.args).length > 0 && (
-                <pre className={styles.inlineToolCode}>
-                  {JSON.stringify(action.args, null, 2)}
-                </pre>
-              )}
-            </div>
-          ))}
-          {hitlStatus === "pending" && onHitlDecision ? (
-            <div className={styles.acpPermissionActions}>
-              <Button
-                type="primary"
-                onClick={() =>
-                  onHitlDecision(actions.map(() => ({ type: "approve" })))
-                }
-              >
-                {t("chat.hitl.approve", "Approve")}
-              </Button>
-              <Button
-                danger
-                onClick={() =>
-                  onHitlDecision(
-                    actions.map(() => ({
-                      type: "reject",
-                      message: t("chat.hitl.rejected", "Rejected by user"),
-                    })),
-                  )
-                }
-              >
-                {t("chat.hitl.reject", "Reject")}
-              </Button>
-            </div>
-          ) : hitlStatus !== "pending" ? (
-            <div
-              className={`${styles.hitlResolved} ${
-                hitlStatus === "approved"
-                  ? styles.hitlResolvedApproved
-                  : styles.hitlResolvedRejected
-              }`}
-            >
-              {hitlStatus === "approved"
-                ? t("chat.hitl.approved", "Approved")
-                : t("chat.hitl.rejectedLabel", "Rejected")}
-            </div>
-          ) : null}
-        </div>
+        <HitlApprovalCard
+          actions={actions}
+          status={hitlStatus}
+          onDecision={onHitlDecision}
+        />
       </div>
     );
   }

--- a/dashboard/src/pages/Chat/utils/summarizeHitlAction.test.ts
+++ b/dashboard/src/pages/Chat/utils/summarizeHitlAction.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "vitest";
+import zh from "../../../locales/zh.json";
+import { summarizeHitlAction, type HitlTranslate } from "./summarizeHitlAction";
+
+function lookup(bundle: unknown, key: string): string | undefined {
+  let node: unknown = bundle;
+  for (const part of key.split(".")) {
+    if (!node || typeof node !== "object") return undefined;
+    node = (node as Record<string, unknown>)[part];
+  }
+  return typeof node === "string" ? node : undefined;
+}
+
+function interpolate(template: string, vars: Record<string, unknown>): string {
+  return template.replace(/\{\{(\w+)\}\}/g, (_, name: string) =>
+    name in vars ? String(vars[name]) : `{{${name}}}`,
+  );
+}
+
+/** Mimic i18next: missing keys return the key; `{{name}}` is interpolated. */
+function tFrom(bundle: unknown): HitlTranslate {
+  return (key, options) => {
+    const vars =
+      options && typeof options === "object"
+        ? (options as Record<string, unknown>)
+        : {};
+    const fallback = typeof options === "string" ? options : undefined;
+    const found = lookup(bundle, key);
+    if (found === undefined) return fallback ?? key;
+    return interpolate(found, vars);
+  };
+}
+
+const tZh = tFrom(zh);
+
+describe("summarizeHitlAction", () => {
+  it("explains browser_use dom_tree in Chinese instead of dumping JSON", () => {
+    const view = summarizeHitlAction(
+      "browser_use",
+      { action: "dom_tree", level: "interactive" },
+      tZh,
+      "使用浏览器",
+    );
+
+    expect(view.toolLabel).toBe("使用浏览器");
+    expect(view.summary).toBe("获取当前网页的可交互元素结构");
+    expect(view.rows).toEqual([
+      { label: "操作", value: "获取网页结构" },
+      { label: "范围", value: "仅交互元素" },
+    ]);
+    const blob = [view.summary, ...view.rows.map((row) => row.value)].join(" ");
+    expect(blob).not.toContain('"action"');
+    expect(blob).not.toContain("{");
+  });
+
+  it("puts the target URL into the navigate summary", () => {
+    const view = summarizeHitlAction(
+      "browser_use",
+      { action: "navigate", url: "https://news.example.com" },
+      tZh,
+      "使用浏览器",
+    );
+
+    expect(view.summary).toBe("打开网页 https://news.example.com");
+    expect(view.rows).toEqual([
+      { label: "操作", value: "打开网页" },
+      { label: "网址", value: "https://news.example.com", mono: true },
+    ]);
+  });
+
+  it("explains a shell command instead of wrapping it in JSON", () => {
+    const view = summarizeHitlAction(
+      "execute",
+      { command: "ls -la inbound" },
+      tZh,
+      "执行指令",
+    );
+
+    expect(view.summary).toBe("执行命令：ls -la inbound");
+    expect(view.rows).toEqual([
+      { label: "命令", value: "ls -la inbound", mono: true },
+    ]);
+  });
+
+  it("prefers the action description when the model already explained it", () => {
+    const view = summarizeHitlAction(
+      "custom_plugin_tool",
+      { foo_bar: "secret.txt" },
+      tZh,
+      "custom_plugin_tool",
+      "读取工作区里的密钥文件",
+    );
+
+    expect(view.summary).toBe("读取工作区里的密钥文件");
+    expect(view.rows).toEqual([{ label: "Foo bar", value: "secret.txt" }]);
+  });
+
+  it("ignores the English HITL template and explains write_file in Chinese", () => {
+    const view = summarizeHitlAction(
+      "write_file",
+      {
+        file_path: "/.octop/workspaces/J7Y3TW/test.txt",
+        content: "Hello, this is a test file!\nCreated at: 2025-01-25\n",
+      },
+      tZh,
+      "写入文件",
+      "Tool execution requires approval Tool: write_file Args: {'file_path': '/.octop/workspaces/J7Y3TW/test.txt', 'content': 'Hello, this is a test file!\\nCreated at: 2025-01-25\\n'}",
+    );
+
+    expect(view.summary).toBe("写入文件 /.octop/workspaces/J7Y3TW/test.txt");
+    expect(view.summary).not.toContain("Tool execution");
+    expect(view.rows).toEqual([
+      {
+        label: "文件路径",
+        value: "/.octop/workspaces/J7Y3TW/test.txt",
+        mono: true,
+      },
+      {
+        label: "内容",
+        value: "Hello, this is a test file!\nCreated at: 2025-01-25\n",
+      },
+    ]);
+  });
+
+  it("omits default profile noise and skips empty args", () => {
+    const view = summarizeHitlAction(
+      "browser_use",
+      { action: "screenshot", profile: "default" },
+      tZh,
+      "使用浏览器",
+    );
+
+    expect(view.summary).toBe("截取当前网页截图");
+    expect(view.rows.map((row) => row.label)).toEqual(["操作"]);
+    expect(view.rows.some((row) => row.value === "default")).toBe(false);
+  });
+});

--- a/dashboard/src/pages/Chat/utils/summarizeHitlAction.ts
+++ b/dashboard/src/pages/Chat/utils/summarizeHitlAction.ts
@@ -1,0 +1,272 @@
+/**
+ * Turn a HITL tool-call into a short explanation plus labelled rows.
+ * Approval cards should never dump raw JSON as the primary view.
+ */
+
+export interface HitlArgRow {
+  label: string;
+  value: string;
+  mono?: boolean;
+}
+
+export interface HitlActionView {
+  toolLabel: string;
+  summary: string;
+  rows: HitlArgRow[];
+}
+
+export type HitlTranslate = (
+  key: string,
+  options?: string | Record<string, unknown>,
+) => string;
+
+const HIDDEN_WHEN_DEFAULT = new Set(["profile"]);
+const ALWAYS_HIDDEN = new Set(["session_id"]);
+const TRUNCATE_KEYS = new Set([
+  "content",
+  "body",
+  "html",
+  "text",
+  "old_string",
+  "new_string",
+  "code",
+  "script",
+]);
+const BROWSER_TOOLS = new Set(["browser_use", "browser_control"]);
+const SHELL_TOOLS = new Set(["execute", "bash", "run_terminal_cmd"]);
+const MONO_KEYS = new Set([
+  "command",
+  "cmd",
+  "path",
+  "file",
+  "file_path",
+  "url",
+  "code",
+  "script",
+  "selector",
+  "pattern",
+]);
+const MAX_TRUNCATED = 280;
+const MAX_HARD = 2000;
+
+const MACHINE_HITL_DESC = /tool execution requires approval/i;
+const TOOL_ARGS_DUMP = /\bTool:\s+\S[\s\S]*\bArgs:\s*[{'"]/;
+
+/** True when harness/langgraph stuffed a raw English args dump into ``description``. */
+export function isMachineHitlDescription(text: string): boolean {
+  const trimmed = text.trim();
+  if (!trimmed) return false;
+  return MACHINE_HITL_DESC.test(trimmed) || TOOL_ARGS_DUMP.test(trimmed);
+}
+
+function resolve(
+  t: HitlTranslate,
+  key: string,
+  fallback: string,
+  vars?: Record<string, unknown>,
+): string {
+  const result = vars
+    ? t(key, { defaultValue: fallback, ...vars })
+    : t(key, fallback);
+  if (!result || result === key) return fallback;
+  return result;
+}
+
+export function humanizeArgKey(key: string): string {
+  const cleaned = key.replace(/[_-]+/g, " ").trim();
+  if (!cleaned) return key;
+  return cleaned[0].toUpperCase() + cleaned.slice(1);
+}
+
+function isEmpty(value: unknown): boolean {
+  return value === null || value === undefined || value === "";
+}
+
+function shouldHide(key: string, value: unknown): boolean {
+  if (ALWAYS_HIDDEN.has(key) || isEmpty(value)) return true;
+  if (HIDDEN_WHEN_DEFAULT.has(key) && value === "default") return true;
+  return false;
+}
+
+function truncate(text: string, max: number): string {
+  if (text.length <= max) return text;
+  return `${text.slice(0, Math.max(0, max - 1))}…`;
+}
+
+function formatPlain(value: unknown, t: HitlTranslate): string {
+  if (typeof value === "boolean") {
+    return resolve(
+      t,
+      value ? "chat.hitl.bool.true" : "chat.hitl.bool.false",
+      value ? "Yes" : "No",
+    );
+  }
+  if (typeof value === "number") return String(value);
+  if (typeof value === "string") return value;
+  if (Array.isArray(value)) {
+    return value
+      .filter((item) => !isEmpty(item))
+      .map((item) => formatPlain(item, t))
+      .join(", ");
+  }
+  if (value && typeof value === "object") {
+    return Object.entries(value as Record<string, unknown>)
+      .filter(([k, v]) => !shouldHide(k, v))
+      .map(([k, v]) => `${humanizeArgKey(k)}: ${formatPlain(v, t)}`)
+      .join("; ");
+  }
+  return String(value);
+}
+
+function formatKnownString(
+  toolName: string,
+  key: string,
+  raw: string,
+  t: HitlTranslate,
+): string {
+  if (BROWSER_TOOLS.has(toolName) || key === "action") {
+    if (key === "action") {
+      return resolve(t, `chat.hitl.browser.actions.${raw}`, raw);
+    }
+    if (key === "level") {
+      return resolve(t, `chat.hitl.browser.levels.${raw}`, raw);
+    }
+    if (key === "direction") {
+      return resolve(t, `chat.hitl.browser.directions.${raw}`, raw);
+    }
+  }
+  return raw;
+}
+
+function formatArgValue(
+  toolName: string,
+  key: string,
+  value: unknown,
+  t: HitlTranslate,
+): string {
+  if (typeof value === "string") {
+    const labelled = formatKnownString(toolName, key, value, t);
+    const max = TRUNCATE_KEYS.has(key) ? MAX_TRUNCATED : MAX_HARD;
+    return truncate(labelled, max);
+  }
+  const plain = formatPlain(value, t);
+  const max = TRUNCATE_KEYS.has(key) ? MAX_TRUNCATED : MAX_HARD;
+  return truncate(plain, max);
+}
+
+function argLabel(key: string, t: HitlTranslate): string {
+  return resolve(t, `chat.hitl.args.${key}`, humanizeArgKey(key));
+}
+
+function stringArg(
+  args: Record<string, unknown>,
+  ...keys: string[]
+): string | undefined {
+  for (const key of keys) {
+    const value = args[key];
+    if (typeof value === "string" && value.trim()) return value.trim();
+  }
+  return undefined;
+}
+
+function browserSummary(
+  args: Record<string, unknown>,
+  t: HitlTranslate,
+  toolLabel: string,
+): string {
+  const action = stringArg(args, "action") ?? "";
+  const url = stringArg(args, "url");
+  const level = stringArg(args, "level");
+  if ((action === "navigate" || action === "open") && url) {
+    return resolve(t, "chat.hitl.summaries.openUrl", `Open ${url}`, { url });
+  }
+  if (action === "new_tab" && url) {
+    return resolve(t, "chat.hitl.summaries.openUrl", `Open ${url}`, { url });
+  }
+  if (action === "screenshot") {
+    return resolve(
+      t,
+      "chat.hitl.summaries.screenshot",
+      "Take a screenshot of the current page",
+    );
+  }
+  if (action === "dom_tree" && level === "interactive") {
+    return resolve(
+      t,
+      "chat.hitl.summaries.domTreeInteractive",
+      "Read the interactive structure of the current page",
+    );
+  }
+  if (action === "dom_tree") {
+    return resolve(
+      t,
+      "chat.hitl.summaries.domTree",
+      "Read the structure of the current page",
+    );
+  }
+  if (action) {
+    return resolve(t, `chat.hitl.browser.actions.${action}`, toolLabel);
+  }
+  return toolLabel;
+}
+
+function buildSummary(
+  name: string,
+  args: Record<string, unknown>,
+  t: HitlTranslate,
+  toolLabel: string,
+  description?: string,
+): string {
+  const explained = description?.trim();
+  if (explained && !isMachineHitlDescription(explained)) return explained;
+  if (BROWSER_TOOLS.has(name)) return browserSummary(args, t, toolLabel);
+  const command = stringArg(args, "command", "cmd");
+  if (SHELL_TOOLS.has(name) && command) {
+    return resolve(t, "chat.hitl.summaries.runCommand", `Run: ${command}`, {
+      command,
+    });
+  }
+  const path = stringArg(args, "path", "file", "file_path");
+  if (name === "write_file" && path) {
+    return resolve(t, "chat.hitl.summaries.writeFile", `Write ${path}`, {
+      path,
+    });
+  }
+  if (name === "read_file" && path) {
+    return resolve(t, "chat.hitl.summaries.readFile", `Read ${path}`, { path });
+  }
+  if (name === "edit_file" && path) {
+    return resolve(t, "chat.hitl.summaries.editFile", `Edit ${path}`, { path });
+  }
+  const url = stringArg(args, "url");
+  if (name === "web_fetch" && url) {
+    return resolve(t, "chat.hitl.summaries.fetchUrl", `Fetch ${url}`, { url });
+  }
+  return toolLabel;
+}
+
+export function summarizeHitlAction(
+  name: string,
+  args: Record<string, unknown> | undefined,
+  t: HitlTranslate,
+  toolLabel: string,
+  description?: string,
+): HitlActionView {
+  const safeArgs = args && typeof args === "object" ? args : {};
+  const rows: HitlArgRow[] = [];
+  for (const [key, value] of Object.entries(safeArgs)) {
+    if (shouldHide(key, value)) continue;
+    const formatted = formatArgValue(name, key, value, t);
+    if (!formatted) continue;
+    rows.push({
+      label: argLabel(key, t),
+      value: formatted,
+      ...(MONO_KEYS.has(key) ? { mono: true } : {}),
+    });
+  }
+  return {
+    toolLabel,
+    summary: buildSummary(name, safeArgs, t, toolLabel, description),
+    rows,
+  };
+}


### PR DESCRIPTION
## Summary
- 聊天工具审批卡不再展示原始 JSON / 英文 Args dump，改为本地化摘要 + 带标签的参数行。
- 增加警示图标与警告色卡片，间距与普通助手消息一致。
- 忽略 harness 注入的机器描述（`Tool execution requires approval` / `Tool: … Args: …`）。

## Test plan
- [ ] 触发 `write_file` 审批：摘要为「写入文件 <路径>」，不出现 JSON / `{'file_path': ...}`。
- [ ] 触发 `browser_use`（如 `dom_tree`）：显示中文动作说明，而非原始 JSON。
- [ ] 中/英界面切换后文案正确；人类自定义 description 仍会展示。
- [ ] 审批卡与上方过程消息间距与普通消息一致，顶部不过大。
- [ ] `cd dashboard && npx vitest run src/pages/Chat/utils/summarizeHitlAction.test.ts src/pages/Chat/components/HitlApprovalCard.test.tsx`


Made with [Cursor](https://cursor.com)