### PR TITLE
feat(desktop): upgrade bundled portable runtime with SQLite backup

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -74,6 +74,11 @@ otherwise extracts the matching zip shipped with the desktop package (embedded
 in the Windows and Linux binaries, under `Contents/Resources` on macOS). The
 Wails shell never downloads Octop. For local runtime debugging, set
 `OCTOP_DESKTOP_PORTABLE_ZIP=/absolute/path/Octop-portable-<plat>-<version>.zip`.
+On later launches, a newer bundled portable version replaces the extracted
+runtime after creating a consistent SQLite backup under `~/.octop/backups/`.
+The upgraded Octop process then applies the normal database migrations during
+startup. Newer extracted runtimes are never downgraded; PostgreSQL remains
+externally managed and is not copied by the desktop shell.
 
 GitHub Release names follow `Octop-<kind>-<os>-<arch>-<version>.<ext>`:
 

--- a/desktop/src/assets/index.html
+++ b/desktop/src/assets/index.html
@@ -621,7 +621,7 @@
       }
 
       function applyCopy(locale) {
-        const t = copy[locale] || copy.zh;
+        const t = copy[locale] || copy.en;
         document.getElementById("title").textContent = t.title;
         document.getElementById("subtitle").textContent = t.subtitle;
         document.getElementById("l-lang").textContent = t.lang;
@@ -726,9 +726,9 @@
       const settingsMode =
         new URLSearchParams(window.location.search).get("settings") === "1";
       const s = await call("GetSettingsStatus");
-      const locale = s.locale || "zh";
+      const locale = s.locale || "en";
       document.getElementById("status").textContent =
-        copy[locale].statusWait;
+        (copy[locale] || copy.en).statusWait;
       applyCopy(locale);
 
       if (settingsMode) {

--- a/desktop/src/desktop_copy.go
+++ b/desktop/src/desktop_copy.go
@@ -1,8 +1,90 @@
 package main
 
-func desktopText(locale Locale, zh, en string) string {
-	if locale == LocaleEN {
-		return en
+import "fmt"
+
+const (
+	copyStatusConnecting       = "status.connecting"
+	copyStatusCheckingRuntime  = "status.checking_runtime"
+	copyStatusStartingService  = "status.starting_service"
+	copyStatusReady            = "status.ready"
+	copyStatusUsingRuntime     = "status.using_runtime"
+	copyStatusBackupDatabase   = "status.backup_database"
+	copyStatusInstallingUpdate  = "status.installing_update"
+	copyStatusUpdatingRuntime   = "status.updating_runtime"
+	copyStatusFirstExtract      = "status.first_extract"
+	copyStatusUpdateFailedKeep  = "status.update_failed_keep"
+	copyErrorBackupFailed       = "error.backup_failed"
+	copyErrorUpgradeFailed      = "error.upgrade_failed"
+	copyWait1Minute            = "wait.1_minute"
+	copyWaitNMinutes           = "wait.n_minutes"
+	copyWait1Second            = "wait.1_second"
+	copyWaitNSeconds           = "wait.n_seconds"
+	copyHealthNotReady5xx      = "health.not_ready_5xx"
+	copyHealthNotReadyConnect  = "health.not_ready_connect"
+	copyHealthNotReady         = "health.not_ready"
+)
+
+var desktopCopy = map[Locale]map[string]string{
+	LocaleEN: {
+		copyStatusConnecting:       "Connecting to Octop…",
+		copyStatusCheckingRuntime:  "Checking the runtime…",
+		copyStatusStartingService:  "Starting the Octop service…",
+		copyStatusReady:            "Octop is ready",
+		copyStatusUsingRuntime:     "Using the existing runtime…",
+		copyStatusBackupDatabase:   "Desktop update %s found. Backing up the database…",
+		copyStatusInstallingUpdate: "Installing the bundled desktop update…",
+		copyStatusUpdatingRuntime:  "Updating the bundled runtime…",
+		copyStatusFirstExtract:     "First launch: unpacking the bundled runtime…",
+		copyStatusUpdateFailedKeep: "Runtime update failed; using the existing runtime…",
+		copyErrorBackupFailed:      "Database backup failed before upgrade; the current version was preserved",
+		copyErrorUpgradeFailed:     "Desktop runtime upgrade failed; the current version was preserved",
+		copyWait1Minute:            "1 minute",
+		copyWaitNMinutes:           "%d minutes",
+		copyWait1Second:            "1 second",
+		copyWaitNSeconds:           "%d seconds",
+		copyHealthNotReady5xx:      "Octop did not become ready within %s (%s). The service responded but is not ready yet. Try again, or check the terminal logs.",
+		copyHealthNotReadyConnect:  "Octop did not become ready within %s (%s). Could not connect — make sure Octop is running.",
+		copyHealthNotReady:         "Octop did not become ready within %s (%s). Make sure Octop is running at this address, or check the terminal logs.",
+	},
+	LocaleZH: {
+		copyStatusConnecting:       "正在连接 Octop…",
+		copyStatusCheckingRuntime:  "正在检查运行环境…",
+		copyStatusStartingService:  "正在启动 Octop 服务…",
+		copyStatusReady:            "Octop 已就绪",
+		copyStatusUsingRuntime:     "正在使用已有运行环境…",
+		copyStatusBackupDatabase:   "发现客户端新版 %s，正在备份数据库…",
+		copyStatusInstallingUpdate: "正在安装客户端内置新版…",
+		copyStatusUpdatingRuntime:  "正在更新内置运行环境…",
+		copyStatusFirstExtract:     "首次启动，正在解压内置运行环境…",
+		copyStatusUpdateFailedKeep: "更新内置运行环境失败，继续使用已有运行环境…",
+		copyErrorBackupFailed:      "升级前数据库备份失败，已保留当前版本",
+		copyErrorUpgradeFailed:     "客户端运行环境升级失败，已保留当前版本",
+		copyWait1Minute:            "1 分钟",
+		copyWaitNMinutes:           "%d 分钟",
+		copyWait1Second:            "1 秒",
+		copyWaitNSeconds:           "%d 秒",
+		copyHealthNotReady5xx:      "Octop 服务未在%s内就绪（%s）。服务已响应但尚未就绪，请稍后再试，或查看终端日志。",
+		copyHealthNotReadyConnect:  "Octop 服务未在%s内就绪（%s）。目前无法连接该地址，请确认 Octop 正在运行。",
+		copyHealthNotReady:         "Octop 服务未在%s内就绪（%s）。请确认本机已启动 Octop，且地址、端口正确；也可查看终端日志。",
+	},
+}
+
+func desktopText(locale Locale, key string, args ...any) string {
+	msg := lookupDesktopCopy(locale, key)
+	if len(args) == 0 {
+		return msg
 	}
-	return zh
+	return fmt.Sprintf(msg, args...)
+}
+
+func lookupDesktopCopy(locale Locale, key string) string {
+	if msgs := desktopCopy[locale]; msgs != nil {
+		if msg, ok := msgs[key]; ok {
+			return msg
+		}
+	}
+	if msg, ok := desktopCopy[LocaleEN][key]; ok {
+		return msg
+	}
+	return key
 }

--- a/desktop/src/desktop_copy_test.go
+++ b/desktop/src/desktop_copy_test.go
@@ -2,14 +2,24 @@ package main
 
 import "testing"
 
-func TestDesktopTextFollowsLocale(t *testing.T) {
-	if got := desktopText(LocaleZH, "中文", "English"); got != "中文" {
+func TestDesktopTextLooksUpLocaleWithEnglishDefault(t *testing.T) {
+	if got := desktopText(LocaleZH, copyStatusReady); got != "Octop 已就绪" {
 		t.Fatalf("zh: %s", got)
 	}
-	if got := desktopText(LocaleEN, "中文", "English"); got != "English" {
+	if got := desktopText(LocaleEN, copyStatusReady); got != "Octop is ready" {
 		t.Fatalf("en: %s", got)
 	}
-	if got := desktopText(Locale(""), "中文", "English"); got != "中文" {
-		t.Fatalf("fallback: %s", got)
+	if got := desktopText(Locale(""), copyStatusReady); got != "Octop is ready" {
+		t.Fatalf("unknown locale should fall back to English: %s", got)
+	}
+	if got := desktopText(LocaleZH, "missing.key"); got != "missing.key" {
+		t.Fatalf("unknown key: %s", got)
+	}
+}
+
+func TestDesktopTextFormatsArgs(t *testing.T) {
+	got := desktopText(LocaleEN, copyStatusBackupDatabase, "0.9.32")
+	if got != "Desktop update 0.9.32 found. Backing up the database…" {
+		t.Fatalf("format: %s", got)
 	}
 }

--- a/desktop/src/download.go
+++ b/desktop/src/download.go
@@ -41,28 +41,20 @@ func ensurePortable(locale Locale, status func(string)) error {
 		bundledVersion, err := bundledPortableVersion()
 		if err != nil || bundledVersion == "" ||
 			(currentVersion != "" && compareVersions(bundledVersion, currentVersion) <= 0) {
-			status(desktopText(locale, "正在使用已有运行环境…", "Using the existing runtime…"))
+			status(desktopText(locale, copyStatusUsingRuntime))
 			return nil
 		}
-		status(desktopText(
-			locale,
-			fmt.Sprintf("发现客户端新版 %s，正在备份数据库…", bundledVersion),
-			fmt.Sprintf("Desktop update %s found. Backing up the database…", bundledVersion),
-		))
+		status(desktopText(locale, copyStatusBackupDatabase, bundledVersion))
 		if _, err := backupSQLiteBeforeUpgrade(root, currentVersion, bundledVersion); err != nil {
-			return fmt.Errorf("%s: %w", desktopText(
-				locale,
-				"升级前数据库备份失败，已保留当前版本",
-				"Database backup failed before upgrade; the current version was preserved",
-			), err)
+			return fmt.Errorf("%s: %w", desktopText(locale, copyErrorBackupFailed), err)
 		}
-		status(desktopText(locale, "正在更新内置运行环境…", "Updating the bundled runtime…"))
+		status(desktopText(locale, copyStatusUpdatingRuntime))
 	} else {
-		status(desktopText(locale, "首次启动，正在解压内置运行环境…", "First launch: unpacking the bundled runtime…"))
+		status(desktopText(locale, copyStatusFirstExtract))
 	}
 	if err := replacePortable(root); err != nil {
 		if launchReady(root) {
-			status(desktopText(locale, "更新内置运行环境失败，继续使用已有运行环境…", "Runtime update failed; using the existing runtime…"))
+			status(desktopText(locale, copyStatusUpdateFailedKeep))
 			return nil
 		}
 		return err
@@ -427,23 +419,16 @@ func formatWaitDuration(locale Locale, d time.Duration) string {
 	if minutes {
 		n = sec / 60
 	}
-	if locale == LocaleEN {
-		unit := "seconds"
-		if minutes {
-			unit = "minutes"
-		}
-		if n == 1 {
-			if minutes {
-				return "1 minute"
-			}
-			return "1 second"
-		}
-		return fmt.Sprintf("%d %s", n, unit)
+	switch {
+	case minutes && n == 1:
+		return desktopText(locale, copyWait1Minute)
+	case minutes:
+		return desktopText(locale, copyWaitNMinutes, n)
+	case n == 1:
+		return desktopText(locale, copyWait1Second)
+	default:
+		return desktopText(locale, copyWaitNSeconds, n)
 	}
-	if minutes {
-		return fmt.Sprintf("%d 分钟", n)
-	}
-	return fmt.Sprintf("%d 秒", n)
 }
 
 func formatHealthWaitError(locale Locale, base string, timeout time.Duration, lastErr error, lastStatus int) error {
@@ -451,19 +436,10 @@ func formatHealthWaitError(locale Locale, base string, timeout time.Duration, la
 	wait := formatWaitDuration(locale, timeout)
 	switch {
 	case lastStatus >= 500:
-		return fmt.Errorf("%s", desktopText(locale,
-			fmt.Sprintf("Octop 服务未在%s内就绪（%s）。服务已响应但尚未就绪，请稍后再试，或查看终端日志。", wait, addr),
-			fmt.Sprintf("Octop did not become ready within %s (%s). The service responded but is not ready yet. Try again, or check the terminal logs.", wait, addr),
-		))
+		return fmt.Errorf("%s", desktopText(locale, copyHealthNotReady5xx, wait, addr))
 	case lastErr != nil:
-		return fmt.Errorf("%s", desktopText(locale,
-			fmt.Sprintf("Octop 服务未在%s内就绪（%s）。目前无法连接该地址，请确认 Octop 正在运行。", wait, addr),
-			fmt.Sprintf("Octop did not become ready within %s (%s). Could not connect — make sure Octop is running.", wait, addr),
-		))
+		return fmt.Errorf("%s", desktopText(locale, copyHealthNotReadyConnect, wait, addr))
 	default:
-		return fmt.Errorf("%s", desktopText(locale,
-			fmt.Sprintf("Octop 服务未在%s内就绪（%s）。请确认本机已启动 Octop，且地址、端口正确；也可查看终端日志。", wait, addr),
-			fmt.Sprintf("Octop did not become ready within %s (%s). Make sure Octop is running at this address, or check the terminal logs.", wait, addr),
-		))
+		return fmt.Errorf("%s", desktopText(locale, copyHealthNotReady, wait, addr))
 	}
 }

--- a/desktop/src/download.go
+++ b/desktop/src/download.go
@@ -44,6 +44,18 @@ func ensurePortable(locale Locale, status func(string)) error {
 			status(desktopText(locale, "正在使用已有运行环境…", "Using the existing runtime…"))
 			return nil
 		}
+		status(desktopText(
+			locale,
+			fmt.Sprintf("发现客户端新版 %s，正在备份数据库…", bundledVersion),
+			fmt.Sprintf("Desktop update %s found. Backing up the database…", bundledVersion),
+		))
+		if _, err := backupSQLiteBeforeUpgrade(root, currentVersion, bundledVersion); err != nil {
+			return fmt.Errorf("%s: %w", desktopText(
+				locale,
+				"升级前数据库备份失败，已保留当前版本",
+				"Database backup failed before upgrade; the current version was preserved",
+			), err)
+		}
 		status(desktopText(locale, "正在更新内置运行环境…", "Updating the bundled runtime…"))
 	} else {
 		status(desktopText(locale, "首次启动，正在解压内置运行环境…", "First launch: unpacking the bundled runtime…"))

--- a/desktop/src/download_test.go
+++ b/desktop/src/download_test.go
@@ -91,8 +91,79 @@ func TestEnsurePortableReplacesOlderRuntime(t *testing.T) {
 	if _, err := os.Stat(stale); !os.IsNotExist(err) {
 		t.Fatalf("old runtime was not replaced: %v", err)
 	}
-	if len(statuses) == 0 || statuses[0] != "正在更新内置运行环境…" {
+	if len(statuses) < 2 ||
+		statuses[0] != "发现客户端新版 0.9.32，正在备份数据库…" ||
+		statuses[1] != "正在更新内置运行环境…" {
 		t.Fatalf("unexpected statuses: %v", statuses)
+	}
+}
+
+func TestEnsurePortableUpgradesBundledVersionAfterDatabaseBackup(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("OCTOP_HOME", home)
+	root := portableDir()
+
+	oldZip := filepath.Join(t.TempDir(), "old.zip")
+	writeTestGreenZip(t, oldZip, "0.9.29")
+	if err := unzipGreen(oldZip, root); err != nil {
+		t.Fatal(err)
+	}
+	database := filepath.Join(home, "octop.db")
+	if err := os.WriteFile(database, []byte("database"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	newZip := filepath.Join(t.TempDir(), "new.zip")
+	writeTestGreenZip(t, newZip, "0.9.32")
+	t.Setenv("OCTOP_DESKTOP_PORTABLE_ZIP", newZip)
+
+	previousBackup := runSQLiteBackup
+	runSQLiteBackup = func(_ string, source string, destination string) error {
+		if source != database {
+			t.Fatalf("backup source = %q, want %q", source, database)
+		}
+		return os.WriteFile(destination, []byte("backup"), 0o600)
+	}
+	t.Cleanup(func() { runSQLiteBackup = previousBackup })
+
+	if err := ensurePortable(LocaleZH, func(string) {}); err != nil {
+		t.Fatal(err)
+	}
+	if got := portableVersion(root); got != "0.9.32" {
+		t.Fatalf("portable version = %q, want 0.9.32", got)
+	}
+	backups, err := filepath.Glob(filepath.Join(home, "backups", "octop-desktop-pre-upgrade-*.db"))
+	if err != nil || len(backups) != 1 {
+		t.Fatalf("upgrade backup = %v, err = %v", backups, err)
+	}
+}
+
+func TestEnsurePortableKeepsRuntimeWhenDatabaseBackupFails(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("OCTOP_HOME", home)
+	root := portableDir()
+
+	oldZip := filepath.Join(t.TempDir(), "old.zip")
+	writeTestGreenZip(t, oldZip, "0.9.29")
+	if err := unzipGreen(oldZip, root); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, "octop.db"), []byte("database"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	newZip := filepath.Join(t.TempDir(), "new.zip")
+	writeTestGreenZip(t, newZip, "0.9.32")
+	t.Setenv("OCTOP_DESKTOP_PORTABLE_ZIP", newZip)
+
+	previousBackup := runSQLiteBackup
+	runSQLiteBackup = func(_, _, _ string) error { return errors.New("backup unavailable") }
+	t.Cleanup(func() { runSQLiteBackup = previousBackup })
+
+	if err := ensurePortable(LocaleZH, func(string) {}); err == nil {
+		t.Fatal("backup failure should abort the runtime upgrade")
+	}
+	if got := portableVersion(root); got != "0.9.29" {
+		t.Fatalf("portable version = %q, want preserved 0.9.29", got)
 	}
 }
 

--- a/desktop/src/main.go
+++ b/desktop/src/main.go
@@ -157,12 +157,12 @@ func (a *App) setStatus(msg string) {
 }
 
 func (a *App) boot() {
-	locale := LocaleZH
+	locale := LocaleEN
 	if a.store != nil {
 		locale = a.store.get().Locale
 	}
 	if url := os.Getenv("OCTOP_DESKTOP_URL"); url != "" {
-		a.setStatus(desktopText(locale, "正在连接 Octop…", "Connecting to Octop…"))
+		a.setStatus(desktopText(locale, copyStatusConnecting))
 		if err := waitHealth(locale, url, 60*time.Second); err != nil {
 			a.setStatus(err.Error())
 			return
@@ -171,7 +171,7 @@ func (a *App) boot() {
 		return
 	}
 	s := a.store.get()
-	a.setStatus(desktopText(locale, "正在检查运行环境…", "Checking the runtime…"))
+	a.setStatus(desktopText(locale, copyStatusCheckingRuntime))
 	if err := ensurePortable(locale, a.setStatus); err != nil {
 		a.setStatus(err.Error())
 		return
@@ -187,7 +187,7 @@ func (a *App) boot() {
 		return
 	}
 	base := dashboardURL(s.Port)
-	a.setStatus(desktopText(locale, "正在启动 Octop 服务…", "Starting the Octop service…"))
+	a.setStatus(desktopText(locale, copyStatusStartingService))
 	if err := waitHealth(locale, base, 2*time.Minute); err != nil {
 		a.setStatus(err.Error())
 		return
@@ -206,7 +206,7 @@ func (a *App) showDashboard(base string) {
 		time.Sleep(800 * time.Millisecond)
 		a.applyDashboardPrefs(s)
 	}()
-	a.setStatus(desktopText(s.Locale, "Octop 已就绪", "Octop is ready"))
+	a.setStatus(desktopText(s.Locale, copyStatusReady))
 }
 
 func (a *App) hideToTray() {

--- a/desktop/src/portable_upgrade.go
+++ b/desktop/src/portable_upgrade.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const sqliteBackupScript = "import sqlite3,sys; src=sqlite3.connect(sys.argv[1]); dst=sqlite3.connect(sys.argv[2]); src.backup(dst); dst.close(); src.close()"
+
+var runSQLiteBackup = func(python, source, destination string) error {
+	cmd := exec.Command(python, "-c", sqliteBackupScript, source, destination)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("SQLite backup failed: %w: %s", err, strings.TrimSpace(string(output)))
+	}
+	return nil
+}
+
+type desktopDatabaseConfig struct {
+	Database struct {
+		Driver     string `json:"driver"`
+		SQLitePath string `json:"sqlite_path"`
+	} `json:"database"`
+}
+
+func desktopSQLitePath(home string) (string, bool, error) {
+	driver := "sqlite"
+	sqlitePath := "octop.db"
+	configPath := filepath.Join(home, "config.json")
+	if data, err := os.ReadFile(configPath); err == nil {
+		var config desktopDatabaseConfig
+		if err := json.Unmarshal(data, &config); err != nil {
+			return "", false, fmt.Errorf("read database config: %w", err)
+		}
+		if config.Database.Driver != "" {
+			driver = strings.ToLower(strings.TrimSpace(config.Database.Driver))
+		}
+		if config.Database.SQLitePath != "" {
+			sqlitePath = config.Database.SQLitePath
+		}
+	} else if !os.IsNotExist(err) {
+		return "", false, fmt.Errorf("read database config: %w", err)
+	}
+
+	if os.Getenv("OCTOP_DATABASE_URL") != "" {
+		driver = "postgresql"
+	}
+	if value := strings.TrimSpace(os.Getenv("OCTOP_DATABASE_DRIVER")); value != "" {
+		driver = strings.ToLower(value)
+	}
+	if value := os.Getenv("OCTOP_DATABASE_SQLITE_PATH"); value != "" {
+		sqlitePath = value
+	}
+	if driver == "postgresql" {
+		return "", false, nil
+	}
+	if driver != "sqlite" {
+		return "", false, fmt.Errorf("unsupported database driver %q", driver)
+	}
+	if !filepath.IsAbs(sqlitePath) {
+		sqlitePath = filepath.Join(home, sqlitePath)
+	}
+	return filepath.Clean(sqlitePath), true, nil
+}
+
+func safeVersion(value string) string {
+	var result strings.Builder
+	for _, char := range value {
+		if (char >= 'a' && char <= 'z') || (char >= 'A' && char <= 'Z') ||
+			(char >= '0' && char <= '9') || char == '.' || char == '-' {
+			result.WriteRune(char)
+		}
+	}
+	if result.Len() == 0 {
+		return "unknown"
+	}
+	return result.String()
+}
+
+func backupSQLiteBeforeUpgrade(root, currentVersion, nextVersion string) (string, error) {
+	home := octopHome()
+	source, isSQLite, err := desktopSQLitePath(home)
+	if err != nil || !isSQLite {
+		return "", err
+	}
+	if _, err := os.Stat(source); os.IsNotExist(err) {
+		return "", nil
+	} else if err != nil {
+		return "", fmt.Errorf("inspect SQLite database: %w", err)
+	}
+
+	backupDir := filepath.Join(home, "backups")
+	if err := os.MkdirAll(backupDir, 0o700); err != nil {
+		return "", fmt.Errorf("create backup directory: %w", err)
+	}
+	name := fmt.Sprintf(
+		"octop-desktop-pre-upgrade-%s-to-%s-%s.db",
+		safeVersion(currentVersion),
+		safeVersion(nextVersion),
+		time.Now().UTC().Format("20060102T150405.000000000Z"),
+	)
+	destination := filepath.Join(backupDir, name)
+	if err := runSQLiteBackup(pythonExe(root), source, destination); err != nil {
+		_ = os.Remove(destination)
+		return "", err
+	}
+	if err := os.Chmod(destination, 0o600); err != nil {
+		_ = os.Remove(destination)
+		return "", fmt.Errorf("secure SQLite backup: %w", err)
+	}
+	return destination, nil
+}

--- a/desktop/src/portable_upgrade_test.go
+++ b/desktop/src/portable_upgrade_test.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestPortableVersionPrefersNewestPackageMetadata(t *testing.T) {
+	root := t.TempDir()
+	for versionIndex, version := range []string{"0.9.29", "0.9.32"} {
+		path := filepath.Join(
+			root,
+			"packages",
+			"octop-"+version+".dist-info",
+			"METADATA",
+		)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte("Version: "+version+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if versionIndex == 0 {
+			if err := os.WriteFile(filepath.Join(root, "VERSION.txt"), []byte("octop_version=0.9.28\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	if got := portableVersion(root); got != "0.9.32" {
+		t.Fatalf("portable version = %q, want 0.9.32", got)
+	}
+}
+
+func TestDesktopSQLitePathUsesConfiguredRelativePath(t *testing.T) {
+	home := t.TempDir()
+	config := `{"database":{"driver":"sqlite","sqlite_path":"state/control.db"}}`
+	if err := os.WriteFile(filepath.Join(home, "config.json"), []byte(config), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	path, isSQLite, err := desktopSQLitePath(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !isSQLite {
+		t.Fatal("configured SQLite database was not detected")
+	}
+	want := filepath.Join(home, "state", "control.db")
+	if path != want {
+		t.Fatalf("SQLite path = %q, want %q", path, want)
+	}
+}
+
+func TestDesktopSQLitePathSkipsPostgreSQL(t *testing.T) {
+	home := t.TempDir()
+	config := `{"database":{"driver":"postgresql"}}`
+	if err := os.WriteFile(filepath.Join(home, "config.json"), []byte(config), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	path, isSQLite, err := desktopSQLitePath(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if isSQLite || path != "" {
+		t.Fatalf("PostgreSQL resolved as SQLite: path=%q isSQLite=%v", path, isSQLite)
+	}
+}

--- a/desktop/src/settings.go
+++ b/desktop/src/settings.go
@@ -26,7 +26,7 @@ type Settings struct {
 
 func defaultSettings() Settings {
 	return Settings{
-		Locale:         LocaleZH,
+		Locale:         LocaleEN,
 		Autostart:      false,
 		MinimizeToTray: true,
 		PreventSleep:   false,
@@ -75,8 +75,8 @@ func loadSettings() Settings {
 	if s.Port == 0 {
 		s.Port = 8088
 	}
-	if s.Locale != LocaleEN {
-		s.Locale = LocaleZH
+	if s.Locale != LocaleZH {
+		s.Locale = LocaleEN
 	}
 	return s
 }


### PR DESCRIPTION
## Summary

- Upgrade the extracted desktop portable runtime when the bundled package is newer, after writing a consistent SQLite backup under `~/.octop/backups/`; abort and keep the current runtime if backup or the new package fails, never downgrade, and skip PostgreSQL.
- Replace inline Chinese/English splash copy with a key-based catalog that defaults to English unless settings locale is `zh`.

## Target branch

- [x] Base is **`develop`** (feature / fix — default)
- [ ] Base is **`main`** (`release/*` or `hotfix/*` only)

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / chore
- [ ] Release / hotfix

## Test plan

<!-- How did you verify this? Include commands run (e.g. `make all`). -->

- `cd desktop/src && go test ./...` — passed
- Covers version comparison, SQLite backup before replace, backup/incomplete-package abort, English-default copy lookup

- [ ] `make all` passes locally
- [x] Added/updated tests

## Checklist

- [ ] Updated `CHANGELOG.md` (if user-facing)
- [x] README / docs updated (if needed)