### PR TITLE
style(desktop): apply Ruff formatting to portable launch scripts

### DIFF
--- a/desktop/portable/templates/launch.py
+++ b/desktop/portable/templates/launch.py
@@ -4,8 +4,10 @@ Using plain ``PYTHONPATH=packages`` skips ``.pth`` processing (pywin32 etc.).
 ``site.addsitedir`` loads those hooks. On Windows we also expose
 ``pywin32_system32`` DLLs so ``import pywintypes`` works.
 """
+
 from __future__ import annotations
 
+import contextlib
 import os
 import runpy
 import site
@@ -43,10 +45,8 @@ def _bootstrap() -> Path:
             # Python 3.8+: prefer explicit DLL search path.
             add_dll = getattr(os, "add_dll_directory", None)
             if add_dll is not None:
-                try:
+                with contextlib.suppress(OSError):
                     add_dll(dll_s)
-                except OSError:
-                    pass
     return root
 
 

--- a/desktop/portable/verify_imports.py
+++ b/desktop/portable/verify_imports.py
@@ -7,6 +7,7 @@ Usage:
     --requirements desktop/portable/requirements-<plat>.txt \\
     [--overrides desktop/portable/overrides-<plat>.txt]
 """
+
 from __future__ import annotations
 
 import argparse
@@ -17,9 +18,7 @@ import site
 import sys
 from pathlib import Path
 
-_REQ_RE = re.compile(
-    r"^(?P<name>[A-Za-z0-9][A-Za-z0-9._-]*)(?:\s*==\s*(?P<ver>[^\s;#]+))?"
-)
+_REQ_RE = re.compile(r"^(?P<name>[A-Za-z0-9][A-Za-z0-9._-]*)(?:\s*==\s*(?P<ver>[^\s;#]+))?")
 
 # Import names that have historically drifted across lock/install environments.
 _SMOKE_IMPORTS = (


### PR DESCRIPTION
## Summary
- Apply remaining Ruff formatting on portable desktop scripts (`launch.py`, `verify_imports.py`).
- No behavior change: extra blank line after module docstring, `contextlib.suppress` for DLL path registration, and a wrapped regex collapsed to one line.

## Test plan
- [x] `git commit` pre-commit (`make precommit` + dashboard build) green
- [ ] Confirm portable Windows/Linux launch still bootstraps `packages/`


Made with [Cursor](https://cursor.com)