### PR TITLE
feat(settings): move voice and search settings under models page

### DIFF
--- a/dashboard/src/api/modules/voice.ts
+++ b/dashboard/src/api/modules/voice.ts
@@ -28,6 +28,16 @@ export interface ActiveVoice {
   tts: string;
 }
 
+export interface VoiceProviderInput {
+  name: string;
+  kind: string;
+  capability: string;
+  base_url?: string | null;
+  api_key?: string | null;
+  extra_json?: string | null;
+  note?: string | null;
+}
+
 function recordingFilename(type: string): string {
   const lower = type.toLowerCase();
   if (lower.includes("mp4")) return "recording.m4a";
@@ -83,15 +93,7 @@ export const voiceApi = {
         ...(provider ? { provider } : {}),
       }),
     }),
-  createProvider: (body: {
-    name: string;
-    kind: string;
-    capability: string;
-    base_url?: string | null;
-    api_key?: string | null;
-    extra_json?: string | null;
-    note?: string | null;
-  }) =>
+  createProvider: (body: VoiceProviderInput) =>
     request<VoiceProviderRow>("/admin/voice/providers", {
       method: "POST",
       body: JSON.stringify(body),
@@ -120,6 +122,14 @@ export const voiceApi = {
       {
         method: "POST",
         body: JSON.stringify({ mode }),
+      },
+    ),
+  testConfiguration: (body: VoiceProviderInput & { mode: "stt" | "tts" }) =>
+    request<{ ok: boolean; error?: string }>(
+      "/admin/voice/providers/test-configuration",
+      {
+        method: "POST",
+        body: JSON.stringify(body),
       },
     ),
 };

--- a/dashboard/src/locales/en.json
+++ b/dashboard/src/locales/en.json
@@ -2350,6 +2350,7 @@
   "voice": {
     "loading": "Loading voice settings…",
     "loadError": "Failed to load voice settings",
+    "description": "Manage speech-to-text and text-to-speech models, and choose the active services.",
     "sttSection": "Speech Input (STT)",
     "ttsSection": "Read Aloud (TTS)",
     "free": "Free",
@@ -2360,7 +2361,12 @@
     "activeUpdated": "Active voice provider updated",
     "activeUpdateFailed": "Failed to update active provider",
     "configure": "Configure",
+    "configureTitle": "Configure {{name}}",
     "saved": "Configuration saved",
+    "credentialsRequired": "Complete the connection credentials first",
+    "probe": "Probe",
+    "probeSuccess": "Voice model probe succeeded",
+    "probeFailed": "Voice model probe failed",
     "tencentHint": "Create SecretId / SecretKey in Tencent Cloud console. ASR and TTS include free trial quota.",
     "openaiHint": "Uses OpenAI Whisper for STT and OpenAI TTS for read-aloud.",
     "mimoHint": "Xiaomi MiMo ASR/TTS. Choose endpoint and enter the corresponding API key.",
@@ -2800,9 +2806,11 @@
     "ollamaNotRunning": "Ollama service is not running",
     "testUseSavedConfig": "Uses saved configuration",
     "pageTitle": "Models",
-    "pageSubtitle": "Manage conversational, image-generation, and video-generation model services in one place.",
+    "pageSubtitle": "Manage conversational, image/video generation, voice, and search engine services in one place.",
     "chatModelsTab": "Conversation models",
     "generationModelsTab": "Generation models",
+    "voiceModelsTab": "Voice models",
+    "searchModelsTab": "Search engines",
     "addCustomProvider": "New Provider",
     "loadingProviders": "Loading...",
     "noProvidersHint": "No providers yet. Click the top right to create one.",
@@ -2915,9 +2923,11 @@
   "advancedSettings": {
     "description": "Manage runtime configuration and environment variables.",
     "search": {
-      "desc": "Configure AI-powered web search providers to enable your assistant to search the internet. Each provider requires an API key from the respective service.",
+      "desc": "Manage web search providers for agents to retrieve from the internet.",
       "tip": "You can configure or modify search providers here. Changes take effect immediately on the next chat session.",
       "configure": "Configure",
+      "configureTitle": "Configure {{name}}",
+      "probe": "Probe",
       "sourceBuiltinTitle": "Current search source: built-in search",
       "sourceBuiltinDesc": "When no third-party search provider is configured, Octop still provides its built-in search service. It requires no API key, but its stability and availability are not guaranteed. It switches automatically once a third-party provider is configured.",
       "sourceConfiguredTitle": "Current search source: {{name}}",
@@ -4952,7 +4962,7 @@
     },
     "models": {
       "title": "Model Management",
-      "subtitle": "Configure LLM providers and API keys"
+      "subtitle": "Configure conversation, generation, voice, and search engines"
     },
     "voice": {
       "title": "Voice Services",
@@ -4980,7 +4990,7 @@
     },
     "adminAdvanced": {
       "title": "Application Settings",
-      "subtitle": "Environment variables, search, voice, backup, HTTPS, and updates"
+      "subtitle": "Environment variables, backup, HTTPS, and updates"
     },
     "security": {
       "title": "Security",

--- a/dashboard/src/locales/zh.json
+++ b/dashboard/src/locales/zh.json
@@ -2350,6 +2350,7 @@
   "voice": {
     "loading": "加载语音配置…",
     "loadError": "加载语音配置失败",
+    "description": "管理语音识别与语音合成模型，并选择当前使用的服务。",
     "sttSection": "语音输入 (STT)",
     "ttsSection": "语音朗读 (TTS)",
     "free": "免费",
@@ -2360,7 +2361,12 @@
     "activeUpdated": "已更新当前语音服务",
     "activeUpdateFailed": "更新失败",
     "configure": "配置",
+    "configureTitle": "配置 {{name}}",
     "saved": "配置已保存",
+    "credentialsRequired": "请先填写完整的连接凭证",
+    "probe": "探测",
+    "probeSuccess": "语音模型探测成功",
+    "probeFailed": "语音模型探测失败",
     "tencentHint": "在腾讯云控制台创建 SecretId / SecretKey，语音识别与合成均有免费试用额度。",
     "openaiHint": "使用 OpenAI Whisper 识别、OpenAI TTS 朗读。",
     "mimoHint": "小米 Mimo 语音识别与合成。选择接入点并填写对应的 API Key。",
@@ -2798,9 +2804,11 @@
     "ollamaNotRunning": "Ollama 服务未启动",
     "testUseSavedConfig": "使用已保存的配置",
     "pageTitle": "模型设置",
-    "pageSubtitle": "统一管理对话模型与图片、视频生成模型服务。",
+    "pageSubtitle": "统一管理对话模型、图片视频生成模型、语音模型与搜索引擎。",
     "chatModelsTab": "对话模型",
     "generationModelsTab": "生成模型",
+    "voiceModelsTab": "语音模型",
+    "searchModelsTab": "搜索引擎",
     "addCustomProvider": "自定义供应商",
     "loadingProviders": "加载中...",
     "noProvidersHint": "还没有 provider,点击右上角新建",
@@ -2912,9 +2920,11 @@
   "advancedSettings": {
     "description": "管理运行配置和环境变量等高级选项。",
     "search": {
-      "desc": "配置 AI 驱动的网络搜索提供商，使您的助手能够搜索互联网。每个提供商需要来自相应服务的 API 密钥。",
+      "desc": "管理网络搜索提供商，供智能体检索互联网。",
       "tip": "您可以在此处配置或修改搜索提供商。更改将在下一次聊天会话时生效。",
       "configure": "配置",
+      "configureTitle": "配置 {{name}}",
+      "probe": "探测",
       "sourceBuiltinTitle": "当前搜索源：内置搜索",
       "sourceBuiltinDesc": "未配置第三方搜索服务时，仍可使用产品内置搜索服务；该服务无需 API Key，但不保证稳定性和可用性。配置第三方服务后会自动切换。",
       "sourceConfiguredTitle": "当前搜索源：{{name}}",
@@ -5091,7 +5101,7 @@
     },
     "models": {
       "title": "模型配置",
-      "subtitle": "配置 LLM 提供商和 API 密钥"
+      "subtitle": "配置对话模型、生成模型、语音模型与搜索引擎"
     },
     "voice": {
       "title": "语音服务",
@@ -5119,7 +5129,7 @@
     },
     "adminAdvanced": {
       "title": "应用设置",
-      "subtitle": "环境变量、搜索、语音、备份、HTTPS 与更新"
+      "subtitle": "环境变量、备份、HTTPS 与更新"
     },
     "security": {
       "title": "安全防护",

--- a/dashboard/src/pages/Settings/AdvancedSettings/index.tsx
+++ b/dashboard/src/pages/Settings/AdvancedSettings/index.tsx
@@ -1,17 +1,8 @@
 import type { ReactNode } from "react";
 import { useTranslation } from "react-i18next";
-import {
-  Archive,
-  Lock,
-  Mic2,
-  RefreshCw,
-  Search,
-  Variable,
-  Activity,
-} from "lucide-react";
+import { Navigate, useSearchParams } from "react-router-dom";
+import { Archive, Lock, RefreshCw, Variable, Activity } from "lucide-react";
 import EnvironmentsPage from "../Environments";
-import SearchConfigPage from "../SearchConfig";
-import { VoiceSettingsPanel } from "../Voice";
 import { ObservabilitySettingsPanel } from "../Observability";
 import BackupRestorePanel from "../BackupRestore";
 import { HttpsSettingsPanel } from "../HttpsSettings";
@@ -23,14 +14,7 @@ import ForbiddenPage from "../../../components/ForbiddenPage";
 import { useGatedSearchTabs } from "../../../hooks/useGatedSearchTabs";
 import { ADVANCED_TAB_PERMISSIONS } from "../../../utils/permissions";
 
-type TabKey =
-  | "env-vars"
-  | "search"
-  | "voice"
-  | "observability"
-  | "backup"
-  | "https"
-  | "updates";
+type TabKey = "env-vars" | "observability" | "backup" | "https" | "updates";
 
 const TABS: { key: TabKey; labelKey: string; icon: ReactNode }[] = [
   {
@@ -38,8 +22,6 @@ const TABS: { key: TabKey; labelKey: string; icon: ReactNode }[] = [
     labelKey: "nav.environments",
     icon: <Variable size={15} />,
   },
-  { key: "search", labelKey: "nav.search", icon: <Search size={15} /> },
-  { key: "voice", labelKey: "nav.voice", icon: <Mic2 size={15} /> },
   {
     key: "observability",
     labelKey: "nav.observability",
@@ -56,8 +38,6 @@ const TABS: { key: TabKey; labelKey: string; icon: ReactNode }[] = [
 
 function parseTab(raw: string | null): TabKey {
   if (
-    raw === "search" ||
-    raw === "voice" ||
     raw === "observability" ||
     raw === "backup" ||
     raw === "https" ||
@@ -70,6 +50,7 @@ function parseTab(raw: string | null): TabKey {
 
 export default function AdvancedSettingsPage() {
   const { t } = useTranslation();
+  const [searchParams] = useSearchParams();
   const { allowedTabs, activeTab, forbidden, selectTab } = useGatedSearchTabs({
     tabs: TABS,
     tabPermissions: ADVANCED_TAB_PERMISSIONS,
@@ -77,16 +58,17 @@ export default function AdvancedSettingsPage() {
     querylessKey: "env-vars",
   });
 
+  const moved = searchParams.get("tab");
+  if (moved === "voice" || moved === "search") {
+    return <Navigate to={`/admin/models?tab=${moved}`} replace />;
+  }
+
   if (forbidden) return <ForbiddenPage />;
 
   const renderTab = () => {
     switch (activeTab) {
       case "env-vars":
         return <EnvironmentsPage />;
-      case "search":
-        return <SearchConfigPage />;
-      case "voice":
-        return <VoiceSettingsPanel />;
       case "observability":
         return <ObservabilitySettingsPanel />;
       case "backup":

--- a/dashboard/src/pages/Settings/Models/index.tsx
+++ b/dashboard/src/pages/Settings/Models/index.tsx
@@ -11,7 +11,14 @@
  */
 import { useMemo, useState } from "react";
 import { Button, Divider, Empty, Space, Tabs, Typography } from "antd";
-import { Images, MessageSquareText, Plus, RefreshCw } from "lucide-react";
+import {
+  Images,
+  MessageSquareText,
+  Mic2,
+  Plus,
+  RefreshCw,
+  Search,
+} from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { useSearchParams } from "react-router-dom";
 import PageShell from "../../../layouts/PageShell";
@@ -31,6 +38,30 @@ import {
 } from "./components";
 import styles from "./index.module.less";
 import { MediaGenerationSettingsPanel } from "../MediaGeneration";
+import { VoiceSettingsPanel } from "../Voice";
+import { SearchSettingsPanel } from "../SearchConfig";
+
+type ModelCategory = "chat" | "generation" | "voice" | "search";
+
+function resolveModelCategory(
+  requestedTab: string | null,
+  canChat: boolean,
+  canProviders: boolean,
+  canVoice: boolean,
+  canSearch: boolean,
+): ModelCategory {
+  if (requestedTab === "generation" && canProviders) return "generation";
+  if (requestedTab === "voice" && canVoice) return "voice";
+  if (requestedTab === "search" && canSearch) return "search";
+  if ((requestedTab === "chat" || requestedTab === null) && canChat) {
+    return "chat";
+  }
+  if (canChat) return "chat";
+  if (canVoice) return "voice";
+  if (canSearch) return "search";
+  if (canProviders) return "generation";
+  return "chat";
+}
 
 const { Title } = Typography;
 
@@ -40,6 +71,9 @@ export default function ModelsPage() {
   const canProviders = userCan(user, "providers");
   const canOllama = userCan(user, "ollama_models");
   const canOnnx = userCan(user, "onnx_models");
+  const canVoice = userCan(user, "voice");
+  const canSearch = userCan(user, "search");
+  const canChat = canProviders || canOllama || canOnnx;
   const {
     providers,
     presets,
@@ -53,14 +87,18 @@ export default function ModelsPage() {
   const [hoveredCard, setHoveredCard] = useState<string | null>(null);
   const [addOpen, setAddOpen] = useState(false);
   const [searchParams, setSearchParams] = useSearchParams();
-  const modelCategory =
-    canProviders && searchParams.get("tab") === "generation"
-      ? "generation"
-      : "chat";
+  const modelCategory = resolveModelCategory(
+    searchParams.get("tab"),
+    canChat,
+    canProviders,
+    canVoice,
+    canSearch,
+  );
   const setModelCategory = (next: string) => {
     const updated = new URLSearchParams(searchParams);
-    if (next === "generation") updated.set("tab", "generation");
-    else updated.delete("tab");
+    if (next === "generation" || next === "voice" || next === "search") {
+      updated.set("tab", next);
+    } else updated.delete("tab");
     setSearchParams(updated, { replace: true });
   };
 
@@ -159,15 +197,19 @@ export default function ModelsPage() {
         activeKey={modelCategory}
         onChange={setModelCategory}
         items={[
-          {
-            key: "chat",
-            label: (
-              <Space size={6}>
-                <MessageSquareText size={15} />
-                {t("models.chatModelsTab")}
-              </Space>
-            ),
-          },
+          ...(canChat
+            ? [
+                {
+                  key: "chat",
+                  label: (
+                    <Space size={6}>
+                      <MessageSquareText size={15} />
+                      {t("models.chatModelsTab")}
+                    </Space>
+                  ),
+                },
+              ]
+            : []),
           ...(canProviders
             ? [
                 {
@@ -181,10 +223,40 @@ export default function ModelsPage() {
                 },
               ]
             : []),
+          ...(canVoice
+            ? [
+                {
+                  key: "voice",
+                  label: (
+                    <Space size={6}>
+                      <Mic2 size={15} />
+                      {t("models.voiceModelsTab")}
+                    </Space>
+                  ),
+                },
+              ]
+            : []),
+          ...(canSearch
+            ? [
+                {
+                  key: "search",
+                  label: (
+                    <Space size={6}>
+                      <Search size={15} />
+                      {t("models.searchModelsTab")}
+                    </Space>
+                  ),
+                },
+              ]
+            : []),
         ]}
       />
       {modelCategory === "generation" ? (
         <MediaGenerationSettingsPanel />
+      ) : modelCategory === "voice" ? (
+        <VoiceSettingsPanel />
+      ) : modelCategory === "search" ? (
+        <SearchSettingsPanel />
       ) : loading ? (
         <LoadingState message={t("models.loadingProviders")} />
       ) : error ? (

--- a/dashboard/src/pages/Settings/SearchConfig/index.module.less
+++ b/dashboard/src/pages/Settings/SearchConfig/index.module.less
@@ -252,16 +252,18 @@
   padding: 48px 0;
 }
 
-.modalHint {
-  margin: 0 0 16px;
+.drawerHint {
+  margin-bottom: 16px;
+  padding: 10px 12px;
+  border-radius: var(--fn-radius-md);
+  background: var(--fn-surface-sunken);
+  color: var(--fn-text-tertiary);
   font-size: 13px;
-  line-height: 1.55;
-  color: var(--fn-text-secondary);
+  line-height: 1.5;
 }
 
-.modalActions {
+.drawerFooter {
   display: flex;
-  flex-wrap: wrap;
+  justify-content: flex-end;
   gap: 8px;
-  margin-top: 4px;
 }

--- a/dashboard/src/pages/Settings/SearchConfig/index.tsx
+++ b/dashboard/src/pages/Settings/SearchConfig/index.tsx
@@ -1,13 +1,13 @@
 import { useEffect, useState, useCallback } from "react";
-import { App, Button, Form, Input, Typography, Spin, Modal } from "antd";
+import { App, Button, Drawer, Form, Input, Typography, Spin } from "antd";
 
 import {
+  Activity,
   Check,
   CheckCircle,
   Search,
   Settings2,
   Trash2,
-  Zap,
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { envsApi } from "../../../api/modules/env";
@@ -67,7 +67,7 @@ function searchProviderLogo(providerId: string): string {
   return getProviderLogo(providerId) ?? customProviderLogo;
 }
 
-interface ConfigureModalProps {
+interface ConfigureDrawerProps {
   provider: SearchProvider;
   envVars: Record<string, string>;
   open: boolean;
@@ -75,13 +75,13 @@ interface ConfigureModalProps {
   onSaved: () => void;
 }
 
-function ConfigureModal({
+function ConfigureDrawer({
   provider,
   envVars,
   open,
   onClose,
   onSaved,
-}: ConfigureModalProps) {
+}: ConfigureDrawerProps) {
   const { t } = useTranslation();
   const { modal, message } = App.useApp();
   const [form] = Form.useForm();
@@ -120,7 +120,7 @@ function ConfigureModal({
     }
   };
 
-  const handleTest = async () => {
+  const handleProbe = async () => {
     try {
       setTesting(true);
       const values = (await form.validateFields()) as Record<string, string>;
@@ -183,23 +183,37 @@ function ConfigureModal({
     });
   };
 
-  const modalTitle = provider.configured
-    ? `${t("common.edit")} — ${provider.name}`
-    : `${t("advancedSettings.search.configure")} — ${provider.name}`;
-
   return (
-    <Modal
-      title={modalTitle}
+    <Drawer
+      title={t("advancedSettings.search.configureTitle", {
+        name: provider.name,
+      })}
       open={open}
-      onCancel={onClose}
-      onOk={() => void handleSave()}
-      confirmLoading={saving}
-      okText={t("common.save")}
-      cancelText={t("common.cancel")}
-      destroyOnClose
-      width={480}
+      onClose={onClose}
+      width={440}
+      placement="right"
+      destroyOnHidden
+      footer={
+        <div className={styles.drawerFooter}>
+          <Button onClick={onClose}>{t("common.cancel")}</Button>
+          <Button
+            icon={<Activity size={14} />}
+            loading={testing}
+            onClick={() => void handleProbe()}
+          >
+            {t("advancedSettings.search.probe")}
+          </Button>
+          <Button
+            type="primary"
+            loading={saving}
+            onClick={() => void handleSave()}
+          >
+            {t("common.save")}
+          </Button>
+        </div>
+      }
     >
-      <p className={styles.modalHint}>{t(provider.descriptionKey)}</p>
+      <div className={styles.drawerHint}>{t(provider.descriptionKey)}</div>
       <Form form={form} layout="vertical" requiredMark={false}>
         {provider.required_keys.map((key) => (
           <Form.Item
@@ -229,6 +243,14 @@ function ConfigureModal({
                     </>
                   ) : null}
                 </span>
+              ) : provider.docs_url && key === provider.required_keys[0] ? (
+                <a
+                  href={provider.docs_url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {t("setupWizard.search.getApiKey")}
+                </a>
               ) : undefined
             }
           >
@@ -239,35 +261,17 @@ function ConfigureModal({
           </Form.Item>
         ))}
       </Form>
-
-      <div className={styles.modalActions}>
+      {provider.configured ? (
         <Button
-          icon={<Zap size={14} />}
-          loading={testing}
-          onClick={() => void handleTest()}
+          danger
+          icon={<Trash2 size={14} />}
+          loading={revoking}
+          onClick={handleRevoke}
         >
-          {t("setupWizard.search.test")}
+          {t("setupWizard.search.revoke")}
         </Button>
-        {provider.docs_url ? (
-          <Button
-            type="link"
-            onClick={() => window.open(provider.docs_url, "_blank")}
-          >
-            {t("setupWizard.search.docs")}
-          </Button>
-        ) : null}
-        {provider.configured ? (
-          <Button
-            danger
-            icon={<Trash2 size={14} />}
-            loading={revoking}
-            onClick={handleRevoke}
-          >
-            {t("setupWizard.search.revoke")}
-          </Button>
-        ) : null}
-      </div>
-    </Modal>
+      ) : null}
+    </Drawer>
   );
 }
 
@@ -327,7 +331,7 @@ export default function SearchConfigPage() {
     <>
       <TabPanelHeader
         icon={<Search size={22} />}
-        title={t("nav.search")}
+        title={t("models.searchModelsTab")}
         description={t("advancedSettings.search.desc")}
       />
 
@@ -457,7 +461,7 @@ export default function SearchConfigPage() {
       </Text>
 
       {editing ? (
-        <ConfigureModal
+        <ConfigureDrawer
           provider={editing}
           envVars={envVars}
           open
@@ -468,3 +472,5 @@ export default function SearchConfigPage() {
     </>
   );
 }
+
+export { SearchConfigPage as SearchSettingsPanel };

--- a/dashboard/src/pages/Settings/Voice/index.module.less
+++ b/dashboard/src/pages/Settings/Voice/index.module.less
@@ -209,3 +209,19 @@
   margin: 24px 0 20px !important;
   border-color: var(--fn-border-primary) !important;
 }
+
+.drawerHint {
+  margin-bottom: 16px;
+  padding: 10px 12px;
+  border-radius: var(--fn-radius-md);
+  background: var(--fn-surface-sunken);
+  color: var(--fn-text-tertiary);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.drawerFooter {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}

--- a/dashboard/src/pages/Settings/Voice/index.tsx
+++ b/dashboard/src/pages/Settings/Voice/index.tsx
@@ -1,12 +1,13 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { Button, Divider, Modal, Space, Typography, Input, Select } from "antd";
+import { Button, Divider, Drawer, Form, Input, Select, Typography } from "antd";
 import { message } from "@/utils/antdMessage";
 
-import { Mic2, RefreshCw, Check, Settings2 } from "lucide-react";
+import { Activity, Mic2, Check, Settings2 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import {
   voiceApi,
   type VoicePreset,
+  type VoiceProviderInput,
   type VoiceProviderRow,
 } from "../../../api/modules/voice";
 import { customProviderLogo, getProviderLogo } from "../../../assets/providers";
@@ -25,7 +26,7 @@ interface ConfigureState {
   existing?: VoiceProviderRow;
 }
 
-/** Voice provider settings panel — embeddable in Advanced Settings tab. */
+/** Voice provider settings panel — embeddable in the Models page tab. */
 export function VoiceSettingsPanel() {
   const { t } = useTranslation();
   const [presets, setPresets] = useState<VoicePreset[]>([]);
@@ -41,6 +42,7 @@ export function VoiceSettingsPanel() {
   );
   const [mimoVoiceId, setMimoVoiceId] = useState("冰糖");
   const [saving, setSaving] = useState(false);
+  const [probing, setProbing] = useState(false);
 
   const fetchAll = useCallback(async () => {
     setLoading(true);
@@ -103,47 +105,88 @@ export function VoiceSettingsPanel() {
     setMimoVoiceId(String(extra.voice_id ?? "冰糖"));
   };
 
+  const buildProviderPayload = (): VoiceProviderInput | null => {
+    if (!configure) return null;
+    const { preset } = configure;
+    let extra: Record<string, unknown>;
+    let baseUrl: string | null = null;
+    if (preset.kind === "tencent") {
+      extra = {
+        secret_id: secretId,
+        secret_key: secretKey,
+        region: "ap-guangzhou",
+      };
+    } else if (preset.kind === "edge") {
+      extra = { voice_id: "zh-CN-XiaoxiaoNeural" };
+    } else if (preset.kind === "mimo") {
+      baseUrl =
+        mimoEndpoint === "tokenplan"
+          ? "https://token-plan-cn.xiaomimimo.com/v1"
+          : "https://api.xiaomimimo.com/v1";
+      extra = {
+        endpoint_type: mimoEndpoint,
+        voice_id: preset.capability === "tts" ? mimoVoiceId : undefined,
+      };
+    } else {
+      extra = { model: preset.kind === "openai" ? "whisper-1" : undefined };
+    }
+    return {
+      name: preset.id,
+      kind: preset.kind,
+      capability: preset.capability,
+      base_url: baseUrl,
+      api_key:
+        preset.kind === "tencent"
+          ? secretId && secretKey
+            ? `${secretId}:${secretKey}`
+            : null
+          : apiKey || null,
+      extra_json: JSON.stringify(extra),
+    };
+  };
+
+  const validateCredentials = () => {
+    if (!configure?.preset.requires_key) return true;
+    const complete =
+      configure.preset.kind === "tencent"
+        ? Boolean(secretId.trim() && secretKey.trim())
+        : Boolean(apiKey.trim());
+    if (!complete) message.warning(t("voice.credentialsRequired"));
+    return complete;
+  };
+
+  const handleProbe = async () => {
+    const payload = buildProviderPayload();
+    if (!payload || !validateCredentials() || !configure) return;
+    const modes: ("stt" | "tts")[] =
+      configure.preset.capability === "both"
+        ? ["stt", "tts"]
+        : [configure.preset.capability];
+    setProbing(true);
+    try {
+      for (const mode of modes) {
+        const result = await voiceApi.testConfiguration({ ...payload, mode });
+        if (!result.ok) {
+          message.error(result.error || t("voice.probeFailed"));
+          return;
+        }
+      }
+      message.success(t("voice.probeSuccess"));
+    } catch (err) {
+      message.error(
+        err instanceof Error ? err.message : t("voice.probeFailed"),
+      );
+    } finally {
+      setProbing(false);
+    }
+  };
+
   const handleSaveProvider = async () => {
-    if (!configure) return;
+    const payload = buildProviderPayload();
+    if (!configure || !payload || !validateCredentials()) return;
     setSaving(true);
     try {
       const { preset, existing } = configure;
-      let extra: Record<string, unknown>;
-      let baseUrl: string | null = null;
-      if (preset.kind === "tencent") {
-        extra = {
-          secret_id: secretId,
-          secret_key: secretKey,
-          region: "ap-guangzhou",
-        };
-      } else if (preset.kind === "edge") {
-        extra = { voice_id: "zh-CN-XiaoxiaoNeural" };
-      } else if (preset.kind === "mimo") {
-        const mimoBase =
-          mimoEndpoint === "tokenplan"
-            ? "https://token-plan-cn.xiaomimimo.com/v1"
-            : "https://api.xiaomimimo.com/v1";
-        baseUrl = mimoBase;
-        extra = {
-          endpoint_type: mimoEndpoint,
-          voice_id: preset.capability === "tts" ? mimoVoiceId : undefined,
-        };
-      } else {
-        extra = { model: preset.kind === "openai" ? "whisper-1" : undefined };
-      }
-      const payload = {
-        name: preset.id,
-        kind: preset.kind,
-        capability: preset.capability,
-        base_url: baseUrl,
-        api_key:
-          preset.kind === "tencent"
-            ? secretId && secretKey
-              ? `${secretId}:${secretKey}`
-              : null
-            : apiKey || null,
-        extra_json: JSON.stringify(extra),
-      };
       if (existing) {
         await voiceApi.patchProvider(existing.id, payload);
       } else {
@@ -301,16 +344,8 @@ export function VoiceSettingsPanel() {
     <>
       <TabPanelHeader
         icon={<Mic2 size={22} />}
-        title={t("nav.voice")}
-        description={t("pageShell.voice.subtitle")}
-        actions={
-          <Button
-            icon={<RefreshCw size={14} />}
-            onClick={() => void fetchAll()}
-          >
-            {t("common.refresh")}
-          </Button>
-        }
+        title={t("models.voiceModelsTab")}
+        description={t("voice.description")}
       />
 
       {loading ? (
@@ -335,102 +370,129 @@ export function VoiceSettingsPanel() {
         </>
       )}
 
-      <Modal
-        title={
-          configure ? `${t("voice.configure")} — ${configure.preset.name}` : ""
-        }
+      <Drawer
+        title={t("voice.configureTitle", {
+          name: configure?.preset.name ?? "",
+        })}
         open={!!configure}
-        onCancel={() => setConfigure(null)}
-        onOk={() => void handleSaveProvider()}
-        confirmLoading={saving}
-        okText={t("common.save")}
+        onClose={() => setConfigure(null)}
+        width={440}
+        placement="right"
+        destroyOnHidden
+        footer={
+          <div className={styles.drawerFooter}>
+            <Button onClick={() => setConfigure(null)}>
+              {t("common.cancel")}
+            </Button>
+            <Button
+              icon={<Activity size={14} />}
+              loading={probing}
+              onClick={() => void handleProbe()}
+            >
+              {t("voice.probe")}
+            </Button>
+            <Button
+              type="primary"
+              loading={saving}
+              onClick={() => void handleSaveProvider()}
+            >
+              {t("common.save")}
+            </Button>
+          </div>
+        }
       >
-        {configure?.preset.kind === "tencent" && (
-          <Space direction="vertical" style={{ width: "100%" }}>
-            <Text type="secondary">{t("voice.tencentHint")}</Text>
-            <Input
-              placeholder="SecretId"
-              value={secretId}
-              onChange={(e) => setSecretId(e.target.value)}
-            />
-            <Input.Password
-              placeholder="SecretKey"
-              value={secretKey}
-              onChange={(e) => setSecretKey(e.target.value)}
-            />
-          </Space>
-        )}
-        {configure?.preset.kind === "openai" && (
-          <Space direction="vertical" style={{ width: "100%" }}>
-            <Text type="secondary">{t("voice.openaiHint")}</Text>
-            <Input.Password
-              placeholder="API Key"
-              value={apiKey}
-              onChange={(e) => setApiKey(e.target.value)}
-            />
-            <Select
-              style={{ width: "100%" }}
-              defaultValue="https://api.openai.com/v1"
-              disabled
-              options={[
-                { value: "https://api.openai.com/v1", label: "OpenAI API" },
-              ]}
-            />
-          </Space>
-        )}
-        {configure?.preset.kind === "mimo" && (
-          <Space direction="vertical" style={{ width: "100%" }}>
-            <Text type="secondary">{t("voice.mimoHint")}</Text>
-            <div>
-              <div style={{ fontSize: 12, marginBottom: 4 }}>
-                {t("voice.mimoEndpoint")}
-              </div>
-              <Select
-                style={{ width: "100%" }}
-                value={mimoEndpoint}
-                onChange={(v) => setMimoEndpoint(v)}
-                options={[
-                  {
-                    value: "payg",
-                    label: t("voice.mimoEndpointPayg"),
-                  },
-                  {
-                    value: "tokenplan",
-                    label: t("voice.mimoEndpointTokenplan"),
-                  },
-                ]}
-              />
-            </div>
-            <Input.Password
-              placeholder="API Key (sk-... / tp-...)"
-              value={apiKey}
-              onChange={(e) => setApiKey(e.target.value)}
-            />
-            {configure.preset.capability === "tts" && (
-              <div>
-                <div style={{ fontSize: 12, marginBottom: 4 }}>
-                  {t("voice.mimoVoice")}
-                </div>
+        <Form layout="vertical">
+          {configure?.preset.kind === "tencent" && (
+            <>
+              <div className={styles.drawerHint}>{t("voice.tencentHint")}</div>
+              <Form.Item label="SecretId" required>
+                <Input
+                  placeholder="SecretId"
+                  value={secretId}
+                  onChange={(e) => setSecretId(e.target.value)}
+                />
+              </Form.Item>
+              <Form.Item label="SecretKey" required>
+                <Input.Password
+                  placeholder="SecretKey"
+                  value={secretKey}
+                  onChange={(e) => setSecretKey(e.target.value)}
+                />
+              </Form.Item>
+            </>
+          )}
+          {configure?.preset.kind === "openai" && (
+            <>
+              <div className={styles.drawerHint}>{t("voice.openaiHint")}</div>
+              <Form.Item label="API Key" required>
+                <Input.Password
+                  placeholder="API Key"
+                  value={apiKey}
+                  onChange={(e) => setApiKey(e.target.value)}
+                />
+              </Form.Item>
+              <Form.Item label={t("voice.mimoEndpoint")}>
                 <Select
-                  style={{ width: "100%" }}
-                  value={mimoVoiceId}
-                  onChange={(v) => setMimoVoiceId(v)}
+                  value="https://api.openai.com/v1"
+                  disabled
                   options={[
-                    { value: "冰糖", label: "冰糖 (中文·女)" },
-                    { value: "茉莉", label: "茉莉 (中文·女)" },
-                    { value: "苏打", label: "苏打 (中文·男)" },
-                    { value: "白桦", label: "白桦 (中文·男)" },
-                    { value: "Mia", label: "Mia (EN·Female)" },
-                    { value: "Chloe", label: "Chloe (EN·Female)" },
-                    { value: "Milo", label: "Milo (EN·Male)" },
-                    { value: "Dean", label: "Dean (EN·Male)" },
+                    {
+                      value: "https://api.openai.com/v1",
+                      label: "OpenAI API",
+                    },
                   ]}
                 />
-              </div>
-            )}
-          </Space>
-        )}
-      </Modal>
+              </Form.Item>
+            </>
+          )}
+          {configure?.preset.kind === "mimo" && (
+            <>
+              <div className={styles.drawerHint}>{t("voice.mimoHint")}</div>
+              <Form.Item label={t("voice.mimoEndpoint")} required>
+                <Select
+                  value={mimoEndpoint}
+                  onChange={(v) => setMimoEndpoint(v)}
+                  options={[
+                    {
+                      value: "payg",
+                      label: t("voice.mimoEndpointPayg"),
+                    },
+                    {
+                      value: "tokenplan",
+                      label: t("voice.mimoEndpointTokenplan"),
+                    },
+                  ]}
+                />
+              </Form.Item>
+              <Form.Item label="API Key" required>
+                <Input.Password
+                  placeholder="API Key (sk-... / tp-...)"
+                  value={apiKey}
+                  onChange={(e) => setApiKey(e.target.value)}
+                />
+              </Form.Item>
+              {configure.preset.capability === "tts" && (
+                <Form.Item label={t("voice.mimoVoice")}>
+                  <Select
+                    value={mimoVoiceId}
+                    onChange={(v) => setMimoVoiceId(v)}
+                    options={[
+                      { value: "冰糖", label: "冰糖 (中文·女)" },
+                      { value: "茉莉", label: "茉莉 (中文·女)" },
+                      { value: "苏打", label: "苏打 (中文·男)" },
+                      { value: "白桦", label: "白桦 (中文·男)" },
+                      { value: "Mia", label: "Mia (EN·Female)" },
+                      { value: "Chloe", label: "Chloe (EN·Female)" },
+                      { value: "Milo", label: "Milo (EN·Male)" },
+                      { value: "Dean", label: "Dean (EN·Male)" },
+                    ]}
+                  />
+                </Form.Item>
+              )}
+            </>
+          )}
+        </Form>
+      </Drawer>
     </>
   );
 }

--- a/dashboard/src/routes/controlAdminPath.test.ts
+++ b/dashboard/src/routes/controlAdminPath.test.ts
@@ -44,6 +44,16 @@ describe("pathPermissionKeys", () => {
     expect(NAV_PERMISSIONS["admin-advanced"]).toEqual(PERM.advancedPage);
   });
 
+  it("keeps voice and search on models page, not advanced", () => {
+    expect(pathPermissionKeys("/admin/models")).toEqual([...PERM.modelsPage]);
+    expect(pathPermissionKeys("/admin/voice")).toEqual([...PERM.modelsPage]);
+    expect([...PERM.modelsPage]).toContain("voice");
+    expect([...PERM.modelsPage]).toContain("search");
+    expect([...PERM.advancedPage]).not.toContain("voice");
+    expect([...PERM.advancedPage]).not.toContain("search");
+    expect(NAV_PERMISSIONS.models).toEqual(PERM.modelsPage);
+  });
+
   it("does not gate common pages", () => {
     expect(pathPermissionKeys("/chat")).toBeNull();
     expect(pathPermissionKeys("/experts")).toBeNull();

--- a/dashboard/src/routes/index.tsx
+++ b/dashboard/src/routes/index.tsx
@@ -229,7 +229,7 @@ export const routeConfigs: RouteConfig[] = [
   { path: "/admin/security", element: <AdminSecurityPage /> },
   {
     path: "/admin/voice",
-    element: <Navigate to="/admin/advanced?tab=voice" replace />,
+    element: <Navigate to="/admin/models?tab=voice" replace />,
   },
   {
     path: "/admin/updates",

--- a/dashboard/src/utils/permissions.ts
+++ b/dashboard/src/utils/permissions.ts
@@ -21,19 +21,11 @@ export const PERM = {
   desktop: ["desktop"],
   mobile: ["mobile"],
   usersPage: ["users", "sso"],
-  modelsPage: ["providers", "ollama_models", "onnx_models"],
+  modelsPage: ["providers", "ollama_models", "onnx_models", "voice", "search"],
   storage: ["storage_backends"],
   plugins: ["plugins"],
   securityPage: ["security", "admin_console"],
-  advancedPage: [
-    "voice",
-    "update",
-    "envs",
-    "tls",
-    "observability",
-    "backup",
-    "search",
-  ],
+  advancedPage: ["update", "envs", "tls", "observability", "backup"],
 } as const satisfies Record<string, readonly string[]>;
 
 /** Sidebar item key → permission keys. Shared with path guards. */
@@ -63,8 +55,6 @@ export const USERS_TAB_PERMISSIONS = {
 
 export const ADVANCED_TAB_PERMISSIONS = {
   "env-vars": "envs",
-  search: "search",
-  voice: "voice",
   observability: "observability",
   backup: "backup",
   https: "tls",
@@ -132,7 +122,11 @@ export function pathPermissionKeys(pathname: string): PermissionKeys | null {
   if (pathname.startsWith("/admin/users") || pathname === "/admin/sso") {
     return PERM.usersPage;
   }
-  if (pathname.startsWith("/admin/models") || pathname === "/models") {
+  if (
+    pathname.startsWith("/admin/models") ||
+    pathname === "/models" ||
+    pathname.startsWith("/admin/voice")
+  ) {
     return PERM.modelsPage;
   }
   if (pathname.startsWith("/admin/backend")) {
@@ -153,7 +147,6 @@ export function pathPermissionKeys(pathname: string): PermissionKeys | null {
   }
   if (
     pathname.startsWith("/admin/advanced") ||
-    pathname.startsWith("/admin/voice") ||
     pathname.startsWith("/admin/updates")
   ) {
     return PERM.advancedPage;

--- a/src/octop/api/routers/voice.py
+++ b/src/octop/api/routers/voice.py
@@ -75,6 +75,10 @@ class VoiceTestBody(BaseModel):
     mode: Literal["stt", "tts"] = "tts"
 
 
+class VoiceConfigurationTestBody(VoiceProviderCreateBody):
+    mode: Literal["stt", "tts"] = "tts"
+
+
 @router.get("/presets")
 async def list_voice_presets(_: Any = Depends(current_user)) -> list[dict[str, Any]]:
     return load_voice_presets()
@@ -233,3 +237,20 @@ async def admin_test_voice_provider(
     server: Any = Depends(get_server),
 ) -> dict[str, Any]:
     return await _voice_manager(server).test_provider(provider_id, mode=body.mode)
+
+
+@admin_router.post("/test-configuration")
+async def admin_test_voice_configuration(
+    body: VoiceConfigurationTestBody,
+    _: Any = Depends(require_permission("voice")),
+    server: Any = Depends(get_server),
+) -> dict[str, Any]:
+    return await _voice_manager(server).test_configuration(
+        name=body.name,
+        kind=body.kind,
+        capability=body.capability,
+        base_url=body.base_url,
+        api_key=body.api_key,
+        extra_json=body.extra_json,
+        mode=body.mode,
+    )

--- a/src/octop/infra/users/permissions.py
+++ b/src/octop/infra/users/permissions.py
@@ -144,11 +144,11 @@ PERMISSIONS: dict[str, PermissionDef] = {
     "search": _p(
         "search",
         "admin",
-        "AI 搜索",
-        "AI search",
-        page="advanced",
-        page_zh="应用设置",
-        page_en="App settings",
+        "搜索引擎",
+        "Search engines",
+        page="models",
+        page_zh="模型",
+        page_en="Models",
     ),
     "knowledge_settings": _p(
         "knowledge_settings",
@@ -162,11 +162,11 @@ PERMISSIONS: dict[str, PermissionDef] = {
     "voice": _p(
         "voice",
         "admin",
-        "语音",
-        "Voice",
-        page="advanced",
-        page_zh="应用设置",
-        page_en="App settings",
+        "语音模型",
+        "Voice models",
+        page="models",
+        page_zh="模型",
+        page_en="Models",
     ),
     "observability": _p(
         "observability",

--- a/src/octop/infra/voice/manager.py
+++ b/src/octop/infra/voice/manager.py
@@ -189,3 +189,31 @@ class VoiceManager:
         if mode == "stt":
             return await adapters.test_stt(row, row.kind)
         return await adapters.test_tts(row, row.kind)
+
+    async def test_configuration(
+        self,
+        *,
+        name: str,
+        kind: str,
+        capability: str,
+        base_url: str | None,
+        api_key: str | None,
+        extra_json: str | None,
+        mode: str,
+    ) -> dict[str, Any]:
+        row = VoiceProviderRow(
+            id=0,
+            name=name,
+            kind=kind,
+            capability=capability,
+            base_url=base_url,
+            api_key=api_key,
+            extra_json=extra_json,
+            note=None,
+            enabled=1,
+            created_at=0,
+            updated_at=0,
+        )
+        if mode == "stt":
+            return await adapters.test_stt(row, kind)
+        return await adapters.test_tts(row, kind)

--- a/tests/unit/test_voice_manager.py
+++ b/tests/unit/test_voice_manager.py
@@ -9,8 +9,9 @@ import pytest
 from octop.infra.db.migrate import run_migrations
 from octop.infra.db.pool import SqlitePool
 from octop.infra.db.repos.settings import SettingsRepo
-from octop.infra.db.repos.voice_providers import VoiceProviderRepo
+from octop.infra.db.repos.voice_providers import VoiceProviderRepo, VoiceProviderRow
 from octop.infra.errors import ErrorCode, OctopError
+from octop.infra.voice import adapters
 from octop.infra.voice.manager import VoiceManager
 
 
@@ -52,3 +53,36 @@ async def test_synthesize_browser_raises_browser_only(voice_mgr: VoiceManager) -
         chunks = [c async for c in voice_mgr.synthesize("hello")]
         assert not chunks
     assert exc.value.code == ErrorCode.VOICE_BROWSER_ONLY
+
+
+@pytest.mark.asyncio
+async def test_configuration_probe_uses_unsaved_values(
+    voice_mgr: VoiceManager, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    captured_row: VoiceProviderRow | None = None
+    captured_kind = ""
+
+    async def fake_test_stt(row: VoiceProviderRow | None, kind: str) -> dict[str, object]:
+        nonlocal captured_row, captured_kind
+        captured_row = row
+        captured_kind = kind
+        return {"ok": True}
+
+    monkeypatch.setattr(adapters, "test_stt", fake_test_stt)
+
+    result = await voice_mgr.test_configuration(
+        name="draft",
+        kind="openai",
+        capability="both",
+        base_url="https://example.test/v1",
+        api_key="sk-draft",
+        extra_json='{"model":"whisper-1"}',
+        mode="stt",
+    )
+
+    assert result == {"ok": True}
+    assert captured_kind == "openai"
+    assert captured_row is not None
+    assert captured_row.name == "draft"
+    assert captured_row.api_key == "sk-draft"
+    assert captured_row.base_url == "https://example.test/v1"

--- a/tests/unit/users/test_permissions.py
+++ b/tests/unit/users/test_permissions.py
@@ -68,6 +68,8 @@ def test_categories_match_nav_groups() -> None:
         "mobile",
     }
     assert PERMISSIONS["envs"].page == "advanced"
+    assert PERMISSIONS["voice"].page == "models"
+    assert PERMISSIONS["search"].page == "models"
     assert PERMISSIONS["knowledge_settings"].page == "advanced"
     assert PERMISSIONS["knowledge_settings"].category == "admin"
     assert "knowledge_settings" not in BASELINE_PERMISSIONS


### PR DESCRIPTION
## Summary
- Relocate the **Voice** and **Search engines** admin settings from the *Advanced* page into the *Models* page (nav item, route guard, permission category `page: "models"`).
- Add `POST /admin/voice/providers/test-configuration` + `VoiceManager.test_configuration()` so unsaved provider values (name/kind/base_url/api_key/extra_json) can be probed before saving, instead of only testing already-persisted providers.
- Legacy `/admin/advanced?tab=voice` and `?tab=search` links redirect to `/admin/models?tab=voice|search`; `/admin/voice` route now points at the Models page.

## Test plan
- `make lint` — pass
- `make typecheck` — pass
- `cd dashboard && npx tsc --noEmit` — pass
- `uv run pytest -m "not live" -q` — 2931 passed, 8 skipped
- `make build-frontend` — builds cleanly
- Pre-commit hook (`make all` + dashboard build) passed on commit