### PR TITLE
feat: system prompt playbook variable interpolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ## [Unreleased]
 
+### 新增
+
+- 智能体 system_prompt 支持 playbook 插值变量（{agent_id}/{agent_name}/{date}/{datetime}/{work_dir}/{model}）：编译图时按当前 agent/工作目录/时间渲染，动态状态仍由 MEMORY.md 热索引承载（每轮注入）；未知占位符原样保留，模板写错变量名不静默丢失
+
 ## [0.9.32] - 2026-09-06
 
 ### 新增

--- a/src/octop/infra/agents/manager.py
+++ b/src/octop/infra/agents/manager.py
@@ -8,6 +8,7 @@ import json
 import logging
 import re
 import shutil
+import zoneinfo
 from collections.abc import AsyncIterator, Awaitable, Callable, Sequence
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field, fields, replace
@@ -116,6 +117,7 @@ def _render_system_prompt(
     agent_name: str,
     work_dir: str,
     model: str | None,
+    timezone: str | None = None,
 ) -> str:
     """Render ``{playbook}`` variables into an agent system prompt.
 
@@ -123,8 +125,13 @@ def _render_system_prompt(
     prompt may reference the agent's own identity, working directory, and the
     current date so a single template stays accurate across instances. Values
     are filled once when the harness graph is compiled, not per turn.
+
+    ``timezone`` is the configured IANA zone (``OctopConfig.default_timezone``);
+    when unset or invalid we fall back to UTC so ``{date}``/``{datetime}`` never
+    silently use the machine's local time, which may disagree with the
+    server-wide configured timezone.
     """
-    now = datetime.datetime.now()
+    now = _now_in_timezone(timezone)
     substitutions = {
         "agent_id": agent_id,
         "agent_name": agent_name,
@@ -137,6 +144,16 @@ def _render_system_prompt(
     for key, value in substitutions.items():
         out = out.replace("{" + key + "}", value)
     return out
+
+
+def _now_in_timezone(timezone: str | None) -> datetime.datetime:
+    """Tz-aware now; UTC fallback when the zone is unset or unknown."""
+    if timezone:
+        try:
+            return datetime.datetime.now(zoneinfo.ZoneInfo(timezone))
+        except (ValueError, KeyError, OSError):
+            logger.warning("unknown default_timezone %r, falling back to UTC", timezone)
+    return datetime.datetime.now(datetime.timezone.utc)
 
 
 def skills_disabled_set(cfg: dict[str, Any]) -> set[str]:
@@ -2638,6 +2655,7 @@ class AgentManager:
                 agent_name=row.name or row.agent_id,
                 work_dir=str(harness_workspace),
                 model=default_model,
+                timezone=self._config.default_timezone,
             )
 
         uid = self._connector_uid_for(row)

--- a/src/octop/infra/agents/manager.py
+++ b/src/octop/infra/agents/manager.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import datetime
 import json
 import logging
 import re
@@ -91,6 +92,51 @@ _HARNESS_AGENT_CONFIG_FIELDS = frozenset(item.name for item in fields(HarnessAge
 
 def _memory_namespace(agent_id: str) -> str:
     return f"{_MEMORY_NS_PREFIX}{agent_id}"
+
+
+#: system_prompt template variables rendered at graph-compile time. Dynamic
+#: per-turn state (project facts, current focus) is *not* part of this layer:
+#: it lives in the workspace MEMORY.md hot index, which is injected verbatim
+#: on every turn. Unknown ``{placeholder}``s are left untouched so a typo in a
+#: template is visible to the model instead of silently vanishing.
+_SYSTEM_PROMPT_VARS = (
+    "agent_id",
+    "agent_name",
+    "date",
+    "datetime",
+    "work_dir",
+    "model",
+)
+
+
+def _render_system_prompt(
+    template: str,
+    *,
+    agent_id: str,
+    agent_name: str,
+    work_dir: str,
+    model: str | None,
+) -> str:
+    """Render ``{playbook}`` variables into an agent system prompt.
+
+    Inspired by openresearch-cli's playbook substitution: the persona system
+    prompt may reference the agent's own identity, working directory, and the
+    current date so a single template stays accurate across instances. Values
+    are filled once when the harness graph is compiled, not per turn.
+    """
+    now = datetime.datetime.now()
+    substitutions = {
+        "agent_id": agent_id,
+        "agent_name": agent_name,
+        "date": now.strftime("%Y-%m-%d"),
+        "datetime": now.strftime("%Y-%m-%d %H:%M"),
+        "work_dir": work_dir,
+        "model": model or "",
+    }
+    out = template
+    for key, value in substitutions.items():
+        out = out.replace("{" + key + "}", value)
+    return out
 
 
 def skills_disabled_set(cfg: dict[str, Any]) -> set[str]:
@@ -2576,11 +2622,23 @@ class AgentManager:
         )
         acp_config = ACPConfig.from_dict({"runners": runners_dict})
 
+        default_model = (
+            self._providers.resolve_explicit_default_model(row, cfg)
+            or self.resolve_fallback_model_ref()
+        )
         system_prompt = row.system_prompt
         memory: tuple[str, ...] | None = None
         if not bootstrap_marker_exists(ws):
             system_prompt = None
             memory = ()
+        if system_prompt:
+            system_prompt = _render_system_prompt(
+                system_prompt,
+                agent_id=row.agent_id,
+                agent_name=row.name or row.agent_id,
+                work_dir=str(harness_workspace),
+                model=default_model,
+            )
 
         uid = self._connector_uid_for(row)
         mcp_server_configs: dict[str, Any] = {}
@@ -2655,10 +2713,7 @@ class AgentManager:
             # first, else first usable) — so promotion works whenever chat does.
             # Per-turn AUTO routing is unaffected: the gateway resolves models via
             # ``resolve_explicit_default_model`` directly.
-            default_model=(
-                self._providers.resolve_explicit_default_model(row, cfg)
-                or self.resolve_fallback_model_ref()
-            ),
+            default_model=default_model,
             system_prompt=system_prompt,
             memory=memory,
             backend=harness_backend,  # spec, or live OpenSandbox instance

--- a/src/octop/infra/agents/persona.py
+++ b/src/octop/infra/agents/persona.py
@@ -62,11 +62,19 @@ class PersonaLoader:
         custom: str | None,
     ) -> str:
         template = self.load(mbti)
-        return template.format(
-            agent_name=agent_name,
-            user_display=user_display,
-            custom=(custom or "").strip(),
-        )
+        # Replace the three known placeholders via ``str.replace`` instead of
+        # ``str.format``: a persona that carries playbook variables rendered
+        # later (e.g. {date} / {work_dir}, see ``_render_system_prompt`` in
+        # AgentManager) must survive this pass unchanged — ``.format`` would
+        # raise ``KeyError`` on any unknown placeholder.
+        out = template.replace("{agent_name}", agent_name).replace("{user_display}", user_display)
+        custom_text = (custom or "").strip()
+        if custom_text:
+            out = out.replace("{custom}", custom_text)
+        else:
+            # Custom block absent: drop the placeholder line entirely.
+            out = out.replace("{custom}\n", "").replace("{custom}", "")
+        return out
 
 
 def resolve_persona_code(

--- a/tests/unit/agents/test_agent_manager.py
+++ b/tests/unit/agents/test_agent_manager.py
@@ -325,6 +325,39 @@ def test_build_harness_config_keeps_system_prompt_after_bootstrap(
     assert cfg.system_prompt == "MBTI persona prompt"
 
 
+def test_build_harness_config_renders_system_prompt_playbook_vars(
+    manager: AgentManager,
+) -> None:
+    """System prompt template variables render at graph-compile time.
+
+    {agent_id} {agent_name} {date} {datetime} {work_dir} {model} are filled
+    from the row; unknown placeholders are left untouched so template typos
+    stay visible to the model instead of silently vanishing.
+    """
+    from dataclasses import replace
+
+    agent_id = "AGT_PB"
+    ws = manager._paths.ensure_agent_workspace(agent_id)
+    (ws / ".bootstrapped").write_text("", encoding="utf-8")
+    row = replace(
+        _row(agent_id=agent_id, default_model="gpt-4o-mini"),
+        system_prompt=(
+            "agent {agent_id} ({agent_name}) workdir {work_dir} "
+            "model {model} date {date} datetime {datetime} unknown {foo}"
+        ),
+        config_json=json.dumps({"backend": _fs_backend(ws)}),
+    )
+    cfg = manager._build_harness_config(row)
+    assert cfg.system_prompt is not None
+    assert agent_id in cfg.system_prompt
+    assert "bot" in cfg.system_prompt  # row.name
+    assert str(ws) in cfg.system_prompt
+    assert "gpt-4o-mini" in cfg.system_prompt
+    assert "20" in cfg.system_prompt  # rendered date starts with 20xx
+    assert "{foo}" in cfg.system_prompt  # unknown placeholder preserved
+    assert "{date}" not in cfg.system_prompt
+
+
 def test_bootstrap_complete_defers_graph_refresh(manager: AgentManager) -> None:
     agent_id = "AGT_BOOT"
     manager._repos.agent_repo.create(agent_id=agent_id, user_id=None, name="boot")

--- a/tests/unit/agents/test_agent_manager.py
+++ b/tests/unit/agents/test_agent_manager.py
@@ -336,6 +336,8 @@ def test_build_harness_config_renders_system_prompt_playbook_vars(
     """
     from dataclasses import replace
 
+    _seed_test_provider(manager)
+
     agent_id = "AGT_PB"
     ws = manager._paths.ensure_agent_workspace(agent_id)
     (ws / ".bootstrapped").write_text("", encoding="utf-8")
@@ -347,13 +349,17 @@ def test_build_harness_config_renders_system_prompt_playbook_vars(
         ),
         config_json=json.dumps({"backend": _fs_backend(ws)}),
     )
+    import re
+
     cfg = manager._build_harness_config(row)
     assert cfg.system_prompt is not None
     assert agent_id in cfg.system_prompt
     assert "bot" in cfg.system_prompt  # row.name
     assert str(ws) in cfg.system_prompt
     assert "gpt-4o-mini" in cfg.system_prompt
-    assert "20" in cfg.system_prompt  # rendered date starts with 20xx
+    # rendered date is a real YYYY-MM-DD, not just a bare substring
+    assert re.search(r"date \d{4}-\d{2}-\d{2}", cfg.system_prompt)
+    assert re.search(r"datetime \d{4}-\d{2}-\d{2} \d{2}:\d{2}", cfg.system_prompt)
     assert "{foo}" in cfg.system_prompt  # unknown placeholder preserved
     assert "{date}" not in cfg.system_prompt
 
@@ -1445,3 +1451,38 @@ def test_prepare_stream_request_maps_model_settings_and_max_input_tokens(
         "max_tokens": 2048,
     }
     assert req["configurable"]["max_input_tokens"] == 32000
+
+
+def test_render_system_prompt_timezone_aware() -> None:
+    """Rendered {date}/{datetime} follow the configured IANA zone; invalid or
+    missing zones fall back to UTC instead of the machine's local time."""
+    import re
+
+    from octop.infra.agents.manager import _render_system_prompt
+
+    base = dict(
+        agent_id="AGT_TZ",
+        agent_name="tz",
+        work_dir="/tmp/ws",
+        model="m",
+    )
+
+    rendered = _render_system_prompt(
+        "{date} {datetime}", timezone="Asia/Shanghai", **base
+    )
+    # template renders to "<date> <date> <time>"
+    m = re.match(r"^(\d{4}-\d{2}-\d{2}) (\d{4}-\d{2}-\d{2}) (\d{2}:\d{2})$", rendered)
+    assert m is not None
+    # Shanghai is UTC+8 without DST: local wall-clock is always >= UTC.
+    from datetime import datetime, timezone as dt_timezone
+
+    utc_wall = datetime.now(dt_timezone.utc).strftime("%H:%M")
+    assert m.group(2) >= utc_wall or m.group(1) > datetime.now(dt_timezone.utc).strftime(
+        "%Y-%m-%d"
+    )
+
+    # Invalid zone -> UTC fallback (renders without error).
+    rendered_fallback = _render_system_prompt(
+        "{date}", timezone="Not/AZone", **base
+    )
+    assert re.match(r"\d{4}-\d{2}-\d{2}$", rendered_fallback)

--- a/tests/unit/agents/test_persona.py
+++ b/tests/unit/agents/test_persona.py
@@ -42,6 +42,21 @@ def test_render_handles_empty_custom(loader: PersonaLoader):
     assert "{custom}" not in out
 
 
+def test_render_preserves_unknown_placeholders_for_compile_time(loader: PersonaLoader):
+    """Playbook variables rendered later ({date}/{work_dir}/…) must survive
+    the persona pass untouched — ``str.format`` would raise KeyError."""
+    out = loader.render(
+        mbti=None,
+        agent_name="A",
+        user_display="B",
+        custom="Today is {date}. Workdir {work_dir}. Model {model}.",
+    )
+    assert "{date}" in out
+    assert "{work_dir}" in out
+    assert "{model}" in out
+    assert "{agent_name}" not in out
+
+
 def test_render_persona_template_uses_profile_fields():
     profile = get_profile("INTJ")
     assert profile is not None


### PR DESCRIPTION
## 背景

Octop 的 system_prompt（agents 表 persona）是静态模板：同一个模板在多个 agent 实例间复用，但实例名/工作目录/时间无法区分。吸收 openresearch-cli 的 playbook 插值设计（SYSTEM_PROMPT.md 渲染 {name}/{id}/{project_state}），让 persona 模板支持身份与环境的占位符，编译图时渲染。

## 改动

- `AgentManager._render_system_prompt`：渲染 `{agent_id}` `{agent_name}` `{date}` `{datetime}` `{work_dir}` `{model}` 六个变量；未知 `{xxx}` 原样保留（模板写错变量名不静默丢失）
- `_build_harness_config`：bootstrap 完成后非空 system_prompt 走渲染；default_model 只解析一次（渲染 + HarnessAgentConfig 复用）
- `PersonaLoader.render`：`str.format` 改为宽容替换——用户自定义 persona 里的 `{date}` 等变量此前直接 KeyError 炸 agent 创建，现原样保留给编译期渲染
- 单测：渲染路径 + 未知占位符保留 + persona 宽容（tests/unit/agents/test_agent_manager.py、test_persona.py）
- CHANGELOG [Unreleased] 记录

## 设计边界

- 渲染时机 = 编译图时（agent 配置变更），不是每轮 turn；动态状态（项目事实/当前重点）继续走 workspace MEMORY.md 热索引（每轮全文注入）
- 四文件（SOUL/USER/MEMORY/AGENTS）走 memory 通道，不参与本插值——变量只作用于 agents 表 system_prompt（persona 底座）

## 配套的上下文治理设计（本 PR 之外的本地补丁，供参考）

本 PR 是上下文治理的一部分，另外三块在 harness/deepagents 层（本机补丁，harness-agent 上游仓未公开，故不在此仓落地）：

1. **历史工具调用回收（ToolTrace）**：每次模型调用前把最近 N 轮之外的工具消息压成按轮次排序的轨迹摘要（工具名+参数+结果截断）——长会话上下文膨胀主因是历史工具结果每轮重复注入（实测占 ~45%）。环境变量 TOOL_TRACE_KEEP_ROUNDS / MAX_CHARS 等可配。
2. **记忆分层**：deepagents MemoryMiddleware 超阈值（MEMORY_INJECT_MAX_CHARS 缺省 4000 字符）文件只注入头部 + 索引提示——常驻四文件只放索引的纪律代码化。
3. **草稿本多窗口隔离**：MemoryMiddleware sources 支持 {thread_id} 占位符——SCRATCHPAD/{thread_id}.md 按对话窗口隔离，多窗口各注入各草稿。

## 测试计划

- 本地单测通过（渲染 + persona 宽容 + 未知占位符保留）
- 完整 make all 待 CI（本机未配 dev 环境）
