### PR TITLE
feat(dashboard): keep token usage stats on one row

### DIFF
--- a/dashboard/src/pages/Control/TokenUsage/UsageStats.test.tsx
+++ b/dashboard/src/pages/Control/TokenUsage/UsageStats.test.tsx
@@ -1,0 +1,85 @@
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { UsageStats, visibleStatCount, type UsageStatItem } from "./UsageStats";
+
+const getComputedStyle = window.getComputedStyle;
+
+beforeAll(() => {
+  vi.spyOn(window, "getComputedStyle").mockImplementation((element) =>
+    getComputedStyle(element),
+  );
+});
+
+afterAll(() => {
+  vi.restoreAllMocks();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+const ITEMS: UsageStatItem[] = [
+  { key: "total", label: "总 tokens", value: "2,788,473" },
+  { key: "input", label: "输入", value: "2,764,158" },
+  { key: "output", label: "输出", value: "24,315" },
+  { key: "cacheRead", label: "缓存输入", value: "2,097,826" },
+  { key: "cacheHit", label: "缓存命中率", value: "76.0%" },
+  { key: "turns", label: "对话轮数", value: 15 },
+  { key: "avg", label: "均值/轮", value: "185,898" },
+];
+
+describe("visibleStatCount", () => {
+  it("fits all seven cards on a wide row", () => {
+    expect(visibleStatCount(1400, 7)).toBe(7);
+  });
+
+  it("keeps a single row and reserves the overflow control on a slightly narrow display", () => {
+    const visible = visibleStatCount(900, 7);
+    expect(visible).toBeGreaterThanOrEqual(1);
+    expect(visible).toBeLessThan(7);
+  });
+});
+
+describe("UsageStats", () => {
+  it("shows every metric in one row on a wide display", () => {
+    render(<UsageStats items={ITEMS} width={1400} />);
+
+    expect(screen.getByText("总 tokens")).toBeInTheDocument();
+    expect(screen.getByText("均值/轮")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "common.viewMore" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("stays on one row and opens leftover metrics from the overflow icon", async () => {
+    const user = userEvent.setup();
+    render(<UsageStats items={ITEMS} width={900} />);
+
+    expect(screen.getByText("总 tokens")).toBeInTheDocument();
+    expect(screen.queryByText("均值/轮")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "common.viewMore" }));
+
+    expect(await screen.findByText("均值/轮")).toBeInTheDocument();
+    expect(screen.getByText("185,898")).toBeInTheDocument();
+  });
+
+  it("does not hide metrics behind overflow on mobile", () => {
+    render(<UsageStats items={ITEMS} width={900} overflowEnabled={false} />);
+
+    expect(screen.getByText("总 tokens")).toBeInTheDocument();
+    expect(screen.getByText("均值/轮")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "common.viewMore" }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/dashboard/src/pages/Control/TokenUsage/UsageStats.tsx
+++ b/dashboard/src/pages/Control/TokenUsage/UsageStats.tsx
@@ -1,0 +1,142 @@
+import { useEffect, useRef, useState } from "react";
+import { Popover } from "antd";
+import { MoreVertical } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import styles from "./index.module.less";
+
+export interface UsageStatItem {
+  key: string;
+  label: string;
+  value: string | number;
+}
+
+const STAT_CARD_MIN_PX = 160;
+const STAT_GAP_PX = 12;
+const STAT_MORE_PX = 36;
+
+/** How many metric cards fit in a single row, reserving the ⋮ when needed. */
+export function visibleStatCount(width: number, total: number): number {
+  if (total <= 0) return 0;
+  const maxFit = Math.floor(
+    (width + STAT_GAP_PX) / (STAT_CARD_MIN_PX + STAT_GAP_PX),
+  );
+  if (maxFit >= total) return total;
+  const withMore = Math.floor(
+    (width - STAT_MORE_PX) / (STAT_CARD_MIN_PX + STAT_GAP_PX),
+  );
+  return Math.max(1, Math.min(total - 1, withMore));
+}
+
+function StatBlock({
+  label,
+  value,
+}: {
+  label: string;
+  value: string | number;
+}) {
+  return (
+    <div className={styles.statBlock}>
+      <div className={styles.statLabel}>{label}</div>
+      <div className={styles.statValue}>{value}</div>
+    </div>
+  );
+}
+
+function StatRow({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div className={styles.statsDrawerRow}>
+      <span className={styles.statsDrawerLabel}>{label}</span>
+      <span className={styles.statsDrawerValue}>{value}</span>
+    </div>
+  );
+}
+
+export function UsageStats({
+  items,
+  width: widthProp,
+  overflowEnabled = true,
+}: {
+  items: UsageStatItem[];
+  width?: number;
+  /** Desktop-only: hide overflowing cards behind ⋮. Off on phones. */
+  overflowEnabled?: boolean;
+}) {
+  const { t } = useTranslation();
+  const hostRef = useRef<HTMLDivElement>(null);
+  const [measuredWidth, setMeasuredWidth] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (widthProp !== undefined || !overflowEnabled) return;
+    const el = hostRef.current;
+    if (!el || typeof ResizeObserver === "undefined") return;
+    const apply = (width: number) => {
+      if (width > 0) setMeasuredWidth(width);
+    };
+    apply(el.clientWidth);
+    const ro = new ResizeObserver((entries) => {
+      const width = entries[0]?.contentRect.width;
+      if (width === undefined) return;
+      apply(width);
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [widthProp, overflowEnabled]);
+
+  const width = widthProp ?? measuredWidth ?? Number.POSITIVE_INFINITY;
+  const visible = overflowEnabled
+    ? visibleStatCount(width, items.length)
+    : items.length;
+  const shown = items.slice(0, visible);
+  const overflow = overflowEnabled ? items.slice(visible) : [];
+
+  return (
+    <div ref={hostRef} className={styles.statsHost}>
+      <div className={styles.statsRow}>
+        <div
+          className={
+            overflowEnabled ? styles.statsGrid : styles.statsGridMobile
+          }
+          style={
+            overflowEnabled
+              ? {
+                  gridTemplateColumns: `repeat(${Math.max(
+                    shown.length,
+                    1,
+                  )}, minmax(160px, 1fr))`,
+                }
+              : undefined
+          }
+        >
+          {shown.map((item) => (
+            <StatBlock key={item.key} label={item.label} value={item.value} />
+          ))}
+        </div>
+        {overflow.length > 0 ? (
+          <Popover
+            trigger="click"
+            placement="bottomRight"
+            content={
+              <div className={styles.statsDrawerList}>
+                {overflow.map((item) => (
+                  <StatRow
+                    key={item.key}
+                    label={item.label}
+                    value={item.value}
+                  />
+                ))}
+              </div>
+            }
+          >
+            <button
+              type="button"
+              className={styles.statsMoreIcon}
+              aria-label={t("common.viewMore")}
+            >
+              <MoreVertical size={18} strokeWidth={2} aria-hidden />
+            </button>
+          </Popover>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/dashboard/src/pages/Control/TokenUsage/index.module.less
+++ b/dashboard/src/pages/Control/TokenUsage/index.module.less
@@ -90,14 +90,87 @@
   box-sizing: border-box;
 }
 
-.statsGrid {
-  display: grid;
-  gap: 12px;
+.statsHost {
+  width: 100%;
   flex-shrink: 0;
 }
 
+.statsRow {
+  display: flex;
+  flex-wrap: nowrap;
+  gap: 12px;
+  align-items: stretch;
+}
+
+.statsGrid {
+  display: grid;
+  gap: 12px;
+  flex: 1 1 auto;
+  min-width: 0;
+  grid-auto-flow: column;
+  grid-template-rows: auto;
+  grid-template-columns: repeat(7, minmax(160px, 1fr));
+}
+
+.statsGridMobile {
+  display: grid;
+  gap: 12px;
+  flex: 1 1 auto;
+  min-width: 0;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.statsMoreIcon {
+  flex: 0 0 36px;
+  width: 36px;
+  padding: 0;
+  border: 1px solid var(--fn-border-secondary);
+  border-radius: 6px;
+  background: var(--fn-bg-secondary);
+  color: var(--fn-text-secondary);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.statsMoreIcon:hover {
+  color: var(--fn-text-primary);
+  border-color: var(--fn-border-primary);
+}
+
+.statsDrawerList {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.statsDrawerRow {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 14px;
+  background: var(--fn-bg-secondary);
+  border: 1px solid var(--fn-border-secondary);
+  border-radius: 6px;
+}
+
+.statsDrawerLabel {
+  font-size: 13px;
+  color: var(--fn-text-tertiary);
+}
+
+.statsDrawerValue {
+  font-size: 16px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  color: var(--fn-text-primary);
+  text-align: right;
+}
+
 .statBlock {
-  flex: 1;
+  min-width: 0;
   padding: 12px 16px;
   background: var(--fn-bg-secondary);
   border-radius: 6px;
@@ -109,12 +182,17 @@
   color: var(--fn-text-tertiary);
   text-transform: uppercase;
   letter-spacing: 0.04em;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .statValue {
   font-size: 22px;
   font-weight: 600;
   margin-top: 4px;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
 }
 
 .pieGrid,

--- a/dashboard/src/pages/Control/TokenUsage/index.tsx
+++ b/dashboard/src/pages/Control/TokenUsage/index.tsx
@@ -25,6 +25,7 @@ import {
 import { useTranslation } from "react-i18next";
 import PageShell from "../../../layouts/PageShell";
 import { useIsMobile } from "../../../hooks/useIsMobile";
+import { UsageStats, type UsageStatItem } from "./UsageStats";
 import { useUserRole } from "../../../hooks/useUserRole";
 import { request } from "../../../api/request";
 import { useAgent } from "../../../context/AgentContext";
@@ -222,19 +223,43 @@ function UsageBarChart({
   );
 }
 
-function StatBlock({
-  label,
-  value,
-}: {
-  label: string;
-  value: string | number;
-}) {
-  return (
-    <div className={styles.statBlock}>
-      <div className={styles.statLabel}>{label}</div>
-      <div className={styles.statValue}>{value}</div>
-    </div>
-  );
+function usageStatItems(
+  totals: UsageSummary,
+  t: (key: string) => string,
+): UsageStatItem[] {
+  return [
+    {
+      key: "total",
+      label: t("tokenUsage.totalTokens"),
+      value: formatNumber(totals.total_tokens),
+    },
+    {
+      key: "input",
+      label: t("tokenUsage.input"),
+      value: formatNumber(totals.input_tokens),
+    },
+    {
+      key: "output",
+      label: t("tokenUsage.output"),
+      value: formatNumber(totals.output_tokens),
+    },
+    {
+      key: "cacheRead",
+      label: t("tokenUsage.cacheRead"),
+      value: formatNumber(totals.cache_read_tokens),
+    },
+    {
+      key: "cacheHit",
+      label: t("tokenUsage.cacheHit"),
+      value: `${totals.cache_hit_percent.toFixed(1)}%`,
+    },
+    { key: "turns", label: t("tokenUsage.turns"), value: totals.turns },
+    {
+      key: "avg",
+      label: t("tokenUsage.avgPerTurn"),
+      value: formatNumber(totals.avg_per_turn),
+    },
+  ];
 }
 
 function bucketColumnTitle(
@@ -492,40 +517,10 @@ function SummaryView({
 
   return (
     <div className={styles.summaryBody}>
-      <div
-        className={styles.statsGrid}
-        style={{
-          gridTemplateColumns: isMobile
-            ? "repeat(2, minmax(0, 1fr))"
-            : "repeat(7, minmax(0, 1fr))",
-        }}
-      >
-        <StatBlock
-          label={t("tokenUsage.totalTokens")}
-          value={formatNumber(totals.total_tokens)}
-        />
-        <StatBlock
-          label={t("tokenUsage.input")}
-          value={formatNumber(totals.input_tokens)}
-        />
-        <StatBlock
-          label={t("tokenUsage.output")}
-          value={formatNumber(totals.output_tokens)}
-        />
-        <StatBlock
-          label={t("tokenUsage.cacheRead")}
-          value={formatNumber(totals.cache_read_tokens)}
-        />
-        <StatBlock
-          label={t("tokenUsage.cacheHit")}
-          value={`${totals.cache_hit_percent.toFixed(1)}%`}
-        />
-        <StatBlock label={t("tokenUsage.turns")} value={totals.turns} />
-        <StatBlock
-          label={t("tokenUsage.avgPerTurn")}
-          value={formatNumber(totals.avg_per_turn)}
-        />
-      </div>
+      <UsageStats
+        items={usageStatItems(totals, t)}
+        overflowEnabled={!isMobile}
+      />
 
       <div
         className={styles.pieGrid}
@@ -618,40 +613,10 @@ function DimensionView({
 
   return (
     <div className={styles.summaryBody}>
-      <div
-        className={styles.statsGrid}
-        style={{
-          gridTemplateColumns: isMobile
-            ? "repeat(2, minmax(0, 1fr))"
-            : "repeat(7, minmax(0, 1fr))",
-        }}
-      >
-        <StatBlock
-          label={t("tokenUsage.totalTokens")}
-          value={formatNumber(totals.total_tokens)}
-        />
-        <StatBlock
-          label={t("tokenUsage.input")}
-          value={formatNumber(totals.input_tokens)}
-        />
-        <StatBlock
-          label={t("tokenUsage.output")}
-          value={formatNumber(totals.output_tokens)}
-        />
-        <StatBlock
-          label={t("tokenUsage.cacheRead")}
-          value={formatNumber(totals.cache_read_tokens)}
-        />
-        <StatBlock
-          label={t("tokenUsage.cacheHit")}
-          value={`${totals.cache_hit_percent.toFixed(1)}%`}
-        />
-        <StatBlock label={t("tokenUsage.turns")} value={totals.turns} />
-        <StatBlock
-          label={t("tokenUsage.avgPerTurn")}
-          value={formatNumber(totals.avg_per_turn)}
-        />
-      </div>
+      <UsageStats
+        items={usageStatItems(totals, t)}
+        overflowEnabled={!isMobile}
+      />
 
       {granularity !== "by_day" && pieData.length > 0 && (
         <div


### PR DESCRIPTION
## Summary
- Token Usage 桌面端统计卡片改为单行展示：放不下的指标收到 ⋮ 菜单，不再折行。
- 手机端仍用两列网格，不隐藏指标。
- 抽出 `UsageStats` 组件，并补上可见数量与 overflow 交互测试。

## Test plan
- [ ] 宽屏打开 Token Usage：7 张指标卡同一行，无 ⋮。
- [ ] 缩窄窗口：卡片仍单行，点击 ⋮ 能看到被收起的指标（如均值/轮）。
- [ ] 手机宽度：两列网格，7 项全部可见，无 overflow 按钮。
- [ ] 汇总视图与按维度视图的顶部统计行为一致。
- [ ] `cd dashboard && npx vitest run src/pages/Control/TokenUsage/UsageStats.test.tsx`


Made with [Cursor](https://cursor.com)