### PR TITLE
feat(onnx): race COS with Hugging Face for embedding downloads

### DIFF
--- a/dashboard/src/pages/KnowledgeBases/index.tsx
+++ b/dashboard/src/pages/KnowledgeBases/index.tsx
@@ -2116,6 +2116,9 @@ export default function KnowledgeBasesPage() {
         title={t("knowledgeBases.settingsTitle")}
         placement="right"
         width={isMobile ? "100%" : 520}
+        // Below antd's default dialog layer (1000) so confirm/progress modals
+        // opened from inside this drawer always stack above it.
+        zIndex={990}
         open={featureModalOpen}
         onClose={() => setFeatureModalOpen(false)}
         destroyOnHidden
@@ -2467,7 +2470,7 @@ export default function KnowledgeBasesPage() {
         onCancel={dismissDownloadProgressToBackground}
         closable
         maskClosable
-        destroyOnClose={false}
+        destroyOnHidden={false}
         footer={
           <Button onClick={dismissDownloadProgressToBackground}>
             {t("models.localDownloadContinueBackground")}

--- a/dashboard/src/pages/Settings/Models/components/modals/ProviderConfigModal.tsx
+++ b/dashboard/src/pages/Settings/Models/components/modals/ProviderConfigModal.tsx
@@ -1076,7 +1076,7 @@ export function ProviderConfigModal({
         onCancel={dismissDownloadProgressToBackground}
         closable
         maskClosable
-        destroyOnClose={false}
+        destroyOnHidden={false}
         footer={
           <Button onClick={dismissDownloadProgressToBackground}>
             {t("models.localDownloadContinueBackground")}

--- a/src/octop/infra/agents/providers/onnx_download.py
+++ b/src/octop/infra/agents/providers/onnx_download.py
@@ -1,10 +1,13 @@
-"""Race Hugging Face and hf-mirror, then download from the winner."""
+"""Race COS, Hugging Face, and hf-mirror, then download from the winner."""
 
 from __future__ import annotations
 
+import json
 import logging
 import os
+import shutil
 import sys
+import tempfile
 import time
 from collections.abc import Callable
 from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
@@ -21,6 +24,12 @@ logger = logging.getLogger(__name__)
 
 HF_ENDPOINT_OFFICIAL = "https://huggingface.co"
 HF_ENDPOINT_MIRROR = "https://hf-mirror.com"
+# Same public bucket that hosts install.sh; objects live under /models/embedding/.
+COS_ENDPOINT_DEFAULT = "https://octop-1258344699.cos.ap-guangzhou.myqcloud.com"
+COS_PREFIX = "models/embedding"
+COS_MANIFEST_NAME = "files.json"
+COS_REVISION = "cos-mirror"
+_COS_BASE_ENV = "OCTOP_ONNX_COS_BASE"
 
 _PROBE_TIMEOUT_S = 4.0
 _USER_AGENT = "octop-onnx-download"
@@ -30,20 +39,29 @@ _HF_ALLOW_PATTERNS = (
     "tokenizer_config.json",
     "special_tokens_map.json",
     "preprocessor_config.json",
+    "vocab.txt",
+    "vocab.json",
+    "merges.txt",
+    "sentencepiece.bpe.model",
     "*.onnx",
+    "*.onnx_data",
     "onnx/*.onnx",
+    "onnx/*.onnx_data",
     "onnx/*.json",
 )
+# Extra ONNX variants in upstream repos; COS trees keep the primary weights only.
+_COS_SKIP_ONNX_NAMES = frozenset({"model_fp16.onnx", "model_quantized.onnx", "model_int8.onnx"})
 
 
 @dataclass(frozen=True)
 class DownloadCandidate:
-    """One Hugging Face endpoint that can be probed and then fetched."""
+    """One endpoint that can be probed and then fetched."""
 
     kind: str
     probe_url: str
     hf_endpoint: str
     hf_repo: str
+    model_name: str = ""
 
 
 ProbeFn = Callable[[str, float], float]
@@ -54,28 +72,59 @@ SnapshotProgressFn = Callable[[int, int | None, str], None]
 def _hf_repo_id(model_name: str) -> str:
     """Resolve the Hugging Face repo: catalog ``hf_source``, else the model id."""
     meta = get_onnx_model_meta(model_name)
-    hf_repo = meta.get("hf_source")
-    if not isinstance(hf_repo, str) or not hf_repo.strip():
-        hf_repo = model_name
-    return hf_repo.strip()
+    hf_source = meta.get("hf_source")
+    if not isinstance(hf_source, str) or not hf_source.strip():
+        return model_name.strip()
+    return hf_source.strip()
+
+
+def cos_base_url() -> str:
+    """Public COS origin; override with ``OCTOP_ONNX_COS_BASE`` for a private bucket."""
+    return os.environ.get(_COS_BASE_ENV, COS_ENDPOINT_DEFAULT).rstrip("/")
+
+
+def cos_object_key(model_name: str, rel_path: str = "") -> str:
+    """Return the COS object key under ``/models/embedding/{model_id}/``."""
+    prefix = f"{COS_PREFIX}/{model_name.strip().strip('/')}"
+    rel = rel_path.replace("\\", "/").lstrip("/")
+    return f"{prefix}/{rel}" if rel else prefix
+
+
+def cos_file_url(model_name: str, rel_path: str) -> str:
+    """HTTPS URL for one COS object in the embedding tree."""
+    return f"{cos_base_url()}/{cos_object_key(model_name, rel_path)}"
+
+
+def cos_local_model_dir(dest_root: Path, model_name: str) -> Path:
+    """Local directory that mirrors ``/models/embedding/{model_id}/``."""
+    return dest_root / COS_PREFIX / model_name.strip().strip("/")
 
 
 def build_download_candidates(model_name: str) -> list[DownloadCandidate]:
-    """Build official HF + hf-mirror candidates; URLs are inferred from the repo id."""
+    """Build COS + official HF + hf-mirror candidates."""
     hf_repo = _hf_repo_id(model_name)
     probe_file = "config.json"
     return [
+        DownloadCandidate(
+            kind="cos",
+            probe_url=cos_file_url(model_name, probe_file),
+            hf_endpoint="",
+            hf_repo=hf_repo,
+            model_name=model_name,
+        ),
         DownloadCandidate(
             kind="hf",
             probe_url=f"{HF_ENDPOINT_OFFICIAL}/{hf_repo}/resolve/main/{probe_file}",
             hf_endpoint=HF_ENDPOINT_OFFICIAL,
             hf_repo=hf_repo,
+            model_name=model_name,
         ),
         DownloadCandidate(
             kind="hf-mirror",
             probe_url=f"{HF_ENDPOINT_MIRROR}/{hf_repo}/resolve/main/{probe_file}",
             hf_endpoint=HF_ENDPOINT_MIRROR,
             hf_repo=hf_repo,
+            model_name=model_name,
         ),
     ]
 
@@ -134,7 +183,7 @@ def race_download_sources(
     """
     if not candidates:
         return []
-    pool = ThreadPoolExecutor(max_workers=min(len(candidates), 2))
+    pool = ThreadPoolExecutor(max_workers=min(len(candidates), 3))
     try:
         futures = {pool.submit(probe, cand.probe_url, timeout_s): cand for cand in candidates}
         result = _first_probe_success(futures)
@@ -166,7 +215,7 @@ def download_model_raced(
     errors: list[str] = []
     for cand in ordered:
         try:
-            _download_hf_snapshot(cand, cache_dir, on_progress=on_progress)
+            _download_candidate(cand, cache_dir, on_progress=on_progress)
             logger.info("ONNX model %s downloaded from %s", model_name, cand.kind)
             return cand.kind
         except Exception as exc:
@@ -174,6 +223,18 @@ def download_model_raced(
             errors.append(f"{cand.kind}: {exc}")
     detail = "; ".join(errors) if errors else "no sources"
     raise RuntimeError(f"All embedding download sources failed: {detail}")
+
+
+def _download_candidate(
+    cand: DownloadCandidate,
+    cache_dir: Path,
+    *,
+    on_progress: SnapshotProgressFn | None = None,
+) -> None:
+    if cand.kind == "cos":
+        _download_cos_snapshot(cand, cache_dir, on_progress=on_progress)
+        return
+    _download_hf_snapshot(cand, cache_dir, on_progress=on_progress)
 
 
 def _progress_tqdm(on_progress: SnapshotProgressFn) -> type[Any] | None:
@@ -230,3 +291,167 @@ def _download_hf_snapshot(
             allow_patterns=list(_HF_ALLOW_PATTERNS),
             tqdm_class=tqdm_cls,
         )
+
+
+def _safe_rel_path(raw: str) -> str:
+    """Reject empty, absolute, or parent-escaping object paths."""
+    rel = raw.replace("\\", "/").strip().lstrip("/")
+    if not rel or rel.startswith("../") or "/../" in f"/{rel}/" or rel == "..":
+        raise ValueError(f"unsafe COS object path: {raw!r}")
+    return rel
+
+
+def _manifest_files(payload: object) -> list[str]:
+    raw_files: object
+    if isinstance(payload, list):
+        raw_files = payload
+    elif isinstance(payload, dict):
+        raw_files = payload.get("files")
+    else:
+        raise ValueError("COS manifest must be an object or a file list")
+    if not isinstance(raw_files, list) or not raw_files:
+        raise ValueError("COS manifest has no files")
+    files: list[str] = []
+    for item in raw_files:
+        if isinstance(item, str):
+            files.append(_safe_rel_path(item))
+            continue
+        if isinstance(item, dict):
+            path = item.get("path")
+            if isinstance(path, str) and path.strip():
+                files.append(_safe_rel_path(path))
+                continue
+        raise ValueError(f"invalid COS manifest entry: {item!r}")
+    return files
+
+
+def write_cos_manifest(model_dir: Path, *, model_id: str, hf_repo: str) -> Path:
+    """Write ``files.json`` listing every file under *model_dir* except the manifest."""
+    files = sorted(
+        path.relative_to(model_dir).as_posix()
+        for path in model_dir.rglob("*")
+        if path.is_file() and path.name != COS_MANIFEST_NAME
+    )
+    payload = {"model_id": model_id, "hf_repo": hf_repo, "files": files}
+    dest = model_dir / COS_MANIFEST_NAME
+    dest.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    return dest
+
+
+def hf_cache_snapshot_dir(cache_dir: Path, hf_repo: str, *, revision: str = COS_REVISION) -> Path:
+    """Create a Hugging Face cache snapshot that ``huggingface_hub`` will reuse."""
+    repo_dir = cache_dir / ("models--" + hf_repo.replace("/", "--"))
+    refs = repo_dir / "refs"
+    refs.mkdir(parents=True, exist_ok=True)
+    (refs / "main").write_text(revision + "\n", encoding="utf-8")
+    dest = repo_dir / "snapshots" / revision
+    dest.mkdir(parents=True, exist_ok=True)
+    return dest
+
+
+def _download_http_file(
+    client: httpx.Client,
+    url: str,
+    dest: Path,
+    *,
+    on_progress: SnapshotProgressFn | None,
+    downloaded_so_far: int,
+    total: int | None,
+) -> int:
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    tmp = dest.with_name(dest.name + ".part")
+    written = 0
+    with client.stream("GET", url) as response:
+        response.raise_for_status()
+        with tmp.open("wb") as handle:
+            for chunk in response.iter_bytes(64 * 1024):
+                handle.write(chunk)
+                written += len(chunk)
+                if on_progress is not None:
+                    on_progress(downloaded_so_far + written, total, dest.name)
+    tmp.replace(dest)
+    return written
+
+
+def _download_cos_snapshot(
+    cand: DownloadCandidate,
+    cache_dir: Path,
+    *,
+    on_progress: SnapshotProgressFn | None = None,
+) -> None:
+    model_name = cand.model_name or cand.hf_repo
+    if not model_name:
+        raise RuntimeError("COS download is missing a model id")
+    logger.info("ONNX COS snapshot %s via %s", model_name, cand.kind)
+    timeout = httpx.Timeout(120.0, connect=10.0)
+    with httpx.Client(
+        timeout=timeout,
+        follow_redirects=True,
+        headers={"User-Agent": _USER_AGENT},
+    ) as client:
+        manifest = client.get(cos_file_url(model_name, COS_MANIFEST_NAME))
+        manifest.raise_for_status()
+        files = _manifest_files(manifest.json())
+        dest = hf_cache_snapshot_dir(cache_dir, cand.hf_repo or model_name)
+        downloaded = 0
+        for rel in files:
+            written = _download_http_file(
+                client,
+                cos_file_url(model_name, rel),
+                dest / rel,
+                on_progress=on_progress,
+                downloaded_so_far=downloaded,
+                total=None,
+            )
+            downloaded += written
+    if not any(dest.rglob("*.onnx")):
+        raise RuntimeError(f"COS snapshot for {model_name} has no ONNX weights")
+
+
+def export_model_tree_for_cos(
+    model_name: str,
+    dest_root: Path,
+    *,
+    hf_endpoint: str = HF_ENDPOINT_MIRROR,
+    on_progress: SnapshotProgressFn | None = None,
+) -> Path:
+    """Download *model_name* and write the COS object tree under *dest_root*.
+
+    Layout: ``{dest_root}/models/embedding/{model_id}/…`` plus ``files.json``.
+    """
+    _disable_hf_xet()
+    try:
+        from huggingface_hub import snapshot_download
+    except ImportError as exc:
+        raise RuntimeError("huggingface_hub is required to stage COS model trees") from exc
+    hf_repo = _hf_repo_id(model_name)
+    dest = cos_local_model_dir(dest_root, model_name)
+    tqdm_cls = _progress_tqdm(on_progress) if on_progress is not None else None
+    with tempfile.TemporaryDirectory(prefix="octop-onnx-cos-") as tmp:
+        snapshot = Path(
+            snapshot_download(
+                repo_id=hf_repo,
+                cache_dir=tmp,
+                endpoint=hf_endpoint,
+                allow_patterns=list(_HF_ALLOW_PATTERNS),
+                ignore_patterns=[f"**/{name}" for name in _COS_SKIP_ONNX_NAMES],
+                tqdm_class=tqdm_cls,
+            )
+        )
+        if dest.exists():
+            shutil.rmtree(dest)
+        dest.mkdir(parents=True, exist_ok=True)
+        for path in snapshot.rglob("*"):
+            if not path.is_file():
+                continue
+            rel = path.relative_to(snapshot)
+            if rel.as_posix().startswith("."):
+                continue
+            if path.name in _COS_SKIP_ONNX_NAMES:
+                continue
+            target = dest / rel
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(path, target)
+    write_cos_manifest(dest, model_id=model_name, hf_repo=hf_repo)
+    logger.info("Staged COS tree for %s at %s", model_name, dest)
+    return dest

--- a/src/octop/infra/agents/providers/onnx_download.py
+++ b/src/octop/infra/agents/providers/onnx_download.py
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 
 HF_ENDPOINT_OFFICIAL = "https://huggingface.co"
 HF_ENDPOINT_MIRROR = "https://hf-mirror.com"
-# Same public bucket that hosts install.sh; objects live under /models/embedding/.
+# Public COS bucket; objects live under /models/embedding/{model_id}/.
 COS_ENDPOINT_DEFAULT = "https://octop-1258344699.cos.ap-guangzhou.myqcloud.com"
 COS_PREFIX = "models/embedding"
 COS_MANIFEST_NAME = "files.json"

--- a/tests/unit/agents/test_onnx_download.py
+++ b/tests/unit/agents/test_onnx_download.py
@@ -2,19 +2,25 @@
 
 from __future__ import annotations
 
+import json
 import os
 import sys
 import threading
 import time
 from pathlib import Path
 
+import httpx
+
 from octop.infra.agents.providers.onnx_catalog import get_onnx_model_meta
 from octop.infra.agents.providers.onnx_download import (
+    COS_ENDPOINT_DEFAULT,
     HF_ENDPOINT_MIRROR,
     HF_ENDPOINT_OFFICIAL,
     DownloadCandidate,
     build_download_candidates,
+    cos_file_url,
     download_model_raced,
+    export_model_tree_for_cos,
     race_download_sources,
 )
 
@@ -28,20 +34,24 @@ def test_bge_small_zh_infers_hf_repo_without_fastembed(monkeypatch) -> None:
     assert "direct_url" not in meta
 
 
-def test_candidates_are_hf_and_mirror_with_inferred_urls(monkeypatch) -> None:
+def test_candidates_are_cos_hf_and_mirror_with_inferred_urls(monkeypatch) -> None:
     from octop.infra.agents.providers import onnx_catalog as catalog
 
     monkeypatch.setattr(catalog, "_fastembed_meta_map", lambda: {})
     cands = build_download_candidates("BAAI/bge-small-zh-v1.5")
-    assert [c.kind for c in cands] == ["hf", "hf-mirror"]
+    assert [c.kind for c in cands] == ["cos", "hf", "hf-mirror"]
     assert cands[0].probe_url == (
-        f"{HF_ENDPOINT_OFFICIAL}/Qdrant/bge-small-zh-v1.5/resolve/main/config.json"
+        f"{COS_ENDPOINT_DEFAULT}/models/embedding/BAAI/bge-small-zh-v1.5/config.json"
     )
     assert cands[1].probe_url == (
+        f"{HF_ENDPOINT_OFFICIAL}/Qdrant/bge-small-zh-v1.5/resolve/main/config.json"
+    )
+    assert cands[2].probe_url == (
         f"{HF_ENDPOINT_MIRROR}/Qdrant/bge-small-zh-v1.5/resolve/main/config.json"
     )
-    assert cands[0].hf_endpoint == HF_ENDPOINT_OFFICIAL
-    assert cands[1].hf_endpoint == HF_ENDPOINT_MIRROR
+    assert cands[0].hf_repo == "Qdrant/bge-small-zh-v1.5"
+    assert cands[1].hf_endpoint == HF_ENDPOINT_OFFICIAL
+    assert cands[2].hf_endpoint == HF_ENDPOINT_MIRROR
 
 
 def test_unknown_model_uses_model_id_as_hf_repo(monkeypatch) -> None:
@@ -49,12 +59,13 @@ def test_unknown_model_uses_model_id_as_hf_repo(monkeypatch) -> None:
 
     monkeypatch.setattr(catalog, "_fastembed_meta_map", lambda: {})
     cands = build_download_candidates("jinaai/jina-embeddings-v2-base-zh")
-    assert [c.kind for c in cands] == ["hf", "hf-mirror"]
-    assert cands[0].hf_repo == "jinaai/jina-embeddings-v2-base-zh"
-    assert cands[0].probe_url.startswith(
+    assert [c.kind for c in cands] == ["cos", "hf", "hf-mirror"]
+    assert cands[1].hf_repo == "jinaai/jina-embeddings-v2-base-zh"
+    assert cands[0].probe_url == cos_file_url("jinaai/jina-embeddings-v2-base-zh", "config.json")
+    assert cands[1].probe_url.startswith(
         f"{HF_ENDPOINT_OFFICIAL}/jinaai/jina-embeddings-v2-base-zh/"
     )
-    assert cands[1].probe_url.startswith(f"{HF_ENDPOINT_MIRROR}/jinaai/jina-embeddings-v2-base-zh/")
+    assert cands[2].probe_url.startswith(f"{HF_ENDPOINT_MIRROR}/jinaai/jina-embeddings-v2-base-zh/")
 
 
 def test_race_orders_by_ttfb_and_skips_failures() -> None:
@@ -243,3 +254,149 @@ def test_snapshot_disables_xet_before_hub_import(monkeypatch, tmp_path: Path) ->
     assert seen["env"] == "1"
     assert seen["const"] is True
     assert seen["endpoint"] == HF_ENDPOINT_MIRROR
+
+
+def test_cos_base_env_override(monkeypatch) -> None:
+    monkeypatch.setenv("OCTOP_ONNX_COS_BASE", "https://example-cos.example.com/")
+    assert cos_file_url("BAAI/bge-small-zh-v1.5", "config.json") == (
+        "https://example-cos.example.com/models/embedding/BAAI/bge-small-zh-v1.5/config.json"
+    )
+
+
+def test_cos_download_writes_hf_cache(monkeypatch, tmp_path: Path) -> None:
+    from octop.infra.agents.providers.onnx_download import _download_cos_snapshot
+
+    files = {
+        "files.json": json.dumps(
+            {
+                "model_id": "BAAI/bge-small-zh-v1.5",
+                "hf_repo": "Qdrant/bge-small-zh-v1.5",
+                "files": ["config.json", "model.onnx"],
+            }
+        ).encode(),
+        "config.json": b'{"hidden_size": 512}',
+        "model.onnx": b"onnx-bytes",
+    }
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        name = request.url.path.rsplit("/", 1)[-1]
+        body = files.get(name)
+        if body is None:
+            return httpx.Response(404, request=request)
+        return httpx.Response(200, content=body, request=request)
+
+    real_client = httpx.Client
+    monkeypatch.setattr(
+        httpx,
+        "Client",
+        lambda **_kwargs: real_client(transport=httpx.MockTransport(handler)),
+    )
+    cache = tmp_path / "cache"
+    _download_cos_snapshot(
+        DownloadCandidate(
+            kind="cos",
+            probe_url="http://cos/config.json",
+            hf_endpoint="",
+            hf_repo="Qdrant/bge-small-zh-v1.5",
+            model_name="BAAI/bge-small-zh-v1.5",
+        ),
+        cache,
+    )
+    snapshot = cache / "models--Qdrant--bge-small-zh-v1.5" / "snapshots" / "cos-mirror"
+    assert (snapshot / "config.json").read_text(encoding="utf-8") == '{"hidden_size": 512}'
+    assert (snapshot / "model.onnx").read_bytes() == b"onnx-bytes"
+    assert (cache / "models--Qdrant--bge-small-zh-v1.5" / "refs" / "main").read_text(
+        encoding="utf-8"
+    ).strip() == "cos-mirror"
+
+
+def test_cos_download_rejects_parent_paths(monkeypatch, tmp_path: Path) -> None:
+    from octop.infra.agents.providers.onnx_download import _download_cos_snapshot
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("files.json"):
+            return httpx.Response(
+                200,
+                content=json.dumps({"files": ["../escape.onnx"]}).encode(),
+                request=request,
+            )
+        return httpx.Response(404, request=request)
+
+    real_client = httpx.Client
+    monkeypatch.setattr(
+        httpx,
+        "Client",
+        lambda **_kwargs: real_client(transport=httpx.MockTransport(handler)),
+    )
+    try:
+        _download_cos_snapshot(
+            DownloadCandidate(
+                kind="cos",
+                probe_url="http://cos/config.json",
+                hf_endpoint="",
+                hf_repo="Qdrant/bge-small-zh-v1.5",
+                model_name="BAAI/bge-small-zh-v1.5",
+            ),
+            tmp_path,
+        )
+    except ValueError as exc:
+        assert "unsafe" in str(exc)
+    else:
+        raise AssertionError("expected unsafe COS path to fail")
+
+
+def test_download_raced_uses_cos_winner(monkeypatch, tmp_path: Path) -> None:
+    from octop.infra.agents.providers import onnx_download as mod
+
+    cands = [
+        DownloadCandidate(
+            kind="cos",
+            probe_url="http://cos",
+            hf_endpoint="",
+            hf_repo="Qdrant/bge-small-zh-v1.5",
+            model_name="BAAI/bge-small-zh-v1.5",
+        ),
+        DownloadCandidate(
+            kind="hf",
+            probe_url="http://hf",
+            hf_endpoint=HF_ENDPOINT_OFFICIAL,
+            hf_repo="Qdrant/bge-small-zh-v1.5",
+        ),
+    ]
+    tried: list[str] = []
+    monkeypatch.setattr(mod, "build_download_candidates", lambda _name: cands)
+    monkeypatch.setattr(mod, "race_download_sources", lambda items, **_kw: items)
+
+    def fake_cos(cand: DownloadCandidate, cache_dir: Path, **_kwargs: object) -> None:
+        del cache_dir
+        tried.append(cand.kind)
+
+    monkeypatch.setattr(mod, "_download_cos_snapshot", fake_cos)
+    winner = download_model_raced("BAAI/bge-small-zh-v1.5", tmp_path)
+    assert winner == "cos"
+    assert tried == ["cos"]
+
+
+def test_export_model_tree_writes_manifest(monkeypatch, tmp_path: Path) -> None:
+    from octop.infra.agents.providers import onnx_catalog as catalog
+
+    monkeypatch.setattr(catalog, "_fastembed_meta_map", lambda: {})
+    snapshot = tmp_path / "snap"
+    snapshot.mkdir()
+    (snapshot / "config.json").write_text("{}", encoding="utf-8")
+    (snapshot / "model.onnx").write_bytes(b"onnx")
+
+    import types
+
+    hub = sys.modules.get("huggingface_hub")
+    if hub is None:
+        hub = types.ModuleType("huggingface_hub")
+        monkeypatch.setitem(sys.modules, "huggingface_hub", hub)
+    monkeypatch.setattr(hub, "snapshot_download", lambda **_kwargs: str(snapshot), raising=False)
+
+    dest = export_model_tree_for_cos("BAAI/bge-small-zh-v1.5", tmp_path / "out")
+    assert dest == tmp_path / "out" / "models" / "embedding" / "BAAI" / "bge-small-zh-v1.5"
+    manifest = json.loads((dest / "files.json").read_text(encoding="utf-8"))
+    assert manifest["model_id"] == "BAAI/bge-small-zh-v1.5"
+    assert manifest["hf_repo"] == "Qdrant/bge-small-zh-v1.5"
+    assert set(manifest["files"]) == {"config.json", "model.onnx"}


### PR DESCRIPTION
## Summary

- Add Tencent COS as a raced source for local ONNX embedding downloads, probing it alongside Hugging Face and hf-mirror so the fastest reachable origin wins.
- Fetch COS objects from `files.json` into the Hugging Face cache layout (`models--{hf_repo}/snapshots/cos-mirror/`) so fastembed can load them without a second network hop; fall back to HF sources if COS fails.
- Allow overriding the public bucket with `OCTOP_ONNX_COS_BASE`, and add a helper to stage COS trees plus tests for URL construction, cache layout, path safety, and winner fallback.

## Target branch

- [x] Base is **`develop`** (feature / fix — default)
- [ ] Base is **`main`** (`release/*` or `hotfix/*` only)

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / chore
- [ ] Release / hotfix

## Test plan

- `uv run pytest tests/unit/agents/test_onnx_download.py -q` — 13 passed
- Live race of `BAAI/bge-small-zh-v1.5` against the public COS bucket succeeded with winner `cos`

- [ ] `make all` passes locally
- [x] Added/updated tests

## Checklist

- [ ] Updated `CHANGELOG.md` (if user-facing)
- [ ] README / docs updated (if needed)