### PR TITLE
chore(desktop): set bundle identifier to com.tencent.octop

### DIFF
--- a/desktop/src/build/config.yml
+++ b/desktop/src/build/config.yml
@@ -5,7 +5,7 @@ version: "3"
 info:
   companyName: "Octop"
   productName: "Octop"
-  productIdentifier: "com.octop.desktop"
+  productIdentifier: "com.tencent.octop"
   description: "Octop desktop shell"
   copyright: "(c) 2026, Octop"
   comments: "Wails v3 + green portable"

--- a/desktop/src/build/darwin/Info.dev.plist
+++ b/desktop/src/build/darwin/Info.dev.plist
@@ -9,7 +9,7 @@
         <key>CFBundleExecutable</key>
         <string>Octop</string>
         <key>CFBundleIdentifier</key>
-        <string>com.octop.desktop</string>
+        <string>com.tencent.octop</string>
         <key>CFBundleVersion</key>
         <string>0.9.26.dev</string>
         <key>CFBundleGetInfoString</key>

--- a/desktop/src/build/darwin/Info.plist
+++ b/desktop/src/build/darwin/Info.plist
@@ -9,7 +9,7 @@
         <key>CFBundleExecutable</key>
         <string>Octop</string>
         <key>CFBundleIdentifier</key>
-        <string>com.octop.desktop</string>
+        <string>com.tencent.octop</string>
         <key>CFBundleVersion</key>
         <string>0.9.26</string>
         <key>CFBundleGetInfoString</key>

--- a/desktop/src/build/windows/wails.exe.manifest
+++ b/desktop/src/build/windows/wails.exe.manifest
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
-    <assemblyIdentity type="win32" name="com.octop.desktop" version="0.9.26.0" processorArchitecture="*"/>
+    <assemblyIdentity type="win32" name="com.tencent.octop" version="0.9.26.0" processorArchitecture="*"/>
     <dependency>
         <dependentAssembly>
             <assemblyIdentity type="win32" name="Microsoft.Windows.Common-Controls" version="6.0.0.0" processorArchitecture="*" publicKeyToken="6595b64144ccf1df" language="*"/>


### PR DESCRIPTION
## Summary

- Change the desktop product identifier from `com.octop.desktop` to `com.tencent.octop` so macOS `CFBundleIdentifier` and the Windows assembly name match the Tencent bundle ID.
- Update Wails `productIdentifier` in `config.yml` together with Darwin plists so packaging does not regenerate the old ID.

## Target branch

- [x] Base is **`develop`** (feature / fix — default)
- [ ] Base is **`main`** (`release/*` or `hotfix/*` only)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactor / chore
- [ ] Release / hotfix

## Test plan

Identifier strings updated in `desktop/src/build/{config.yml,darwin/Info.plist,darwin/Info.dev.plist,windows/wails.exe.manifest}`. Did not rebuild the desktop app or run `make all` (packaging metadata only).

- [ ] `make all` passes locally
- [ ] Added/updated tests

## Checklist

- [ ] Updated `CHANGELOG.md` (if user-facing)
- [ ] README / docs updated (if needed)