### PR TITLE
fix(desktop): stamp pyproject version into packaged app metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 ### 修复
 
+- 桌面客户端打包把 `pyproject.toml` 版本写入 macOS Info.plist、Windows 文件版本和 NSIS 安装器，不再沿用写死的旧号
 - 用户发布专家卡片展示快照内自定义头像（`icon_url` + `/api/experts/published/{id}/avatar`），不再只显示默认 Lucide 图标
 - 用户管理表格（桌面端）横向滚动时固定用户名与操作列（与专家列表一致；移动端不固定）
 - 运行轨迹流式事件在内存聚合、回合边界持久化，避免逐 token 写库和重复存储上下文全文

--- a/desktop/src/.gitignore
+++ b/desktop/src/.gitignore
@@ -5,5 +5,7 @@ bundled/portable.zip
 build/windows/*.syso
 build/darwin/icons.icns
 build/windows/icon.ico
+build/windows/info.generated.json
+build/windows/wails.exe.generated.manifest
 build/windows/nsis/MicrosoftEdgeWebview2Setup.exe
 build/linux/icon.png

--- a/desktop/src/build/config.yml
+++ b/desktop/src/build/config.yml
@@ -1,5 +1,7 @@
 # This file contains the configuration for this project.
 # When you update `info`, run `wails3 task common:update:build-assets` to refresh generated assets.
+# `info.version` is a fallback for local `wails3 generate`; release packaging stamps
+# pyproject.toml's version onto the .app / exe / NSIS metadata.
 version: "3"
 
 info:

--- a/desktop/src/build/darwin/Taskfile.yml
+++ b/desktop/src/build/darwin/Taskfile.yml
@@ -36,6 +36,7 @@ tasks:
         vars:
           PORTABLE_ZIP: "{{.PORTABLE_ZIP}}"
           ARCH: "{{.ARCH}}"
+          VERSION: "{{.VERSION}}"
       - rm -f {{.ARCHIVE}} {{.BIN_DIR}}/{{.APP_NAME}}-Desktop-darwin-{{.ARCH}}.zip {{.BIN_DIR}}/{{.APP_NAME}}-Desktop-darwin-{{.ARCH}}.dmg
       - |
         set -euo pipefail
@@ -141,7 +142,10 @@ tasks:
       - cp {{.PORTABLE_ZIP}} {{.BIN_DIR}}/{{.APP_NAME}}.app/Contents/Resources/Octop-darwin-{{.ARCH}}.zip
       - cp {{.BIN_DIR}}/{{.APP_NAME}} {{.BIN_DIR}}/{{.APP_NAME}}.app/Contents/MacOS
       - cp build/darwin/Info.plist {{.BIN_DIR}}/{{.APP_NAME}}.app/Contents
+      - python3 build/stamp_version.py plist {{.BIN_DIR}}/{{.APP_NAME}}.app/Contents/Info.plist "{{.VERSION}}"
       - codesign --force --deep --sign - {{.BIN_DIR}}/{{.APP_NAME}}.app
+    vars:
+      VERSION: '{{.VERSION | default "dev"}}'
 
   run:
     cmds:

--- a/desktop/src/build/stamp_version.py
+++ b/desktop/src/build/stamp_version.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Stamp the Octop version into Wails desktop metadata copies."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import plistlib
+import re
+import shutil
+import sys
+from pathlib import Path
+
+_MANIFEST_IDENTITY = re.compile(
+    r'(<assemblyIdentity\b[^>]*\bname="com\.tencent\.octop"[^>]*\bversion=")[^"]+(")',
+    re.IGNORECASE,
+)
+
+
+def should_stamp(version: str) -> bool:
+    """Skip placeholders that are not a product version (NSIS needs x.y.z)."""
+    return bool(version) and version != "dev"
+
+
+def four_part_version(version: str) -> str | None:
+    """Windows assemblyIdentity requires four numeric components."""
+    parts = version.split(".")
+    if not parts or not all(p.isdigit() for p in parts):
+        return None
+    while len(parts) < 4:
+        parts.append("0")
+    return ".".join(parts[:4])
+
+
+def stamp_plist(path: Path, version: str) -> None:
+    if not should_stamp(version):
+        return
+    data = plistlib.loads(path.read_bytes())
+    data["CFBundleVersion"] = version
+    data["CFBundleShortVersionString"] = version
+    path.write_bytes(plistlib.dumps(data))
+
+
+def stamp_info_json(src: Path, dest: Path, version: str) -> None:
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    if src.resolve() != dest.resolve():
+        shutil.copyfile(src, dest)
+    if not should_stamp(version):
+        return
+    data = json.loads(dest.read_text(encoding="utf-8"))
+    data["fixed"]["file_version"] = version
+    data["info"]["0000"]["ProductVersion"] = version
+    dest.write_text(json.dumps(data, indent=4) + "\n", encoding="utf-8")
+
+
+def stamp_manifest(src: Path, dest: Path, version: str) -> None:
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    if src.resolve() != dest.resolve():
+        shutil.copyfile(src, dest)
+    if not should_stamp(version):
+        return
+    dotted = four_part_version(version)
+    if dotted is None:
+        return
+    text = dest.read_text(encoding="utf-8")
+    updated, n = _MANIFEST_IDENTITY.subn(rf"\g<1>{dotted}\2", text, count=1)
+    if n != 1:
+        raise SystemExit(f"octop assemblyIdentity not found in {dest}")
+    dest.write_text(updated, encoding="utf-8")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    plist_p = sub.add_parser("plist", help="Set CFBundleVersion keys on a copied Info.plist")
+    plist_p.add_argument("path", type=Path)
+    plist_p.add_argument("version")
+
+    json_p = sub.add_parser("json", help="Copy windows/info.json and set file/product version")
+    json_p.add_argument("src", type=Path)
+    json_p.add_argument("dest", type=Path)
+    json_p.add_argument("version")
+
+    man_p = sub.add_parser("manifest", help="Copy wails.exe.manifest and set assembly version")
+    man_p.add_argument("src", type=Path)
+    man_p.add_argument("dest", type=Path)
+    man_p.add_argument("version")
+
+    args = parser.parse_args(argv)
+    if args.cmd == "plist":
+        stamp_plist(args.path, args.version)
+    elif args.cmd == "json":
+        stamp_info_json(args.src, args.dest, args.version)
+    else:
+        stamp_manifest(args.src, args.dest, args.version)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/desktop/src/build/windows/Taskfile.yml
+++ b/desktop/src/build/windows/Taskfile.yml
@@ -14,6 +14,7 @@ tasks:
       - task: generate:syso
         vars:
           ARCH: "{{.ARCH}}"
+          VERSION: "{{.VERSION}}"
       - go build {{.BUILD_FLAGS}} -o "{{.BIN_DIR}}/{{.APP_NAME}}.exe"
       - cmd: powershell Remove-item *.syso
         platforms: [windows]
@@ -21,6 +22,7 @@ tasks:
         platforms: [linux, darwin]
     vars:
       BUILD_FLAGS: '{{if eq .PRODUCTION "true"}}-tags production -trimpath -buildvcs=false -ldflags="-w -s -H windowsgui"{{else}}-buildvcs=false -gcflags=all="-l"{{end}}'
+      VERSION: '{{.VERSION | default "dev"}}'
     env:
       GOOS: windows
       CGO_ENABLED: "0"
@@ -49,6 +51,7 @@ tasks:
         vars:
           PRODUCTION: "true"
           ARCH: "{{.ARCH}}"
+          VERSION: "{{.VERSION}}"
       - task: create:nsis:installer
         vars:
           ARCH: "{{.ARCH}}"
@@ -79,13 +82,14 @@ tasks:
           New-Item -ItemType Directory -Force '{{.ROOT_DIR}}/{{.BIN_DIR}}' | Out-Null"
       - |
         {{if eq OS "windows"}}
-        makensis -DARG_WAILS_{{.ARG_FLAG}}_BINARY="{{.ROOT_DIR}}\{{.BIN_DIR}}\{{.APP_NAME}}.exe" -DINSTALLER_OUTFILE="{{.ROOT_DIR}}\{{.ARCHIVE}}" project.nsi
+        makensis {{.VERSION_NSIS_DEFINE}}-DARG_WAILS_{{.ARG_FLAG}}_BINARY="{{.ROOT_DIR}}\{{.BIN_DIR}}\{{.APP_NAME}}.exe" -DINSTALLER_OUTFILE="{{.ROOT_DIR}}\{{.ARCHIVE}}" project.nsi
         {{else}}
-        makensis -DARG_WAILS_{{.ARG_FLAG}}_BINARY="{{.ROOT_DIR}}/{{.BIN_DIR}}/{{.APP_NAME}}.exe" -DINSTALLER_OUTFILE="{{.ROOT_DIR}}/{{.ARCHIVE}}" project.nsi
+        makensis {{.VERSION_NSIS_DEFINE}}-DARG_WAILS_{{.ARG_FLAG}}_BINARY="{{.ROOT_DIR}}/{{.BIN_DIR}}/{{.APP_NAME}}.exe" -DINSTALLER_OUTFILE="{{.ROOT_DIR}}/{{.ARCHIVE}}" project.nsi
         {{end}}
     vars:
       ARCH: '{{.ARCH | default ARCH}}'
       VERSION: '{{.VERSION | default "dev"}}'
+      VERSION_NSIS_DEFINE: '{{if and .VERSION (ne .VERSION "dev")}}-DINFO_PRODUCTVERSION="{{.VERSION}}" {{end}}'
       ARG_FLAG: '{{if eq (.ARCH | default ARCH) "amd64"}}AMD64{{else}}ARM64{{end}}'
       ARCHIVE: '{{.BIN_DIR}}/{{.APP_NAME}}-desktop-windows-{{.ARCH}}-{{.VERSION}}.exe'
 
@@ -97,6 +101,15 @@ tasks:
     summary: Generates Windows .syso (linked from module root)
     dir: build
     cmds:
-      - wails3 generate syso -arch {{.ARCH}} -icon windows/icon.ico -manifest windows/wails.exe.manifest -info windows/info.json -out ../wails_windows_{{.ARCH}}.syso
+      - cmd: python stamp_version.py json windows/info.json windows/info.generated.json "{{.VERSION}}"
+        platforms: [windows]
+      - cmd: python3 stamp_version.py json windows/info.json windows/info.generated.json "{{.VERSION}}"
+        platforms: [linux, darwin]
+      - cmd: python stamp_version.py manifest windows/wails.exe.manifest windows/wails.exe.generated.manifest "{{.VERSION}}"
+        platforms: [windows]
+      - cmd: python3 stamp_version.py manifest windows/wails.exe.manifest windows/wails.exe.generated.manifest "{{.VERSION}}"
+        platforms: [linux, darwin]
+      - wails3 generate syso -arch {{.ARCH}} -icon windows/icon.ico -manifest windows/wails.exe.generated.manifest -info windows/info.generated.json -out ../wails_windows_{{.ARCH}}.syso
     vars:
       ARCH: "{{.ARCH | default ARCH}}"
+      VERSION: '{{.VERSION | default "dev"}}'

--- a/desktop/src/build/windows/nsis/wails_tools.nsh
+++ b/desktop/src/build/windows/nsis/wails_tools.nsh
@@ -1,5 +1,6 @@
 # Shared NSIS helpers for the Octop desktop installer.
-# Keep INFO_* defaults in sync with desktop/src/build/config.yml.
+# INFO_PRODUCTVERSION fallback for a local makensis without -D.
+# Release packaging passes -DINFO_PRODUCTVERSION from pyproject.toml.
 
 !include "x64.nsh"
 !include "WinVer.nsh"

--- a/tests/unit/desktop/test_stamp_version.py
+++ b/tests/unit/desktop/test_stamp_version.py
@@ -1,0 +1,83 @@
+"""Tests for desktop Wails version stamping."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import plistlib
+from pathlib import Path
+
+_STAMP = Path(__file__).resolve().parents[3] / "desktop" / "src" / "build" / "stamp_version.py"
+_SPEC = importlib.util.spec_from_file_location("octop_desktop_stamp_version", _STAMP)
+assert _SPEC is not None and _SPEC.loader is not None
+stamp_version = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(stamp_version)
+
+
+def test_stamp_plist_sets_bundle_versions(tmp_path: Path) -> None:
+    src = (
+        Path(__file__).resolve().parents[3] / "desktop" / "src" / "build" / "darwin" / "Info.plist"
+    )
+    dest = tmp_path / "Info.plist"
+    dest.write_bytes(src.read_bytes())
+    stamp_version.stamp_plist(dest, "1.2.3")
+    data = plistlib.loads(dest.read_bytes())
+    assert data["CFBundleVersion"] == "1.2.3"
+    assert data["CFBundleShortVersionString"] == "1.2.3"
+    assert data["LSMinimumSystemVersion"] == "12.0.0"
+
+
+def test_stamp_plist_skips_dev_placeholder(tmp_path: Path) -> None:
+    dest = tmp_path / "Info.plist"
+    dest.write_bytes(
+        plistlib.dumps({"CFBundleVersion": "0.9.31", "CFBundleShortVersionString": "0.9.31"})
+    )
+    stamp_version.stamp_plist(dest, "dev")
+    data = plistlib.loads(dest.read_bytes())
+    assert data["CFBundleVersion"] == "0.9.31"
+
+
+def test_stamp_info_json_copies_and_sets_version(tmp_path: Path) -> None:
+    src = (
+        Path(__file__).resolve().parents[3] / "desktop" / "src" / "build" / "windows" / "info.json"
+    )
+    dest = tmp_path / "info.generated.json"
+    stamp_version.stamp_info_json(src, dest, "1.2.3")
+    data = json.loads(dest.read_text(encoding="utf-8"))
+    assert data["fixed"]["file_version"] == "1.2.3"
+    assert data["info"]["0000"]["ProductVersion"] == "1.2.3"
+    original = json.loads(src.read_text(encoding="utf-8"))
+    assert original["info"]["0000"]["CompanyName"] == data["info"]["0000"]["CompanyName"]
+
+
+def test_stamp_info_json_dev_keeps_source_version(tmp_path: Path) -> None:
+    src = (
+        Path(__file__).resolve().parents[3] / "desktop" / "src" / "build" / "windows" / "info.json"
+    )
+    dest = tmp_path / "info.generated.json"
+    stamp_version.stamp_info_json(src, dest, "dev")
+    data = json.loads(dest.read_text(encoding="utf-8"))
+    original = json.loads(src.read_text(encoding="utf-8"))
+    assert data["fixed"]["file_version"] == original["fixed"]["file_version"]
+
+
+def test_four_part_version_pads_semver() -> None:
+    assert stamp_version.four_part_version("1.2.3") == "1.2.3.0"
+    assert stamp_version.four_part_version("1.2.3.4") == "1.2.3.4"
+    assert stamp_version.four_part_version("dev") is None
+
+
+def test_stamp_manifest_sets_octop_identity_only(tmp_path: Path) -> None:
+    src = (
+        Path(__file__).resolve().parents[3]
+        / "desktop"
+        / "src"
+        / "build"
+        / "windows"
+        / "wails.exe.manifest"
+    )
+    dest = tmp_path / "wails.exe.generated.manifest"
+    stamp_version.stamp_manifest(src, dest, "1.2.3")
+    text = dest.read_text(encoding="utf-8")
+    assert 'name="com.tencent.octop" version="1.2.3.0"' in text
+    assert 'name="Microsoft.Windows.Common-Controls" version="6.0.0.0"' in text


### PR DESCRIPTION
## Summary

- Stamp `pyproject.toml` into macOS Info.plist, Windows VERSIONINFO/manifest, and NSIS at package time so Finder/installer versions match the release instead of leftover hardcoded metadata.
- Leave committed fallback files unchanged; skip stamping when `VERSION` is `dev` so local NSIS stays valid.

## Target branch

- [x] Base is **`develop`** (feature / fix — default)
- [ ] Base is **`main`** (`release/*` or `hotfix/*` only)

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / chore
- [ ] Release / hotfix

## Test plan

- `uv run pytest tests/unit/desktop/test_stamp_version.py -q` → 6 passed
- Fork PR CI: https://github.com/liukewia/Octop/pull/1 (desktop package + Python CI)

- [ ] `make all` passes locally
- [x] Added/updated tests

## Checklist

- [x] Updated `CHANGELOG.md` (if user-facing)
- [ ] README / docs updated (if needed)