### PR TITLE
feat: optimize AskQuestionCard UI and knowledge parsing

### DIFF
--- a/dashboard/src/locales/en.json
+++ b/dashboard/src/locales/en.json
@@ -1281,6 +1281,8 @@
       "submit": "Send answers",
       "skip": "You decide",
       "skipMessage": "You decide — pick the best default and tell me what you assumed.",
+      "dismiss": "Close",
+      "dismissMessage": "The user closed these questions without answering. Do not ask again — wrap up this turn.",
       "answered": "Answered",
       "answeredSummary": "Answered {{count}} question(s)",
       "dismissedSummary": "Closed {{count}} question(s)",

--- a/dashboard/src/locales/zh.json
+++ b/dashboard/src/locales/zh.json
@@ -1281,6 +1281,8 @@
       "submit": "提交回答",
       "skip": "你决定",
       "skipMessage": "你决定吧——按最优默认方案继续，并告诉我你依据的假设。",
+      "dismiss": "关闭",
+      "dismissMessage": "用户关闭了这些问题，没有作答。不要再追问，请就此结束本轮。",
       "answered": "已回答",
       "answeredSummary": "已回答 {{count}} 个问题",
       "dismissedSummary": "已关闭 {{count}} 个问题",

--- a/dashboard/src/pages/Chat/components/AskQuestionCard.module.less
+++ b/dashboard/src/pages/Chat/components/AskQuestionCard.module.less
@@ -22,6 +22,39 @@
   color: var(--fn-text-primary);
 }
 
+.titleActions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.closeButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: none;
+  border-radius: var(--fn-radius-sm);
+  background: transparent;
+  color: var(--fn-text-tertiary);
+  cursor: pointer;
+  transition:
+    color var(--fn-transition-fast),
+    background var(--fn-transition-fast);
+
+  &:hover {
+    color: var(--fn-text-secondary);
+    background: var(--fn-bg-secondary);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--fn-color-brand);
+    outline-offset: 2px;
+  }
+}
+
 .progress {
   padding: 2px 8px;
   border: 1px solid var(--fn-border-secondary);

--- a/dashboard/src/pages/Chat/components/AskQuestionCard.test.tsx
+++ b/dashboard/src/pages/Chat/components/AskQuestionCard.test.tsx
@@ -79,6 +79,24 @@ describe("AskQuestionCard", () => {
     expect(screen.queryByText("chat.ask.other")).not.toBeInTheDocument();
   });
 
+  it("closes the card without answering", () => {
+    const onSubmit = vi.fn();
+    const onDismiss = vi.fn();
+    render(
+      <AskQuestionCard
+        questions={questions}
+        status="pending"
+        onSubmit={onSubmit}
+        onDismiss={onDismiss}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "chat.ask.dismiss" }));
+
+    expect(onDismiss).toHaveBeenCalledOnce();
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
   it("collapses an answered question set in message history", () => {
     const { container } = render(
       <AskQuestionCard questions={questions} status="approved" />,

--- a/dashboard/src/pages/Chat/components/AskQuestionCard.tsx
+++ b/dashboard/src/pages/Chat/components/AskQuestionCard.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { Input } from "antd";
+import { X } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import type { AskQuestion } from "../../../api/types/hitl";
 import styles from "./AskQuestionCard.module.less";
@@ -15,6 +16,8 @@ export interface AskQuestionCardProps {
   questions: AskQuestion[];
   status: "pending" | "approved" | "rejected";
   onSubmit?: (message: string) => void;
+  /** Close the card without answering, ending the pause. */
+  onDismiss?: () => void;
 }
 
 /** What the user picked for one question. */
@@ -150,6 +153,7 @@ function AskQuestionCard({
   questions,
   status,
   onSubmit,
+  onDismiss,
 }: AskQuestionCardProps) {
   const { t } = useTranslation();
   const interactive = status === "pending" && Boolean(onSubmit);
@@ -233,8 +237,21 @@ function AskQuestionCard({
     <div className={styles.card}>
       <div className={styles.titleRow}>
         <span className={styles.title}>{t("chat.ask.title")}</span>
-        <span className={styles.progress}>
-          {reviewing ? t("chat.ask.reviewTag") : `${current + 1} / ${total}`}
+        <span className={styles.titleActions}>
+          <span className={styles.progress}>
+            {reviewing ? t("chat.ask.reviewTag") : `${current + 1} / ${total}`}
+          </span>
+          {onDismiss ? (
+            <button
+              type="button"
+              className={styles.closeButton}
+              onClick={onDismiss}
+              title={t("chat.ask.dismiss")}
+              aria-label={t("chat.ask.dismiss")}
+            >
+              <X size={15} />
+            </button>
+          ) : null}
         </span>
       </div>
 

--- a/dashboard/src/pages/Chat/hooks/chatStore.ts
+++ b/dashboard/src/pages/Chat/hooks/chatStore.ts
@@ -2160,12 +2160,14 @@ export async function resumeHitl(
   threadId: string,
   decisions: Array<{ type: string; message?: string }>,
   onStreamEnd?: () => void,
+  dismissed = false,
 ): Promise<void> {
   const state = getOrCreate(sessionId);
   state.abortController?.abort();
-  const hitlStatus = decisions.some((d) => d.type === "reject")
-    ? "rejected"
-    : "approved";
+  const hitlStatus =
+    dismissed || decisions.some((d) => d.type === "reject")
+      ? "rejected"
+      : "approved";
   resolveHitlPending(state, hitlStatus);
   beginStream(state, sessionId);
   notify(state);

--- a/dashboard/src/pages/Chat/hooks/useChat.ts
+++ b/dashboard/src/pages/Chat/hooks/useChat.ts
@@ -1058,15 +1058,23 @@ export function useChat(
     (
       decisions: Array<{ type: string; message?: string }>,
       storeKey?: string,
+      dismissed?: boolean,
     ) => {
       if (!agentId) return;
       const key = storeKey || stableSessionId;
       const threadId =
         storeKey || (stableSessionId !== "__empty__" ? stableSessionId : "");
       if (!threadId || threadId === "__empty__") return;
-      void chatStore.resumeHitl(key, agentId, threadId, decisions, () => {
-        void refreshHistory(threadId);
-      });
+      void chatStore.resumeHitl(
+        key,
+        agentId,
+        threadId,
+        decisions,
+        () => {
+          void refreshHistory(threadId);
+        },
+        dismissed,
+      );
     },
     [agentId, stableSessionId, refreshHistory],
   );

--- a/dashboard/src/pages/Chat/index.tsx
+++ b/dashboard/src/pages/Chat/index.tsx
@@ -684,6 +684,22 @@ function ChatPageInner() {
     [resumeHitl, activeThreadId],
   );
 
+  /** Close an ask pause without answering: ``respond`` is the only decision
+   *  the agent allows for ``ask_user_question``, so tell it to wrap up. */
+  const handleAskDismiss = useCallback(
+    (actions: unknown[]) => {
+      resumeHitl(
+        actions.map(() => ({
+          type: "respond",
+          message: t("chat.ask.dismissMessage"),
+        })),
+        activeThreadId ?? undefined,
+        true,
+      );
+    },
+    [resumeHitl, activeThreadId, t],
+  );
+
   useEffect(() => {
     let cancelled = false;
     browserApi
@@ -1291,6 +1307,7 @@ function ChatPageInner() {
                         })),
                       )
                     }
+                    onDismiss={() => handleAskDismiss(pendingAsk.actions)}
                   />
                 </div>
               </div>

--- a/src/octop/infra/knowledge/parse.py
+++ b/src/octop/infra/knowledge/parse.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 import csv
+import io
 import json
 from collections.abc import Iterable
 from html.parser import HTMLParser
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from octop.infra.knowledge.ocr import OCR_IMAGE_SUFFIXES
 
@@ -23,6 +24,9 @@ _PLAIN_TEXT_SUFFIXES = {
     ".yml",
     ".jsonl",
 }
+_DOCX_FALLBACK_TAG = "{http://schemas.openxmlformats.org/markup-compatibility/2006}Fallback"
+_DOCX_HTML_TYPES = {"application/xhtml+xml", "text/html"}
+_DOCX_MAIN_TYPE = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
 
 
 def parse_document(path: Path, *, ocr: OcrExtractor | None = None) -> str:
@@ -50,9 +54,7 @@ def parse_document(path: Path, *, ocr: OcrExtractor | None = None) -> str:
             return text
         return ocr(path)
     if suffix == ".docx":
-        from docx import Document
-
-        return "\n".join(paragraph.text for paragraph in Document(str(path)).paragraphs)
+        return _parse_docx(path)
     if suffix == ".pptx":
         from pptx import Presentation
 
@@ -82,9 +84,67 @@ def _parse_json(path: Path) -> str:
     return json.dumps(parsed, ensure_ascii=False, indent=2)
 
 
+def _parse_docx(path: Path) -> str:
+    from docx import Document
+
+    document = Document(str(path))
+    return _docx_body_text(document.element.body, document.part)
+
+
+def _docx_body_text(body: Any, part: Any) -> str:
+    """Collect every ``w:p`` and ``w:altChunk`` in a body, in document order.
+
+    ``Document.paragraphs`` only lists ``w:p`` children of ``w:body``, so text inside
+    tables, content controls (``w:sdt``), revision wrappers (``w:ins``), and text boxes
+    is silently dropped. ``mc:Fallback`` duplicates its ``mc:Choice`` sibling, so its
+    paragraphs are skipped.
+    """
+    from docx.oxml.ns import qn
+
+    alt_chunk_tag = qn("w:altChunk")
+    lines: list[str] = []
+    for element in body.iter(qn("w:p"), alt_chunk_tag):
+        if next(element.iterancestors(_DOCX_FALLBACK_TAG), None) is not None:
+            continue
+        if element.tag == alt_chunk_tag:
+            lines.append(_docx_alt_chunk_text(element, part))
+        else:
+            lines.append(element.text)
+    return "\n".join(lines)
+
+
+def _docx_alt_chunk_text(element: Any, part: Any) -> str:
+    """Expand a ``w:altChunk`` reference the way Word does when opening the file.
+
+    Converters keep the bulk of the text in an embedded HTML or Word part and leave
+    only a stub in ``document.xml``; unexpanded, that body is lost.
+    """
+    from docx.oxml.ns import qn
+
+    chunk = part.related_parts.get(element.get(qn("r:id")) or "")
+    if chunk is None:
+        return ""
+    content_type = str(chunk.content_type)
+    blob: bytes = chunk.blob
+    if content_type in _DOCX_HTML_TYPES:
+        return _html_text(blob.decode("utf-8-sig", errors="replace"))
+    if content_type == "text/plain":
+        return blob.decode("utf-8-sig", errors="replace")
+    if content_type == _DOCX_MAIN_TYPE:
+        from docx import Document
+
+        nested = Document(io.BytesIO(blob))
+        return _docx_body_text(nested.element.body, nested.part)
+    return ""
+
+
 def _parse_html(path: Path) -> str:
+    return _html_text(_read_text(path))
+
+
+def _html_text(raw: str) -> str:
     parser = _HTMLTextParser()
-    parser.feed(_read_text(path))
+    parser.feed(raw)
     parser.close()
     lines = [" ".join(line.split()) for line in parser.text().splitlines()]
     return "\n".join(line for line in lines if line)

--- a/tests/unit/knowledge/test_parse.py
+++ b/tests/unit/knowledge/test_parse.py
@@ -2,11 +2,64 @@
 
 from __future__ import annotations
 
+import io
+import zipfile
 from pathlib import Path
 
 import pytest
 
 from octop.infra.knowledge.parse import parse_document
+
+_DOCX_NAMESPACES = (
+    'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" '
+    'xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" '
+    'xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" '
+    'xmlns:wps="http://schemas.microsoft.com/office/word/2010/wordprocessingShape" '
+    'xmlns:v="urn:schemas-microsoft-com:vml"'
+)
+_DOCX_MAIN_TYPE = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+_ALT_CHUNK_RELATIONSHIP = (
+    '<Relationship Id="rId99" Target="../{name}" '
+    'Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/aFChunk"/>'
+)
+
+
+def _docx_paragraph(text: str) -> str:
+    return f"<w:p><w:r><w:t>{text}</w:t></w:r></w:p>"
+
+
+def _docx_with_body(
+    path: Path, body_xml: str, *, alt_chunk: tuple[str, str, bytes] | None = None
+) -> Path:
+    """Write a .docx whose ``w:body`` holds *body_xml* verbatim.
+
+    *alt_chunk* is ``(part_name, content_type, blob)`` for a part related as ``rId99``,
+    matching what converters emit for ``<w:altChunk r:id="rId99"/>``.
+    """
+    from docx import Document
+
+    Document().save(path)
+    document = f"<w:document {_DOCX_NAMESPACES}><w:body>{body_xml}</w:body></w:document>".encode()
+    with zipfile.ZipFile(path) as source:
+        entries = [(info.filename, source.read(info.filename)) for info in source.infolist()]
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as target:
+        for name, data in entries:
+            if name == "word/document.xml":
+                data = document
+            elif alt_chunk is not None and name == "word/_rels/document.xml.rels":
+                relationship = _ALT_CHUNK_RELATIONSHIP.format(name=alt_chunk[0])
+                data = data.replace(
+                    b"</Relationships>", relationship.encode() + b"</Relationships>"
+                )
+            elif alt_chunk is not None and name == "[Content_Types].xml":
+                override = f'<Override PartName="/{alt_chunk[0]}" ContentType="{alt_chunk[1]}"/>'
+                data = data.replace(b"</Types>", override.encode() + b"</Types>")
+            target.writestr(name, data)
+        if alt_chunk is not None:
+            target.writestr(alt_chunk[0], alt_chunk[2])
+    path.write_bytes(buffer.getvalue())
+    return path
 
 
 def test_parse_plain_text_and_markdown(tmp_path: Path) -> None:
@@ -43,6 +96,55 @@ def test_parse_pdf_docx_and_pptx(tmp_path: Path) -> None:
     assert parse_document(pdf) == ""
     assert parse_document(docx) == "Word notes"
     assert parse_document(pptx) == "Slide title"
+
+
+def test_parse_docx_reads_tables_content_controls_and_revisions(tmp_path: Path) -> None:
+    body = (
+        _docx_paragraph("发布说明")
+        + "<w:p/>"
+        + f"<w:tbl><w:tr><w:tc>{_docx_paragraph('第一章 总则')}</w:tc></w:tr></w:tbl>"
+        + f"<w:sdt><w:sdtContent>{_docx_paragraph('第一条 为了规范')}</w:sdtContent></w:sdt>"
+        + '<w:ins w:id="1" w:author="u" w:date="2026-08-27T00:00:00Z">'
+        + f"{_docx_paragraph('第二条 本办法适用于')}</w:ins>"
+    )
+    path = _docx_with_body(tmp_path / "nested.docx", body)
+
+    assert parse_document(path) == "发布说明\n\n第一章 总则\n第一条 为了规范\n第二条 本办法适用于"
+
+
+def test_parse_docx_reads_text_box_once(tmp_path: Path) -> None:
+    text_box = f"<w:txbxContent>{_docx_paragraph('文本框内容')}</w:txbxContent>"
+    body = _docx_paragraph("正文段落") + (
+        "<w:p><w:r><mc:AlternateContent>"
+        f'<mc:Choice Requires="wps"><wps:txbx>{text_box}</wps:txbx></mc:Choice>'
+        f"<mc:Fallback><v:textbox>{text_box}</v:textbox></mc:Fallback>"
+        "</mc:AlternateContent></w:r></w:p>"
+    )
+    path = _docx_with_body(tmp_path / "textbox.docx", body)
+
+    assert parse_document(path) == "正文段落\n\n文本框内容"
+
+
+def test_parse_docx_expands_html_alt_chunk(tmp_path: Path) -> None:
+    chunk = "<html><body><p>第一章 总则</p><p>第一条 为了规范</p></body></html>".encode()
+    path = _docx_with_body(
+        tmp_path / "html_chunk.docx",
+        _docx_paragraph("发布说明") + '<w:altChunk r:id="rId99"/>',
+        alt_chunk=("chunk.xhtml", "application/xhtml+xml", chunk),
+    )
+
+    assert parse_document(path) == "发布说明\n第一章 总则\n第一条 为了规范"
+
+
+def test_parse_docx_expands_word_alt_chunk(tmp_path: Path) -> None:
+    nested = _docx_with_body(tmp_path / "nested.docx", _docx_paragraph("嵌套正文"))
+    path = _docx_with_body(
+        tmp_path / "word_chunk.docx",
+        _docx_paragraph("发布说明") + '<w:altChunk r:id="rId99"/>',
+        alt_chunk=("chunk.docx", _DOCX_MAIN_TYPE, nested.read_bytes()),
+    )
+
+    assert parse_document(path) == "发布说明\n嵌套正文"
 
 
 def test_parse_csv_xlsx_and_xls(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Optimize the Chat `AskQuestionCard` UI (component, styles, store/chat hooks, i18n strings) with added tests.
- Improve knowledge document parsing in `src/octop/infra/knowledge/parse.py` with accompanying unit tests.

## Verification
- `make all` green (format-all + lint + typecheck + test + dashboard build).
- Commit passed the repo pre-commit hook (all checks passed).

## Notes
- This PR covers the current working-tree diff only (a separate optimization from PR #563).