### PR TITLE
feat: add Didi connector, improve upgrade progress reliability

### DIFF
--- a/.github/workflows/sync-main-to-develop.yml
+++ b/.github/workflows/sync-main-to-develop.yml
@@ -33,7 +33,7 @@ jobs:
           fetch-depth: 0
           ref: develop
 
-      - name: Sync develop onto main
+      - name: Sync main into develop
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ inputs.version }}
@@ -66,7 +66,7 @@ jobs:
 
           saved_develop="$(git rev-parse origin/develop)"
           git checkout -B develop origin/develop
-          merge_msg="chore: sync develop onto main after ${version}"
+          merge_msg="chore: sync main into develop after ${version}"
 
           if git merge origin/main --no-edit -m "${merge_msg}"; then
             if git push origin develop; then
@@ -115,7 +115,7 @@ jobs:
             gh pr create \
               --base develop \
               --head "${sync_branch}" \
-              --title "chore: sync develop onto main after ${version}" \
+              --title "chore: sync main into develop after ${version}" \
               --body "Post-release sync so \`main\` stays an ancestor of \`develop\` (v${version}). Carries main's already-tested tree, so CI is skipped for this branch."
           )"
           echo "Created sync PR: ${url}"

--- a/dashboard/src/assets/connectors/didi.svg
+++ b/dashboard/src/assets/connectors/didi.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="15" fill="#ff6400"/>
+  <path fill="#fff" fill-rule="evenodd" transform="translate(14 18) scale(0.828)" d="M0 0h34.75v8H43.5v3.75A21.75 21.75 0 0 1 0 11.75Zm9 8h25.5v3.75A12.75 12.75 0 0 1 9 11.75Z"/>
+</svg>

--- a/dashboard/src/assets/connectors/index.ts
+++ b/dashboard/src/assets/connectors/index.ts
@@ -1,6 +1,7 @@
 import tencentArdot from "./tencent-ardot.png";
 import baiduMap from "./baidu-map.png";
 import ctripWendao from "./ctrip-wendao.png";
+import didi from "./didi.svg";
 import dida365 from "./dida365.png";
 import dify from "./dify.svg";
 import feishuCli from "./feishu-cli.png";
@@ -29,6 +30,7 @@ export const CONNECTOR_LOGOS: Record<string, string> = {
   "qq-music": qqMusic,
   fliggy,
   "ctrip-wendao": ctripWendao,
+  didi,
   "meituan-travel": meituanTravel,
   yuandian,
   "tencent-ima": tencentIma,

--- a/dashboard/src/pages/Settings/AdvancedSettings/UpdateConfig.tsx
+++ b/dashboard/src/pages/Settings/AdvancedSettings/UpdateConfig.tsx
@@ -153,6 +153,7 @@ export default function UpdateConfig() {
   const { restartPhase, isRestarting, requestRestart, executeRestart } =
     useServiceRestartContext();
   const pollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pollFailRef = useRef(0);
   const autoRestartedRef = useRef(false);
 
   useEffect(() => {
@@ -191,6 +192,7 @@ export default function UpdateConfig() {
   const pollProgress = useCallback(async (taskId: string) => {
     try {
       const prog = await updateApi.getUpgradeProgress(taskId);
+      pollFailRef.current = 0;
       setProgress(prog);
       if (prog.status === "running") {
         pollTimerRef.current = setTimeout(() => pollProgress(taskId), 800);
@@ -207,14 +209,31 @@ export default function UpdateConfig() {
             .catch(() => {});
         }
       }
-    } catch {
+    } catch (err: unknown) {
+      pollFailRef.current += 1;
+      if (pollFailRef.current < 5) {
+        pollTimerRef.current = setTimeout(() => pollProgress(taskId), 800);
+        return;
+      }
       setUpgrading(false);
+      const message = err instanceof Error ? err.message : String(err);
+      setProgress({
+        task_id: taskId,
+        status: "error",
+        stage: "error",
+        percent: null,
+        new_version: null,
+        success: false,
+        error: message,
+        mirror_errors: null,
+      });
     }
   }, []);
 
   const handleUpgrade = useCallback(async () => {
     setUpgrading(true);
     setProgress(null);
+    pollFailRef.current = 0;
     autoRestartedRef.current = false;
     try {
       const started = await updateApi.triggerUpgrade();

--- a/desktop/src/download.go
+++ b/desktop/src/download.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -36,11 +37,22 @@ func pythonExe(root string) string {
 func ensurePortable(locale Locale, status func(string)) error {
 	root := portableDir()
 	if launchReady(root) {
-		status(desktopText(locale, "正在使用已有运行环境…", "Using the existing runtime…"))
-		return nil
+		currentVersion := portableVersion(root)
+		bundledVersion, err := bundledPortableVersion()
+		if err != nil || bundledVersion == "" ||
+			(currentVersion != "" && compareVersions(bundledVersion, currentVersion) <= 0) {
+			status(desktopText(locale, "正在使用已有运行环境…", "Using the existing runtime…"))
+			return nil
+		}
+		status(desktopText(locale, "正在更新内置运行环境…", "Updating the bundled runtime…"))
+	} else {
+		status(desktopText(locale, "首次启动，正在解压内置运行环境…", "First launch: unpacking the bundled runtime…"))
 	}
-	status(desktopText(locale, "首次启动，正在解压内置运行环境…", "First launch: unpacking the bundled runtime…"))
-	if err := extractPortable(root); err != nil {
+	if err := replacePortable(root); err != nil {
+		if launchReady(root) {
+			status(desktopText(locale, "更新内置运行环境失败，继续使用已有运行环境…", "Runtime update failed; using the existing runtime…"))
+			return nil
+		}
 		return err
 	}
 	if runtime.GOOS == "darwin" {
@@ -50,6 +62,190 @@ func ensurePortable(locale Locale, status func(string)) error {
 		return fmt.Errorf("portable extract missing launch.py or python under %s", root)
 	}
 	return nil
+}
+
+func replacePortable(root string) error {
+	next := root + ".new"
+	previous := root + ".previous"
+	_ = os.RemoveAll(next)
+	if err := extractPortable(next); err != nil {
+		_ = os.RemoveAll(next)
+		return err
+	}
+	if !launchReady(next) {
+		_ = os.RemoveAll(next)
+		return fmt.Errorf("portable extract missing launch.py or python under %s", next)
+	}
+
+	_ = os.RemoveAll(previous)
+	hadCurrent := false
+	if _, err := os.Stat(root); err == nil {
+		if err := os.Rename(root, previous); err != nil {
+			_ = os.RemoveAll(next)
+			return err
+		}
+		hadCurrent = true
+	}
+	if err := os.Rename(next, root); err != nil {
+		if hadCurrent {
+			_ = os.Rename(previous, root)
+		}
+		return err
+	}
+	_ = os.RemoveAll(previous)
+	return nil
+}
+
+func portableVersion(root string) string {
+	version := installedPackageVersion(root)
+	data, err := os.ReadFile(filepath.Join(root, "VERSION.txt"))
+	if err == nil {
+		bundledVersion := versionFromText(string(data))
+		if version == "" || compareVersions(bundledVersion, version) > 0 {
+			version = bundledVersion
+		}
+	}
+	return version
+}
+
+func installedPackageVersion(root string) string {
+	matches, _ := filepath.Glob(filepath.Join(root, "packages", "octop-*.dist-info", "METADATA"))
+	version := ""
+	for _, metadata := range matches {
+		data, err := os.ReadFile(metadata)
+		if err != nil {
+			continue
+		}
+		value := metadataVersion(string(data))
+		if value == "" {
+			continue
+		}
+		if version == "" || compareVersions(value, version) > 0 {
+			version = value
+		}
+	}
+	return version
+}
+
+func bundledPortableVersion() (string, error) {
+	if os.Getenv("OCTOP_DESKTOP_PORTABLE_ZIP") == "" && len(embeddedPortable) > 0 {
+		reader, err := zip.NewReader(bytes.NewReader(embeddedPortable), int64(len(embeddedPortable)))
+		if err != nil {
+			return "", err
+		}
+		return versionFromZip(reader.File)
+	}
+	zipPath, err := bundledPortableZip()
+	if err != nil {
+		return "", err
+	}
+	reader, err := zip.OpenReader(zipPath)
+	if err != nil {
+		return "", err
+	}
+	defer reader.Close()
+	return versionFromZip(reader.File)
+}
+
+func versionFromZip(files []*zip.File) (string, error) {
+	fromFile, err := zipEntryVersion(files, func(name string) bool {
+		return filepath.Base(filepath.FromSlash(name)) == "VERSION.txt"
+	}, versionFromText)
+	if err != nil {
+		return "", err
+	}
+	if fromFile != "" {
+		return fromFile, nil
+	}
+	return zipEntryVersion(files, func(name string) bool {
+		rel := filepath.ToSlash(name)
+		return strings.Contains(rel, "/octop-") && strings.HasSuffix(rel, ".dist-info/METADATA")
+	}, metadataVersion)
+}
+
+func zipEntryVersion(files []*zip.File, match func(string) bool, parse func(string) string) (string, error) {
+	version := ""
+	for _, file := range files {
+		if !match(file.Name) {
+			continue
+		}
+		reader, err := file.Open()
+		if err != nil {
+			return "", err
+		}
+		data, readErr := io.ReadAll(reader)
+		closeErr := reader.Close()
+		if readErr != nil {
+			return "", readErr
+		}
+		if closeErr != nil {
+			return "", closeErr
+		}
+		value := parse(string(data))
+		if value == "" {
+			continue
+		}
+		if version == "" || compareVersions(value, version) > 0 {
+			version = value
+		}
+	}
+	return version, nil
+}
+
+func versionFromText(text string) string {
+	for _, line := range strings.Split(text, "\n") {
+		if value, ok := strings.CutPrefix(strings.TrimSpace(line), "octop_version="); ok {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+
+func metadataVersion(text string) string {
+	for _, line := range strings.Split(text, "\n") {
+		value, ok := strings.CutPrefix(strings.TrimSpace(line), "Version:")
+		if ok {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+
+func compareVersions(left, right string) int {
+	leftParts := strings.Split(left, ".")
+	rightParts := strings.Split(right, ".")
+	count := max(len(leftParts), len(rightParts))
+	for index := 0; index < count; index++ {
+		var leftPart, rightPart int
+		if index < len(leftParts) {
+			leftPart = versionPart(leftParts[index])
+		}
+		if index < len(rightParts) {
+			rightPart = versionPart(rightParts[index])
+		}
+		if leftPart < rightPart {
+			return -1
+		}
+		if leftPart > rightPart {
+			return 1
+		}
+	}
+	return 0
+}
+
+func versionPart(segment string) int {
+	numeric := ""
+	for _, ch := range segment {
+		if ch < '0' || ch > '9' {
+			break
+		}
+		numeric += string(ch)
+	}
+	if numeric == "" {
+		return 0
+	}
+	value, _ := strconv.Atoi(numeric)
+	return value
 }
 
 func extractPortable(root string) error {

--- a/desktop/src/download_test.go
+++ b/desktop/src/download_test.go
@@ -19,7 +19,7 @@ func TestEnsurePortableUsesEmbeddedPackage(t *testing.T) {
 	t.Setenv("OCTOP_DESKTOP_PORTABLE_ZIP", "")
 
 	zipPath := filepath.Join(t.TempDir(), "embedded.zip")
-	writeTestGreenZip(t, zipPath)
+	writeTestGreenZip(t, zipPath, "1.0.0")
 	data, err := os.ReadFile(zipPath)
 	if err != nil {
 		t.Fatal(err)
@@ -42,7 +42,7 @@ func TestEnsurePortableUsesBundledPackage(t *testing.T) {
 
 	zipPath := filepath.Join(t.TempDir(), "Octop-"+greenPlat()+".zip")
 	t.Setenv("OCTOP_DESKTOP_PORTABLE_ZIP", zipPath)
-	writeTestGreenZip(t, zipPath)
+	writeTestGreenZip(t, zipPath, "1.0.0")
 
 	var statuses []string
 	err := ensurePortable(LocaleZH, func(status string) {
@@ -59,6 +59,165 @@ func TestEnsurePortableUsesBundledPackage(t *testing.T) {
 	}
 	if _, err := os.Stat(zipPath); err != nil {
 		t.Fatalf("bundled package should be retained: %v", err)
+	}
+}
+
+func TestEnsurePortableReplacesOlderRuntime(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("OCTOP_HOME", home)
+	root := portableDir()
+
+	oldZip := filepath.Join(t.TempDir(), "old.zip")
+	writeTestGreenZip(t, oldZip, "0.9.31")
+	if err := unzipGreen(oldZip, root); err != nil {
+		t.Fatal(err)
+	}
+	stale := filepath.Join(root, "stale.txt")
+	if err := os.WriteFile(stale, []byte("old"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	newZip := filepath.Join(t.TempDir(), "new.zip")
+	writeTestGreenZip(t, newZip, "0.9.32")
+	t.Setenv("OCTOP_DESKTOP_PORTABLE_ZIP", newZip)
+	var statuses []string
+	if err := ensurePortable(LocaleZH, func(status string) { statuses = append(statuses, status) }); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := portableVersion(root); got != "0.9.32" {
+		t.Fatalf("portable version = %q, want 0.9.32", got)
+	}
+	if _, err := os.Stat(stale); !os.IsNotExist(err) {
+		t.Fatalf("old runtime was not replaced: %v", err)
+	}
+	if len(statuses) == 0 || statuses[0] != "正在更新内置运行环境…" {
+		t.Fatalf("unexpected statuses: %v", statuses)
+	}
+}
+
+func TestEnsurePortableKeepsNewerExistingRuntime(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("OCTOP_HOME", home)
+	root := portableDir()
+
+	newZip := filepath.Join(t.TempDir(), "new.zip")
+	writeTestGreenZip(t, newZip, "0.9.33")
+	if err := unzipGreen(newZip, root); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(root, "VERSION.txt"),
+		[]byte("octop_version=0.9.31\n"),
+		0o644,
+	); err != nil {
+		t.Fatal(err)
+	}
+	sentinel := filepath.Join(root, "keep.txt")
+	if err := os.WriteFile(sentinel, []byte("keep"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	oldZip := filepath.Join(t.TempDir(), "old.zip")
+	writeTestGreenZip(t, oldZip, "0.9.32")
+	t.Setenv("OCTOP_DESKTOP_PORTABLE_ZIP", oldZip)
+	if err := ensurePortable(LocaleZH, func(string) {}); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := portableVersion(root); got != "0.9.33" {
+		t.Fatalf("portable version = %q, want 0.9.33", got)
+	}
+	if _, err := os.Stat(sentinel); err != nil {
+		t.Fatalf("newer runtime was unexpectedly replaced: %v", err)
+	}
+}
+
+func TestEnsurePortableKeepsCurrentRuntimeWhenReplacementIsInvalid(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("OCTOP_HOME", home)
+	root := portableDir()
+
+	currentZip := filepath.Join(t.TempDir(), "current.zip")
+	writeTestGreenZip(t, currentZip, "0.9.31")
+	if err := unzipGreen(currentZip, root); err != nil {
+		t.Fatal(err)
+	}
+
+	invalidZip := filepath.Join(t.TempDir(), "invalid.zip")
+	writeVersionOnlyZip(t, invalidZip, "0.9.32")
+	t.Setenv("OCTOP_DESKTOP_PORTABLE_ZIP", invalidZip)
+	var statuses []string
+	if err := ensurePortable(LocaleZH, func(status string) { statuses = append(statuses, status) }); err != nil {
+		t.Fatalf("existing runtime should still boot after a failed replacement: %v", err)
+	}
+
+	if !launchReady(root) {
+		t.Fatal("current runtime should remain usable after replacement failure")
+	}
+	if got := portableVersion(root); got != "0.9.31" {
+		t.Fatalf("portable version = %q, want 0.9.31", got)
+	}
+	if len(statuses) == 0 || statuses[len(statuses)-1] != "更新内置运行环境失败，继续使用已有运行环境…" {
+		t.Fatalf("unexpected statuses: %v", statuses)
+	}
+}
+
+func TestEnsurePortableReplacesLegacyRuntimeWithoutVersionFiles(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("OCTOP_HOME", home)
+	root := portableDir()
+
+	oldZip := filepath.Join(t.TempDir(), "old.zip")
+	writeTestGreenZip(t, oldZip, "0.9.31")
+	if err := unzipGreen(oldZip, root); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(filepath.Join(root, "VERSION.txt")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.RemoveAll(filepath.Join(root, "packages")); err != nil {
+		t.Fatal(err)
+	}
+
+	newZip := filepath.Join(t.TempDir(), "new.zip")
+	writeTestGreenZip(t, newZip, "0.9.32")
+	t.Setenv("OCTOP_DESKTOP_PORTABLE_ZIP", newZip)
+	if err := ensurePortable(LocaleZH, func(string) {}); err != nil {
+		t.Fatal(err)
+	}
+	if got := portableVersion(root); got != "0.9.32" {
+		t.Fatalf("portable version = %q, want 0.9.32", got)
+	}
+}
+
+func TestBundledPortableVersionFallsBackToMetadata(t *testing.T) {
+	zipPath := filepath.Join(t.TempDir(), "meta-only.zip")
+	writeMetadataOnlyZip(t, zipPath, "0.9.32")
+	t.Setenv("OCTOP_DESKTOP_PORTABLE_ZIP", zipPath)
+	got, err := bundledPortableVersion()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "0.9.32" {
+		t.Fatalf("bundled version = %q, want 0.9.32", got)
+	}
+}
+
+func TestCompareVersions(t *testing.T) {
+	for _, test := range []struct {
+		left, right string
+		want        int
+	}{
+		{"0.9.32", "0.9.31", 1},
+		{"0.9.32", "0.9.32", 0},
+		{"0.9.31", "0.9.32", -1},
+		{"1.0", "1.0.0", 0},
+		{"0.9.32rc1", "0.9.31", 1},
+	} {
+		if got := compareVersions(test.left, test.right); got != test.want {
+			t.Fatalf("compareVersions(%q, %q) = %d, want %d", test.left, test.right, got, test.want)
+		}
 	}
 }
 
@@ -162,14 +321,18 @@ func TestWaitHealthTimesOutWithFriendlyMessage(t *testing.T) {
 	}
 }
 
-func writeTestGreenZip(t *testing.T, path string) {
+func writeTestGreenZip(t *testing.T, path, version string) {
 	t.Helper()
 	f, err := os.Create(path)
 	if err != nil {
 		t.Fatal(err)
 	}
 	w := zip.NewWriter(f)
-	files := []string{"Octop-test/launch.py"}
+	files := []string{
+		"Octop-test/launch.py",
+		"Octop-test/VERSION.txt",
+		"Octop-test/packages/octop-" + version + ".dist-info/METADATA",
+	}
 	if runtime.GOOS == "windows" {
 		files = append(files, "Octop-test/runtime/python.exe")
 	} else {
@@ -181,7 +344,11 @@ func writeTestGreenZip(t *testing.T, path string) {
 	for _, name := range files {
 		header := &zip.FileHeader{Name: name, Method: zip.Store}
 		content := []byte("test executable payload")
-		if strings.HasSuffix(name, "/python3") {
+		if strings.HasSuffix(name, "/VERSION.txt") {
+			content = []byte("platform=test\noctop_version=" + version + "\n")
+		} else if strings.HasSuffix(name, "/METADATA") {
+			content = []byte("Name: octop\nVersion: " + version + "\n")
+		} else if strings.HasSuffix(name, "/python3") {
 			header.SetMode(os.ModeSymlink | 0o755)
 			content = []byte("python3.12")
 		} else {
@@ -197,6 +364,50 @@ func writeTestGreenZip(t *testing.T, path string) {
 		if _, err := entry.Write(content); err != nil {
 			t.Fatal(err)
 		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeMetadataOnlyZip(t *testing.T, path, version string) {
+	t.Helper()
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	w := zip.NewWriter(f)
+	entry, err := w.Create("Octop-test/packages/octop-" + version + ".dist-info/METADATA")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := entry.Write([]byte("Name: octop\nVersion: " + version + "\n")); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeVersionOnlyZip(t *testing.T, path, version string) {
+	t.Helper()
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	w := zip.NewWriter(f)
+	entry, err := w.Create("Octop-test/VERSION.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := entry.Write([]byte("octop_version=" + version + "\n")); err != nil {
+		t.Fatal(err)
 	}
 	if err := w.Close(); err != nil {
 		t.Fatal(err)

--- a/src/octop/api/routers/update.py
+++ b/src/octop/api/routers/update.py
@@ -92,7 +92,30 @@ async def check_for_updates(_: Any = Depends(require_permission("update"))) -> d
 
 async def _upgrade_worker(task_id: str) -> None:
     await update_task(task_id, stage="downloading", percent=20)
-    result: UpgradeResult = await asyncio.to_thread(run_upgrade, verbose=False)
+    upgrade_task = asyncio.create_task(asyncio.to_thread(run_upgrade, verbose=False))
+    percent = 20
+    try:
+        while True:
+            try:
+                result: UpgradeResult = await asyncio.wait_for(
+                    asyncio.shield(upgrade_task),
+                    timeout=5,
+                )
+                break
+            except TimeoutError:
+                percent = min(percent + 5, 85)
+                await update_task(task_id, stage="installing", percent=percent)
+    except Exception as exc:
+        logger.exception("upgrade task %s failed unexpectedly", task_id)
+        await update_task(
+            task_id,
+            status=UpgradeTaskStatus.ERROR,
+            stage="error",
+            percent=None,
+            success=False,
+            error=str(exc) or type(exc).__name__,
+        )
+        return
     mirror_errors = result.mirror_errors or None
     if not result.success:
         await update_task(

--- a/src/octop/infra/connectors/builder.py
+++ b/src/octop/infra/connectors/builder.py
@@ -20,6 +20,8 @@ from octop.infra.utils.ulid import new_ulid
 # MCP Streamable HTTP transport (Notion, etc.) requires both content types.
 _MCP_STREAMABLE_HTTP_ACCEPT = "application/json, text/event-stream"
 
+DIDI_MCP_BASE_URL = "https://mcp.didichuxing.com/mcp-servers"
+
 
 def _mcp_http_headers() -> dict[str, str]:
     return {"Accept": _MCP_STREAMABLE_HTTP_ACCEPT}
@@ -86,6 +88,13 @@ def build_http_mcp_spec(
 
 
 def _build_remote_spec(entry: ConnectorCatalogEntry, creds: dict[str, Any]) -> dict[str, Any]:
+    if entry.kind == "didi":
+        api_key = str(creds.get("api_key") or "").strip()
+        return {
+            "transport": "http",
+            "url": f"{DIDI_MCP_BASE_URL}?key={quote(api_key, safe='')}",
+            "headers": _mcp_http_headers(),
+        }
     if entry.kind == "dify":
         url = validate_mcp_http_url(str(creds.get("mcp_url") or ""))
         return {
@@ -314,6 +323,8 @@ def validate_create_credentials(
             raise ValueError(
                 "元典需使用 sk_ 开头的 API Key，请登录 https://open.chineselaw.com/profile 获取"
             )
+        if entry.kind == "didi":
+            return {"api_key": api_key}
         internal_token = new_internal_token()
         out = {"api_key": api_key, "internal_token": internal_token}
         if entry.kind == "tencent-ima":
@@ -425,6 +436,8 @@ def _redact_mcp_configs_for_log(configs: dict[str, Any]) -> dict[str, Any]:
             entry["url"] = url.split("token=", 1)[0] + "token=***"
         elif "/mcp/server/" in url:
             entry["url"] = re.sub(r"(/mcp/server/)[^/?#]+", r"\1***", url)
+        elif "key=" in url:
+            entry["url"] = re.sub(r"([?&]key=)[^&]*", r"\1***", url)
         headers = entry.get("headers")
         if isinstance(headers, dict):
             redacted = dict(headers)

--- a/src/octop/infra/connectors/catalog.py
+++ b/src/octop/infra/connectors/catalog.py
@@ -18,6 +18,15 @@ AuthKind = Literal[
 
 CredentialFieldType = Literal["text", "password", "url", "tags"]
 RemoteTransport = Literal["raw_http", "streamable_http", "sse"]
+ConnectorCategory = Literal[
+    "office",
+    "knowledge",
+    "travel",
+    "productivity",
+    "media",
+    "professional",
+    "self_hosted",
+]
 
 
 @dataclass(frozen=True)
@@ -42,6 +51,7 @@ class ConnectorCatalogEntry:
     color: str
     phase: Literal["available", "coming_soon"]
     mcp_mode: Literal["remote", "gateway"]
+    category: ConnectorCategory
     quick_auth_url: str | None = None
     login_url: str | None = None
     guide_url: str | None = None
@@ -94,6 +104,7 @@ _CATALOG: tuple[ConnectorCatalogEntry, ...] = (
         color="#0052d9",
         phase="available",
         mcp_mode="remote",
+        category="office",
         quick_auth_url="https://docs.qq.com/open/auth/mcp.html",
         guide_url="https://developer.cloud.tencent.com/mcp/server/11803",
         manual_url="https://docs.qq.com/open/auth/mcp.html",
@@ -121,6 +132,7 @@ _CATALOG: tuple[ConnectorCatalogEntry, ...] = (
         color="#07c160",
         phase="available",
         mcp_mode="gateway",
+        category="knowledge",
         quick_auth_url="https://ima.qq.com/agent-interface",
         manual_url="https://ima.qq.com/agent-interface",
         auth_hint="点击「打开授权页」在 IMA 中获取 API Key 与 Client ID（API Key 仅展示一次）",
@@ -135,6 +147,7 @@ _CATALOG: tuple[ConnectorCatalogEntry, ...] = (
         color="#006eff",
         phase="available",
         mcp_mode="remote",
+        category="office",
         quick_auth_url="https://meeting.tencent.com/ai-skill.html",
         guide_url="https://meeting.tencent.com/ai-skill.html",
         manual_url="https://meeting.tencent.com/ai-skill.html",
@@ -150,6 +163,7 @@ _CATALOG: tuple[ConnectorCatalogEntry, ...] = (
         color="#1485ee",
         phase="available",
         mcp_mode="gateway",
+        category="media",
         quick_auth_url="https://news.qq.com/exchange?scene=appkey",
         guide_url="https://qclaw.qq.com/docs/207612064014921728/",
         manual_url="https://news.qq.com/exchange?scene=appkey",
@@ -165,6 +179,7 @@ _CATALOG: tuple[ConnectorCatalogEntry, ...] = (
         color="#1aad19",
         phase="available",
         mcp_mode="gateway",
+        category="media",
         quick_auth_url="https://weread.qq.com/r/weread-skills",
         auth_hint="登录 https://weread.qq.com/r/weread-skills 获取 wrk- 开头的 API Key 后粘贴到下方",
     ),
@@ -178,6 +193,7 @@ _CATALOG: tuple[ConnectorCatalogEntry, ...] = (
         color="#00c1de",
         phase="available",
         mcp_mode="remote",
+        category="office",
         quick_auth_url="https://lexiangla.com/ai/claw",
         guide_url="https://qclaw.qq.com/docs/211858629271314432",
         manual_url="https://lexiangla.com/mcp",
@@ -193,6 +209,7 @@ _CATALOG: tuple[ConnectorCatalogEntry, ...] = (
         color="#00a4ff",
         phase="available",
         mcp_mode="remote",
+        category="office",
         quick_auth_url="https://www.weiyun.com/act/openclaw",
         guide_url="https://www.weiyun.com/act/openclaw",
         manual_url="https://www.weiyun.com/act/openclaw",
@@ -222,6 +239,7 @@ _CATALOG: tuple[ConnectorCatalogEntry, ...] = (
         color="#12b7f5",
         phase="available",
         mcp_mode="gateway",
+        category="productivity",
         manual_url="https://mail.qq.com/",
         auth_hint="选择邮箱服务商，在邮箱设置中开启 IMAP/SMTP 并生成授权码后填入下方",
     ),
@@ -235,6 +253,7 @@ _CATALOG: tuple[ConnectorCatalogEntry, ...] = (
         color="#31c27c",
         phase="available",
         mcp_mode="gateway",
+        category="media",
         quick_auth_url="https://y.qq.com/n/ryqq_v2/qqmusic_skills",
         manual_url="https://y.qq.com/n/ryqq_v2/qqmusic_skills",
         auth_hint="登录 QQ 音乐 Skills 页生成 qmk- 开头的 API Key 并粘贴到下方",
@@ -249,6 +268,7 @@ _CATALOG: tuple[ConnectorCatalogEntry, ...] = (
         color="#ffc700",
         phase="available",
         mcp_mode="gateway",
+        category="travel",
         quick_auth_url="https://flyai.open.fliggy.com/console",
         guide_url="https://qclaw.qq.com/docs/208142370404184064.html",
         manual_url="https://flyai.open.fliggy.com/console",
@@ -264,6 +284,7 @@ _CATALOG: tuple[ConnectorCatalogEntry, ...] = (
         color="#3385ff",
         phase="available",
         mcp_mode="gateway",
+        category="travel",
         quick_auth_url="https://lbs.baidu.com/apiconsole/agentplan",
         guide_url="https://lbsyun.baidu.com/products/agentplan",
         manual_url="https://lbs.baidu.com/apiconsole/agentplan",
@@ -279,6 +300,7 @@ _CATALOG: tuple[ConnectorCatalogEntry, ...] = (
         color="#2577e3",
         phase="available",
         mcp_mode="gateway",
+        category="travel",
         quick_auth_url="http://t.ctrip.cn/28J6RhL",
         guide_url="https://qclaw.qq.com/docs/208231741261246464.html",
         manual_url="http://t.ctrip.cn/28J6RhL",
@@ -296,6 +318,7 @@ _CATALOG: tuple[ConnectorCatalogEntry, ...] = (
         color="#ffc300",
         phase="available",
         mcp_mode="gateway",
+        category="travel",
         quick_auth_url="https://developer.meituan.com/zh/v2/dev/token",
         guide_url="https://developer.meituan.com/hotel-travel-skill",
         manual_url="https://developer.meituan.com/zh/v2/dev/token",
@@ -303,6 +326,23 @@ _CATALOG: tuple[ConnectorCatalogEntry, ...] = (
             "在美团个人开发者页面获取 Token 并粘贴到下方"
             "（探测仅校验格式；真实可用性在对话调用时验证）"
         ),
+    ),
+    ConnectorCatalogEntry(
+        kind="didi",
+        name="滴滴",
+        description="网约车预估/叫车、地点检索与出行路线规划",
+        auth_kind="api_key",
+        doc_url="https://mcp.didichuxing.com/api",
+        icon="didi",
+        color="#ff6400",
+        phase="available",
+        mcp_mode="remote",
+        category="travel",
+        quick_auth_url="https://mcp.didichuxing.com",
+        guide_url="https://mcp.didichuxing.com/api",
+        manual_url="https://mcp.didichuxing.com",
+        auth_hint="打开滴滴开发者控制台登录并激活个人 MCP Key，复制后粘贴到下方",
+        remote_transport="streamable_http",
     ),
     ConnectorCatalogEntry(
         kind="yuandian",
@@ -314,6 +354,7 @@ _CATALOG: tuple[ConnectorCatalogEntry, ...] = (
         color="#1a56db",
         phase="available",
         mcp_mode="gateway",
+        category="professional",
         quick_auth_url="https://open.chineselaw.com/profile",
         guide_url="https://open.chineselaw.com/llms.txt",
         manual_url="https://open.chineselaw.com/profile",
@@ -329,6 +370,7 @@ _CATALOG: tuple[ConnectorCatalogEntry, ...] = (
         color="#8b5cf6",
         phase="available",
         mcp_mode="remote",
+        category="office",
         guide_url="https://docs.ardot.tencent.com/ardot-mcp.html",
         auth_hint="点击「一键授权」完成 Ardot 登录（成功后自动保存），或按文档手动粘贴 Token",
         oauth_issuer="https://ardot.tencent.com",
@@ -345,6 +387,7 @@ _CATALOG: tuple[ConnectorCatalogEntry, ...] = (
         color="#00c853",
         phase="available",
         mcp_mode="remote",
+        category="knowledge",
         quick_auth_url="https://mopen.163.com/#/dashboard",
         guide_url="https://qclaw.qq.com/docs/207508177113886720",
         manual_url="https://mopen.163.com/#/dashboard",
@@ -360,6 +403,7 @@ _CATALOG: tuple[ConnectorCatalogEntry, ...] = (
         color="#000000",
         phase="available",
         mcp_mode="remote",
+        category="knowledge",
         guide_url="https://developers.notion.com/guides/mcp/get-started-with-mcp",
         auth_hint="点击「一键授权」完成 Notion 登录（成功后自动保存），或按官方文档手动获取 Token",
         oauth_issuer="https://mcp.notion.com",
@@ -376,6 +420,7 @@ _CATALOG: tuple[ConnectorCatalogEntry, ...] = (
         color="#e74c3c",
         phase="available",
         mcp_mode="remote",
+        category="productivity",
         guide_url="https://help.dida365.com/articles/7438132116019216384",
         manual_url="https://dida365.com",
         auth_hint="点击「一键授权」完成登录（成功后自动保存），或在网页版「头像 → 设置 → 账户与安全 → API 口令」创建并粘贴 Token",
@@ -394,6 +439,7 @@ _CATALOG: tuple[ConnectorCatalogEntry, ...] = (
         color="#3370ff",
         phase="available",
         mcp_mode="gateway",
+        category="office",
         guide_url="https://open.feishu.cn/document/mcp_open_tools/feishu-cli/set-up-lark-cli-for-ai-agents-in-openclaw_hermes.md",
         manual_url="https://open.feishu.cn/app",
         auth_hint="填写飞书应用 App ID 与 App Secret；文档搜索需再点「登录授权」",
@@ -408,6 +454,7 @@ _CATALOG: tuple[ConnectorCatalogEntry, ...] = (
         color="#2f7bf6",
         phase="available",
         mcp_mode="gateway",
+        category="office",
         guide_url="https://open.work.weixin.qq.com/help2/pc/21676",
         manual_url="https://open.work.weixin.qq.com/help2/pc/cat?doc_id=21677",
         auth_hint="填写长连接智能机器人 Bot ID 与 Secret；主机需已安装 @wecom/cli（wecom-cli）",
@@ -422,6 +469,7 @@ _CATALOG: tuple[ConnectorCatalogEntry, ...] = (
         color="#0052d9",
         phase="available",
         mcp_mode="gateway",
+        category="knowledge",
         guide_url="https://github.com/Tencent/WeKnora/blob/main/docs/api/README.md",
         auth_hint="填写 WeKnora 服务地址；API Key 与 Tenant ID 按部署的鉴权设置填写。",
         credential_fields=(
@@ -466,6 +514,7 @@ _CATALOG: tuple[ConnectorCatalogEntry, ...] = (
         color="#1c64f2",
         phase="available",
         mcp_mode="remote",
+        category="self_hosted",
         auth_hint="在 Dify 应用的访问点中启用 MCP，然后粘贴完整的 MCP Server URL。",
         credential_fields=(
             ConnectorCredentialField(
@@ -509,6 +558,7 @@ def catalog_entry_to_dict(
         "color": entry.color,
         "phase": entry.phase,
         "mcp_mode": entry.mcp_mode,
+        "category": entry.category,
         "quick_auth_url": entry.quick_auth_url,
         "login_url": entry.login_url,
         "guide_url": entry.guide_url or entry.doc_url,

--- a/tests/integration/test_connectors_api.py
+++ b/tests/integration/test_connectors_api.py
@@ -44,6 +44,7 @@ async def test_catalog(env):
         "baidu-map",
         "ctrip-wendao",
         "meituan-travel",
+        "didi",
         "yuandian",
     ):
         entry = next(e for e in r.json() if e["kind"] == kind)
@@ -51,10 +52,12 @@ async def test_catalog(env):
     docs = next(e for e in r.json() if e["kind"] == "tencent-docs")
     assert docs.get("color")
     assert docs.get("quick_auth_url")
+    assert docs["category"] == "office"
     assert "tools" not in docs
     weiyun = next(e for e in r.json() if e["kind"] == "tencent-weiyun")
     assert weiyun["auth_kind"] == "personal_token"
     assert weiyun["mcp_mode"] == "remote"
+    assert weiyun["category"] == "office"
     assert weiyun.get("quick_auth_url") == "https://www.weiyun.com/act/openclaw"
 
 
@@ -417,6 +420,7 @@ async def test_catalog_weknora_dify_last(env):
     assert "wecom-cli" in kinds
     assert kinds.index("feishu-cli") < kinds.index("weknora")
     assert kinds.index("wecom-cli") < kinds.index("dify")
+    assert kinds.index("didi") < kinds.index("weknora")
     assert kinds[-2:] == ["weknora", "dify"]
 
 

--- a/tests/unit/api/test_update_router.py
+++ b/tests/unit/api/test_update_router.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+import asyncio
+import time
+from typing import Any
+
 import pytest
 
 from octop.api.routers import update as update_router
@@ -190,3 +194,62 @@ async def test_upgrade_worker_success_includes_mirror_errors(
     assert stored.status == UpgradeTaskStatus.COMPLETE
     assert stored.new_version == "1.2.3"
     assert stored.mirror_errors == ["mirror-a: skipped"]
+
+
+@pytest.mark.asyncio
+async def test_upgrade_worker_records_unexpected_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_upgrade(*, verbose: bool = False) -> UpgradeResult:
+        del verbose
+        raise RuntimeError("installer crashed")
+
+    monkeypatch.setattr(update_router, "run_upgrade", fail_upgrade)
+
+    task = await create_task()
+    await update_router._upgrade_worker(task.task_id)
+
+    stored = await get_task(task.task_id)
+    assert stored is not None
+    assert stored.status == UpgradeTaskStatus.ERROR
+    assert stored.stage == "error"
+    assert stored.error == "installer crashed"
+
+
+@pytest.mark.asyncio
+async def test_upgrade_worker_advances_percent_while_installing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    percents: list[int] = []
+    original_update_task = update_router.update_task
+
+    async def tracking_update_task(task_id: str, **fields: Any) -> Any:
+        result = await original_update_task(task_id, **fields)
+        percent = fields.get("percent")
+        if isinstance(percent, int):
+            percents.append(percent)
+        return result
+
+    real_wait_for = asyncio.wait_for
+
+    async def wait_for_fast(awaitable: Any, timeout: float | None = None) -> Any:
+        del timeout
+        return await real_wait_for(awaitable, timeout=0.01)
+
+    monkeypatch.setattr(update_router, "update_task", tracking_update_task)
+    monkeypatch.setattr(update_router.asyncio, "wait_for", wait_for_fast)
+    monkeypatch.setattr(
+        update_router,
+        "run_upgrade",
+        lambda verbose=False: (
+            time.sleep(0.05) or UpgradeResult(success=True, installed_version="1.2.3")
+        ),
+    )
+
+    task = await create_task()
+    await update_router._upgrade_worker(task.task_id)
+
+    stored = await get_task(task.task_id)
+    assert stored is not None
+    assert stored.status == UpgradeTaskStatus.COMPLETE
+    assert 25 in percents

--- a/tests/unit/test_connectors.py
+++ b/tests/unit/test_connectors.py
@@ -252,6 +252,78 @@ def test_dify_server_code_is_redacted_from_logs():
     assert redacted["dify__x"]["url"] == "https://dify.example.com/mcp/server/***/mcp"
 
 
+def test_didi_builds_streamable_http_spec_from_user_key():
+    entry = get_catalog_entry("didi")
+    assert entry is not None
+    assert entry.auth_kind == "api_key"
+    assert entry.mcp_mode == "remote"
+    assert entry.remote_transport == "streamable_http"
+
+    creds = validate_create_credentials("didi", {"api_key": "mcp key/1"})
+    assert creds == {"api_key": "mcp key/1"}
+    spec = build_http_mcp_spec(
+        entry=entry,
+        instance_id="x",
+        creds=creds,
+        config=OctopConfig(),
+    )
+    assert spec == {
+        "transport": "http",
+        "url": "https://mcp.didichuxing.com/mcp-servers?key=mcp%20key%2F1",
+        "headers": {"Accept": "application/json, text/event-stream"},
+    }
+
+
+def test_didi_requires_api_key():
+    with pytest.raises(ValueError, match="api_key is required"):
+        validate_create_credentials("didi", {})
+
+
+def test_didi_mcp_key_is_redacted_from_logs():
+    from octop.infra.connectors.builder import _redact_mcp_configs_for_log
+
+    redacted = _redact_mcp_configs_for_log(
+        {
+            "didi__x": {
+                "transport": "http",
+                "url": "https://mcp.didichuxing.com/mcp-servers?key=secret-key",
+            }
+        }
+    )
+    assert redacted["didi__x"]["url"] == "https://mcp.didichuxing.com/mcp-servers?key=***"
+
+
+@pytest.mark.asyncio
+async def test_didi_probe_uses_streamable_http(monkeypatch: pytest.MonkeyPatch):
+    from octop.infra.connectors.probe import probe_connector
+
+    seen: dict[str, object] = {}
+
+    async def _probe(url: str, headers: dict[str, str], *, kind: str) -> dict[str, object]:
+        seen.update(url=url, headers=headers, kind=kind)
+        return {
+            "ok": True,
+            "tool_count": 1,
+            "tools": [{"name": "maps_textsearch", "description": ""}],
+        }
+
+    monkeypatch.setattr("octop.infra.connectors.probe.probe_streamable_http_mcp", _probe)
+    entry = get_catalog_entry("didi")
+    assert entry is not None
+    result = await probe_connector(
+        entry,
+        {"api_key": "mcp-key"},
+        instance_id="probe",
+        config=OctopConfig(),
+    )
+    assert result["ok"] is True
+    assert seen == {
+        "url": "https://mcp.didichuxing.com/mcp-servers?key=mcp-key",
+        "headers": {"Accept": "application/json, text/event-stream"},
+        "kind": "didi",
+    }
+
+
 def test_custom_field_preview_redacts_secrets():
     from octop.api.routers.connectors import _credentials_preview
 
@@ -823,6 +895,34 @@ def test_catalog_entry_dict_has_no_tools():
     assert entry is not None
     data = catalog_entry_to_dict(entry)
     assert "tools" not in data
+    assert data["category"] == "knowledge"
+
+
+def test_every_catalog_entry_has_category():
+    from octop.infra.connectors.catalog import get_catalog_entry, list_catalog
+
+    allowed = {
+        "office",
+        "knowledge",
+        "travel",
+        "productivity",
+        "media",
+        "professional",
+        "self_hosted",
+    }
+    expected = {
+        "tencent-docs": "office",
+        "didi": "travel",
+        "dify": "self_hosted",
+        "yuandian": "professional",
+        "qq-mail": "productivity",
+    }
+    for entry in list_catalog():
+        assert entry.category in allowed, entry.kind
+    for kind, category in expected.items():
+        entry = get_catalog_entry(kind)
+        assert entry is not None
+        assert entry.category == category
 
 
 def test_oauth_ready_notion():


### PR DESCRIPTION
## Summary
- Add Didi (滴滴) MCP connector: catalog entry, remote spec builder, credential validation, and dashboard logo asset.
- Improve self-upgrade reliability: backend reports progress while the upgrade task runs instead of blocking silently, and the frontend poll retries a few times before surfacing a transient error.
- Desktop launcher: detect when the bundled portable runtime is newer than the installed one and replace it in place (extract side-by-side, swap, keep a previous copy for rollback on failure).
- Fix wording in `sync-main-to-develop.yml` (sync direction was described backwards).

## Test plan
- `make all` (format-all + lint + typecheck + test) — all green, 410 tests passed
- `npm run build` (dashboard) — succeeded