### PR TITLE
feat: multi-provider media generation and voice TTS (siliconflow / openai-compatible / local piper)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@
 
 ## [Unreleased]
 
+### 新增
+
+- 媒体生成支持多服务商：火山方舟 / 硅基流动（Qwen-Image、Wan2.2）/ 任意 OpenAI 兼容中转站，服务商与 API 地址可配置
+- 语音合成（TTS）新增两个预置：SiliconFlow（CosyVoice2 TTS + SenseVoice STT）与 OpenAI Compatible（通用中转站，base URL / 模型 / 音色可配）
+- 语音合成新增本地 Piper 预置（127.0.0.1:8081 qwerty 服务，免费零 token，中文华妍 / 英文 Lessac / 中英 mix 自动切换）
+- STT 模型可与 TTS 模型分开配置（extra.stt_model）；OpenAI 官方卡片消息模型修正为 tts-1 + whisper-1
+
+
 ## [0.9.32] - 2026-09-06
 
 ### 新增

--- a/dashboard/src/api/modules/mediaGeneration.ts
+++ b/dashboard/src/api/modules/mediaGeneration.ts
@@ -2,7 +2,7 @@ import { request } from "../request";
 
 export interface MediaGenerationSettings {
   enabled: boolean;
-  provider: "volcengine";
+  provider: string;
   base_url: string;
   image_enabled: boolean;
   video_enabled: boolean;
@@ -18,6 +18,8 @@ export interface MediaGenerationSettingsInput {
   video_enabled: boolean;
   image_model: string;
   video_model: string;
+  provider: string;
+  base_url: string;
   api_key?: string | null;
 }
 
@@ -26,6 +28,8 @@ export interface MediaGenerationTestInput {
   api_key?: string | null;
   image_model?: string;
   video_model?: string;
+  provider?: string;
+  base_url?: string;
 }
 
 export const mediaGenerationApi = {

--- a/dashboard/src/locales/en.json
+++ b/dashboard/src/locales/en.json
@@ -2395,7 +2395,15 @@
     "readAloud": "Read aloud",
     "micNotAvailable": "Audio recording unavailable — please use HTTPS",
     "sttNotAvailable": "Voice input not available on this device (HTTPS required)",
-    "ttsAutoplayBlocked": "Autoplay blocked by browser — tap read-aloud again"
+    "ttsAutoplayBlocked": "Autoplay blocked by browser — tap read-aloud again",
+    "siliconflowHint": "SiliconFlow cloud TTS (CosyVoice2) / STT (SenseVoice) via the OpenAI-compatible API. Voice ids look like FunAudioLLM/CosyVoice2-0.5B:alex (presets: alex/bella/amber and more).",
+    "openaiCompatHint": "Any OpenAI-compatible relay or gateway (one-api, new-api, custom endpoint). Enter its base URL and key.",
+    "endpoint": "API endpoint",
+    "ttsModel": "TTS model",
+    "sttModel": "STT model",
+    "voiceId": "Voice ID",
+    "piperHint": "Local Piper TTS (free, zero token / cloud cost). Served by the qwerty companion service at 127.0.0.1:8081.",
+    "piperVoice": "Voice"
   },
   "security": {
     "intro": "Configure runtime security policies for agents. Running agents reload automatically after save.",
@@ -2515,7 +2523,8 @@
     "imageTestSuccess": "Image model call succeeded",
     "videoTestSuccess": "The video model accepted the test task and cancellation was requested",
     "modelTestFailed": "Generation model test failed",
-    "modelTestBillingHint": "Model tests submit real requests to Ark and may incur a small charge. A successful video task is cancelled immediately after submission."
+    "modelTestBillingHint": "Model tests submit real requests to Ark and may incur a small charge. A successful video task is cancelled immediately after submission.",
+    "baseUrlHint": "Prefilled for the selected provider; set your relay base URL for OpenAI-compatible gateways"
   },
   "toolFeedback": {
     "failed": "Failed",

--- a/dashboard/src/locales/zh.json
+++ b/dashboard/src/locales/zh.json
@@ -2394,7 +2394,15 @@
     "readAloud": "朗读",
     "micNotAvailable": "此设备不支持录音，请通过 HTTPS 访问",
     "sttNotAvailable": "此设备不支持语音输入（需要 HTTPS）",
-    "ttsAutoplayBlocked": "浏览器阻止了自动播放，请再次点击朗读按钮"
+    "ttsAutoplayBlocked": "浏览器阻止了自动播放，请再次点击朗读按钮",
+    "siliconflowHint": "硅基流动 TTS（CosyVoice2）/STT（SenseVoice），OpenAI 兼容协议。音色名形如 FunAudioLLM/CosyVoice2-0.5B:alex（预置音色：alex/bella/amber 等）。",
+    "openaiCompatHint": "任意 OpenAI 兼容中转站或网关（one-api/new-api 等），填写它的 base URL 与密钥。",
+    "endpoint": "API 地址",
+    "ttsModel": "TTS 模型",
+    "sttModel": "STT 模型",
+    "voiceId": "音色（TTS Voice ID）",
+    "piperHint": "本机 Piper TTS（免费，零 token 零云端费用）。朗读走 qwerty 服务 127.0.0.1:8081。",
+    "piperVoice": "音色"
   },
   "security": {
     "intro": "配置 Agent 运行时的安全防护策略。保存后已运行的 Agent 会自动重新加载配置。",
@@ -2513,7 +2521,8 @@
     "imageTestSuccess": "图片模型调用成功",
     "videoTestSuccess": "视频模型已接受测试任务并已请求取消",
     "modelTestFailed": "生成模型测试失败",
-    "modelTestBillingHint": "模型测试会向方舟提交真实请求，可能产生少量费用；视频任务会在提交成功后立即请求取消。"
+    "modelTestBillingHint": "模型测试会向方舟提交真实请求，可能产生少量费用；视频任务会在提交成功后立即请求取消。",
+    "baseUrlHint": "按所选服务商预填默认地址；中转站请填自己的 OpenAI 兼容地址"
   },
   "toolFeedback": {
     "failed": "调用失败",

--- a/dashboard/src/pages/Settings/MediaGeneration/index.tsx
+++ b/dashboard/src/pages/Settings/MediaGeneration/index.tsx
@@ -6,6 +6,7 @@ import {
   Divider,
   Form,
   Input,
+  Select,
   Space,
   Switch,
   Typography,
@@ -23,28 +24,60 @@ const { Text } = Typography;
 const IMAGE_MODEL_OPTIONS = [
   {
     value: "doubao-seedream-5-0-lite-260128",
-    label: "Doubao Seedream 5.0 Lite",
+    label: "Doubao Seedream 5.0 Lite (Volcengine)",
   },
   {
     value: "doubao-seedream-5-0-260128",
-    label: "Doubao Seedream 5.0",
+    label: "Doubao Seedream 5.0 (Volcengine)",
+  },
+  {
+    value: "Qwen/Qwen-Image",
+    label: "Qwen-Image (SiliconFlow)",
+  },
+  {
+    value: "Kwai-Kolors/Kolors",
+    label: "Kolors (SiliconFlow)",
+  },
+  {
+    value: "dall-e-3",
+    label: "DALL-E 3 (OpenAI protocol)",
   },
 ];
 
 const VIDEO_MODEL_OPTIONS = [
   {
     value: "doubao-seedance-2-0-mini-260615",
-    label: "Doubao Seedance 2.0 Mini",
+    label: "Doubao Seedance 2.0 Mini (Volcengine)",
   },
   {
     value: "doubao-seedance-2-0-fast-260128",
-    label: "Doubao Seedance 2.0 Fast",
+    label: "Doubao Seedance 2.0 Fast (Volcengine)",
   },
   {
     value: "doubao-seedance-2-0-260128",
-    label: "Doubao Seedance 2.0",
+    label: "Doubao Seedance 2.0 (Volcengine)",
+  },
+  {
+    value: "Wan-AI/Wan2.2-T2V-A14B",
+    label: "Wan2.2 T2V (SiliconFlow)",
+  },
+  {
+    value: "Wan-AI/Wan2.2-I2V-A14B",
+    label: "Wan2.2 I2V (SiliconFlow)",
   },
 ];
+
+const PROVIDER_OPTIONS = [
+  { value: "volcengine", label: "Volcengine Ark (火山方舟)" },
+  { value: "siliconflow", label: "SiliconFlow (硅基流动)" },
+  { value: "openai-compatible", label: "OpenAI Compatible (中转站)" },
+];
+
+const DEFAULT_BASE_URL: Record<string, string> = {
+  volcengine: "https://ark.cn-beijing.volces.com/api/v3",
+  siliconflow: "https://api.siliconflow.cn/v1",
+  "openai-compatible": "https://api.openai.com/v1",
+};
 
 export function MediaGenerationSettingsPanel() {
   const { t } = useTranslation();
@@ -94,6 +127,8 @@ export function MediaGenerationSettingsPanel() {
         video_enabled: Boolean(values.video_enabled),
         image_model: String(values.image_model || "").trim(),
         video_model: String(values.video_model || "").trim(),
+        provider: String(values.provider || "volcengine").trim(),
+        base_url: String(values.base_url || "").trim(),
         api_key: values.api_key ? String(values.api_key).trim() : null,
       });
       setApiKeySet(cfg.api_key_set);
@@ -116,6 +151,9 @@ export function MediaGenerationSettingsPanel() {
       const result = await mediaGenerationApi.test({
         kind: "credentials",
         api_key: draft || null,
+        provider: String(form.getFieldValue("provider") || "volcengine").trim(),
+        base_url:
+          String(form.getFieldValue("base_url") || "").trim() || undefined,
       });
       if (result.ok) message.success(t("mediaGeneration.testSuccess"));
       else message.error(result.error || t("mediaGeneration.testFailed"));
@@ -137,6 +175,9 @@ export function MediaGenerationSettingsPanel() {
         api_key: draft || null,
         image_model: String(form.getFieldValue("image_model") || "").trim(),
         video_model: String(form.getFieldValue("video_model") || "").trim(),
+        provider: String(form.getFieldValue("provider") || "volcengine").trim(),
+        base_url:
+          String(form.getFieldValue("base_url") || "").trim() || undefined,
       });
       if (result.ok) {
         message.success(
@@ -166,6 +207,7 @@ export function MediaGenerationSettingsPanel() {
   const imageModel = Form.useWatch("image_model", form);
   const videoModel = Form.useWatch("video_model", form);
   const apiKey = Form.useWatch("api_key", form);
+  const provider = Form.useWatch("provider", form);
 
   return (
     <>
@@ -196,10 +238,20 @@ export function MediaGenerationSettingsPanel() {
                 message={t("mediaGeneration.hint")}
               />
               <Form.Item name="provider" label={t("mediaGeneration.provider")}>
-                <Input disabled />
+                <Select
+                  options={PROVIDER_OPTIONS}
+                  onChange={(value: string) => {
+                    const next = DEFAULT_BASE_URL[value];
+                    if (next) form.setFieldValue("base_url", next);
+                  }}
+                />
               </Form.Item>
-              <Form.Item name="base_url" label={t("mediaGeneration.baseUrl")}>
-                <Input disabled />
+              <Form.Item
+                name="base_url"
+                label={t("mediaGeneration.baseUrl")}
+                extra={t("mediaGeneration.baseUrlHint")}
+              >
+                <Input placeholder={DEFAULT_BASE_URL.volcengine} />
               </Form.Item>
               <Form.Item
                 name="api_key"
@@ -224,7 +276,13 @@ export function MediaGenerationSettingsPanel() {
                 }
               >
                 <Input.Password
-                  placeholder="ark-..."
+                  placeholder={
+                    provider === "siliconflow"
+                      ? "sk-..."
+                      : provider === "openai-compatible"
+                        ? "sk-..."
+                        : "ark-..."
+                  }
                   autoComplete="new-password"
                 />
               </Form.Item>

--- a/dashboard/src/pages/Settings/Voice/index.tsx
+++ b/dashboard/src/pages/Settings/Voice/index.tsx
@@ -41,6 +41,11 @@ export function VoiceSettingsPanel() {
     "payg",
   );
   const [mimoVoiceId, setMimoVoiceId] = useState("冰糖");
+  const [endpointInput, setEndpointInput] = useState("");
+  const [modelInput, setModelInput] = useState("");
+  const [sttModelInput, setSttModelInput] = useState("");
+  const [voiceIdInput, setVoiceIdInput] = useState("");
+  const [piperVoiceId, setPiperVoiceId] = useState("zh");
   const [saving, setSaving] = useState(false);
   const [probing, setProbing] = useState(false);
 
@@ -103,6 +108,11 @@ export function VoiceSettingsPanel() {
     setSecretKey(String(extra.secret_key ?? ""));
     setMimoEndpoint(extra.endpoint_type === "tokenplan" ? "tokenplan" : "payg");
     setMimoVoiceId(String(extra.voice_id ?? "冰糖"));
+    setEndpointInput(String(existing?.base_url ?? ""));
+    setModelInput(String(extra.model ?? ""));
+    setSttModelInput(String(extra.stt_model ?? ""));
+    setVoiceIdInput(String(extra.voice_id ?? ""));
+    setPiperVoiceId(String(extra.voice_id ?? "zh"));
   };
 
   const buildProviderPayload = (): VoiceProviderInput | null => {
@@ -127,8 +137,24 @@ export function VoiceSettingsPanel() {
         endpoint_type: mimoEndpoint,
         voice_id: preset.capability === "tts" ? mimoVoiceId : undefined,
       };
+    } else if (preset.id === "siliconflow") {
+      baseUrl = "https://api.siliconflow.cn/v1";
+      extra = {
+        model: modelInput || "FunAudioLLM/CosyVoice2-0.5B",
+        stt_model: sttModelInput || "FunAudioLLM/SenseVoiceSmall",
+        voice_id: voiceIdInput || "FunAudioLLM/CosyVoice2-0.5B:alex",
+      };
+    } else if (preset.id === "openai-compatible") {
+      baseUrl = endpointInput.trim() || "https://api.openai.com/v1";
+      extra = {
+        model: modelInput || "tts-1",
+        stt_model: sttModelInput || "whisper-1",
+        voice_id: voiceIdInput || "alloy",
+      };
+    } else if (preset.kind === "piper") {
+      extra = { voice_id: piperVoiceId || "zh" };
     } else {
-      extra = { model: preset.kind === "openai" ? "whisper-1" : undefined };
+      extra = { model: "tts-1", stt_model: "whisper-1" };
     }
     return {
       name: preset.id,
@@ -421,9 +447,74 @@ export function VoiceSettingsPanel() {
               </Form.Item>
             </>
           )}
-          {configure?.preset.kind === "openai" && (
+          {configure?.preset.kind === "openai" &&
+            configure?.preset.id === "openai" && (
+              <>
+                <div className={styles.drawerHint}>{t("voice.openaiHint")}</div>
+                <Form.Item label="API Key" required>
+                  <Input.Password
+                    placeholder="API Key"
+                    value={apiKey}
+                    onChange={(e) => setApiKey(e.target.value)}
+                  />
+                </Form.Item>
+                <Form.Item label={t("voice.mimoEndpoint")}>
+                  <Select
+                    value="https://api.openai.com/v1"
+                    disabled
+                    options={[
+                      {
+                        value: "https://api.openai.com/v1",
+                        label: "OpenAI API",
+                      },
+                    ]}
+                  />
+                </Form.Item>
+              </>
+            )}
+          {configure?.preset.id === "siliconflow" && (
             <>
-              <div className={styles.drawerHint}>{t("voice.openaiHint")}</div>
+              <div className={styles.drawerHint}>
+                {t("voice.siliconflowHint")}
+              </div>
+              <Form.Item label="API Key" required>
+                <Input.Password
+                  placeholder="SK-..."
+                  value={apiKey}
+                  onChange={(e) => setApiKey(e.target.value)}
+                />
+              </Form.Item>
+              <Form.Item label={t("voice.endpoint")}>
+                <Input value="https://api.siliconflow.cn/v1" disabled />
+              </Form.Item>
+              <Form.Item label={t("voice.ttsModel")}>
+                <Input
+                  placeholder="FunAudioLLM/CosyVoice2-0.5B"
+                  value={modelInput}
+                  onChange={(e) => setModelInput(e.target.value)}
+                />
+              </Form.Item>
+              <Form.Item label={t("voice.sttModel")}>
+                <Input
+                  placeholder="FunAudioLLM/SenseVoiceSmall"
+                  value={sttModelInput}
+                  onChange={(e) => setSttModelInput(e.target.value)}
+                />
+              </Form.Item>
+              <Form.Item label={t("voice.voiceId")}>
+                <Input
+                  placeholder="FunAudioLLM/CosyVoice2-0.5B:alex"
+                  value={voiceIdInput}
+                  onChange={(e) => setVoiceIdInput(e.target.value)}
+                />
+              </Form.Item>
+            </>
+          )}
+          {configure?.preset.id === "openai-compatible" && (
+            <>
+              <div className={styles.drawerHint}>
+                {t("voice.openaiCompatHint")}
+              </div>
               <Form.Item label="API Key" required>
                 <Input.Password
                   placeholder="API Key"
@@ -431,14 +522,49 @@ export function VoiceSettingsPanel() {
                   onChange={(e) => setApiKey(e.target.value)}
                 />
               </Form.Item>
-              <Form.Item label={t("voice.mimoEndpoint")}>
+              <Form.Item label={t("voice.endpoint")} required>
+                <Input
+                  placeholder="https://api.openai.com/v1"
+                  value={endpointInput}
+                  onChange={(e) => setEndpointInput(e.target.value)}
+                />
+              </Form.Item>
+              <Form.Item label={t("voice.ttsModel")}>
+                <Input
+                  placeholder="tts-1"
+                  value={modelInput}
+                  onChange={(e) => setModelInput(e.target.value)}
+                />
+              </Form.Item>
+              <Form.Item label={t("voice.sttModel")}>
+                <Input
+                  placeholder="whisper-1"
+                  value={sttModelInput}
+                  onChange={(e) => setSttModelInput(e.target.value)}
+                />
+              </Form.Item>
+              <Form.Item label={t("voice.voiceId")}>
+                <Input
+                  placeholder="alloy"
+                  value={voiceIdInput}
+                  onChange={(e) => setVoiceIdInput(e.target.value)}
+                />
+              </Form.Item>
+            </>
+          )}
+          {configure?.preset.kind === "piper" && (
+            <>
+              <div className={styles.drawerHint}>{t("voice.piperHint")}</div>
+              <Form.Item label={t("voice.piperVoice")} required>
                 <Select
-                  value="https://api.openai.com/v1"
-                  disabled
+                  value={piperVoiceId}
+                  onChange={(v: string) => setPiperVoiceId(v)}
                   options={[
+                    { value: "zh", label: "中文（华妍）" },
+                    { value: "en", label: "English（Lessac）" },
                     {
-                      value: "https://api.openai.com/v1",
-                      label: "OpenAI API",
+                      value: "mix",
+                      label: "中英混合（自动切换）",
                     },
                   ]}
                 />

--- a/src/octop/api/routers/media_generation.py
+++ b/src/octop/api/routers/media_generation.py
@@ -12,6 +12,8 @@ from octop.infra.agents.media_generation import (
     DEFAULT_ARK_BASE_URL,
     DEFAULT_IMAGE_MODEL,
     DEFAULT_VIDEO_MODEL,
+    SUPPORTED_MEDIA_PROVIDERS,
+    default_media_base_url,
 )
 from octop.infra.errors import ErrorCode, OctopError
 
@@ -36,9 +38,11 @@ class MediaGenerationSettingsBody(BaseModel):
     video_enabled: bool = True
     image_model: str = DEFAULT_IMAGE_MODEL
     video_model: str = DEFAULT_VIDEO_MODEL
+    provider: str = "volcengine"
+    base_url: str | None = None
     api_key: str | None = Field(
         default=None,
-        description="Write-only Ark inference API key; omit to keep the stored key.",
+        description="Write-only provider inference API key; omit to keep the stored key.",
     )
 
 
@@ -46,10 +50,12 @@ class MediaGenerationTestBody(BaseModel):
     kind: Literal["credentials", "image", "video"] = "credentials"
     api_key: str | None = Field(
         default=None,
-        description="Draft Ark API key; omit to test the stored key.",
+        description="Draft provider API key; omit to test the stored key.",
     )
     image_model: str = DEFAULT_IMAGE_MODEL
     video_model: str = DEFAULT_VIDEO_MODEL
+    provider: str | None = None
+    base_url: str | None = None
 
 
 class MediaGenerationTestResponse(BaseModel):
@@ -74,7 +80,7 @@ def _response(view: Any) -> MediaGenerationSettingsResponse:
 @router.get(
     "",
     summary="Get media generation settings",
-    description="Return instance-wide Volcengine Ark generation settings. The stored API key is never returned.",
+    description="Return instance-wide media generation settings (Volcengine Ark, SiliconFlow, or an OpenAI-compatible relay). The stored API key is never returned.",
     response_model=MediaGenerationSettingsResponse,
 )
 async def get_media_generation_settings(
@@ -87,7 +93,7 @@ async def get_media_generation_settings(
 @router.put(
     "",
     summary="Update media generation settings",
-    description="Verify a new Ark API key when supplied, persist the settings, and reload running agents.",
+    description="Verify a new provider API key when supplied, persist the settings, and reload running agents.",
     response_model=MediaGenerationSettingsResponse,
 )
 async def put_media_generation_settings(
@@ -96,13 +102,27 @@ async def put_media_generation_settings(
     server: Any = Depends(get_server),
 ) -> MediaGenerationSettingsResponse:
     api_key = (body.api_key or "").strip() or None
+    provider = (body.provider or "volcengine").strip()
+    if provider not in SUPPORTED_MEDIA_PROVIDERS:
+        raise OctopError(
+            ErrorCode.SLASH_BAD_ARGS,
+            f"unsupported media generation provider {provider!r}; "
+            f"choose from {', '.join(SUPPORTED_MEDIA_PROVIDERS)}",
+        )
+    base_url = (body.base_url or default_media_base_url(provider)).strip()
+    if not base_url.startswith(("https://", "http://")):
+        raise OctopError(ErrorCode.SLASH_BAD_ARGS, "media generation base URL must be an HTTP(S) URL")
     store = server.app_runtime.agent_registry.media_generation
     if api_key is not None:
-        result = await store.test_connection(api_key=api_key)
+        result = await store.test_connection(
+            api_key=api_key,
+            provider=provider,
+            base_url=base_url,
+        )
         if not result.get("ok"):
             raise OctopError(
                 ErrorCode.SLASH_BAD_ARGS,
-                str(result.get("error") or "Ark API key verification failed"),
+                str(result.get("error") or "provider API key verification failed"),
             )
     view = await server.app_runtime.agent_registry.save_media_generation(
         enabled=body.enabled,
@@ -111,13 +131,15 @@ async def put_media_generation_settings(
         image_model=body.image_model,
         video_model=body.video_model,
         api_key=api_key,
+        provider=provider,
+        base_url=base_url,
     )
     return _response(view)
 
 
 @router.post(
     "/test",
-    summary="Test Ark media generation credentials",
+    summary="Test media generation credentials",
     description="Test credentials or submit a real image/video model request. Model tests may incur provider charges.",
     response_model=MediaGenerationTestResponse,
 )
@@ -129,12 +151,18 @@ async def test_media_generation_credentials(
     store = server.app_runtime.agent_registry.media_generation
     api_key = (body.api_key or "").strip() or None
     if body.kind == "credentials":
-        result = await store.test_connection(api_key=api_key)
+        result = await store.test_connection(
+            api_key=api_key,
+            provider=body.provider,
+            base_url=body.base_url,
+        )
     else:
         result = await store.test_model(
             kind=body.kind,
             model=body.image_model if body.kind == "image" else body.video_model,
             api_key=api_key,
+            provider=body.provider,
+            base_url=body.base_url,
         )
     return MediaGenerationTestResponse(
         ok=bool(result.get("ok")),

--- a/src/octop/infra/agents/manager.py
+++ b/src/octop/infra/agents/manager.py
@@ -1532,6 +1532,8 @@ class AgentManager:
         image_model: str,
         video_model: str,
         api_key: str | None = None,
+        provider: str | None = None,
+        base_url: str | None = None,
     ) -> MediaGenerationSettings:
         """Persist media settings and rebuild running harness agents."""
         view = self._media_generation.save(
@@ -1541,6 +1543,8 @@ class AgentManager:
             image_model=image_model,
             video_model=video_model,
             api_key=api_key,
+            provider=provider,
+            base_url=base_url,
         )
         await self.reload_all()
         return view

--- a/src/octop/infra/agents/media_generation.py
+++ b/src/octop/infra/agents/media_generation.py
@@ -18,8 +18,24 @@ if TYPE_CHECKING:
     from harness_agent import MediaGenerationConfig
 
 DEFAULT_ARK_BASE_URL = "https://ark.cn-beijing.volces.com/api/v3"
+DEFAULT_SILICONFLOW_BASE_URL = "https://api.siliconflow.cn/v1"
+DEFAULT_OPENAI_COMPAT_BASE_URL = "https://api.openai.com/v1"
 DEFAULT_IMAGE_MODEL = "doubao-seedream-5-0-lite-260128"
 DEFAULT_VIDEO_MODEL = "doubao-seedance-2-0-mini-260615"
+DEFAULT_IMAGE_MODEL_SILICONFLOW = "Qwen/Qwen-Image"
+DEFAULT_VIDEO_MODEL_SILICONFLOW = "Wan-AI/Wan2.2-T2V-A14B"
+DEFAULT_IMAGE_MODEL_OPENAI_COMPAT = "dall-e-3"
+
+SUPPORTED_MEDIA_PROVIDERS = ("volcengine", "siliconflow", "openai-compatible")
+
+
+def default_media_base_url(provider: str) -> str:
+    if provider == "siliconflow":
+        return DEFAULT_SILICONFLOW_BASE_URL
+    if provider == "openai-compatible":
+        return DEFAULT_OPENAI_COMPAT_BASE_URL
+    return DEFAULT_ARK_BASE_URL
+
 
 MediaTestKind = Literal["image", "video"]
 
@@ -28,6 +44,8 @@ _KEY_IMAGE_ENABLED = "media_generation_image_enabled"
 _KEY_VIDEO_ENABLED = "media_generation_video_enabled"
 _KEY_IMAGE_MODEL = "media_generation_image_model"
 _KEY_VIDEO_MODEL = "media_generation_video_model"
+_KEY_PROVIDER = "media_generation_provider"
+_KEY_BASE_URL = "media_generation_base_url"
 _SECRET_CREDENTIALS = "media_generation_credentials"
 
 
@@ -88,6 +106,213 @@ async def verify_ark_api_key(
     if response.is_error:
         return {"ok": False, "error": f"Ark ping returned HTTP {response.status_code}"}
     return {"ok": True}
+
+
+async def verify_openai_compatible_api_key(
+    api_key: str,
+    *,
+    base_url: str,
+    client: httpx.AsyncClient | None = None,
+) -> dict[str, object]:
+    """Verify a key against the OpenAI-compatible /models endpoint."""
+    try:
+        if client is not None:
+            response = await client.get(
+                f"{base_url.rstrip('/')}/models",
+                headers={"Authorization": f"Bearer {api_key}"},
+            )
+        else:
+            async with httpx.AsyncClient(timeout=10, follow_redirects=True) as http:
+                response = await http.get(
+                    f"{base_url.rstrip('/')}/models",
+                    headers={"Authorization": f"Bearer {api_key}"},
+                )
+    except httpx.HTTPError as exc:
+        return {"ok": False, "error": str(exc)}
+    if response.status_code in {401, 403}:
+        return {"ok": False, "error": "provider API key authentication failed"}
+    if response.is_error:
+        return {"ok": False, "error": f"/models returned HTTP {response.status_code}"}
+    return {"ok": True}
+
+
+async def verify_provider_api_key(
+    api_key: str,
+    *,
+    provider: str,
+    base_url: str,
+    client: httpx.AsyncClient | None = None,
+) -> dict[str, object]:
+    """Verify credentials against the selected media provider."""
+    if provider == "volcengine":
+        return await verify_ark_api_key(api_key, base_url=base_url, client=client)
+    return await verify_openai_compatible_api_key(api_key, base_url=base_url, client=client)
+
+
+async def _verify_openai_compatible_image(
+    api_key: str,
+    *,
+    model: str,
+    base_url: str,
+    client: httpx.AsyncClient | None = None,
+) -> dict[str, object]:
+    """Probe OpenAI-dialect image generations; explicit, potentially billable."""
+
+    async def _request(http: httpx.AsyncClient) -> httpx.Response:
+        return await http.post(
+            f"{base_url.rstrip('/')}/images/generations",
+            headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
+            json={
+                "model": model,
+                "prompt": "A plain blue circle centered on a white background.",
+                "size": "1024x1024",
+                "n": 1,
+                "response_format": "url",
+            },
+        )
+
+    try:
+        if client is not None:
+            response = await _request(client)
+        else:
+            async with httpx.AsyncClient(timeout=120, follow_redirects=True) as http:
+                response = await _request(http)
+    except httpx.HTTPError as exc:
+        return {"ok": False, "error": str(exc)}
+    return _classify_verify_response(response, kind="image", is_siliconflow=False)
+
+
+async def _verify_siliconflow_image(
+    api_key: str,
+    *,
+    model: str,
+    base_url: str,
+    client: httpx.AsyncClient | None = None,
+) -> dict[str, object]:
+    """Probe SiliconFlow-dialect image generations; explicit, potentially billable."""
+
+    async def _request(http: httpx.AsyncClient) -> httpx.Response:
+        return await http.post(
+            f"{base_url.rstrip('/')}/images/generations",
+            headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
+            json={
+                "model": model,
+                "prompt": "A plain blue circle centered on a white background.",
+                "image_size": "1024x1024",
+                "batch_size": 1,
+            },
+        )
+
+    try:
+        if client is not None:
+            response = await _request(client)
+        else:
+            async with httpx.AsyncClient(timeout=120, follow_redirects=True) as http:
+                response = await _request(http)
+    except httpx.HTTPError as exc:
+        return {"ok": False, "error": str(exc)}
+    return _classify_verify_response(response, kind="image", is_siliconflow=True)
+
+
+async def _verify_siliconflow_video(
+    api_key: str,
+    *,
+    model: str,
+    base_url: str,
+    client: httpx.AsyncClient | None = None,
+) -> dict[str, object]:
+    """Submit a SiliconFlow video task to verify model access (runs and bills)."""
+
+    async def _request(http: httpx.AsyncClient) -> httpx.Response:
+        return await http.post(
+            f"{base_url.rstrip('/')}/video/submit",
+            headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
+            json={
+                "model": model,
+                "prompt": "A static blue circle on a white background.",
+                "image_size": "1280x720",
+            },
+        )
+
+    try:
+        if client is not None:
+            response = await _request(client)
+        else:
+            async with httpx.AsyncClient(timeout=60, follow_redirects=True) as http:
+                response = await _request(http)
+    except httpx.HTTPError as exc:
+        return {"ok": False, "error": str(exc)}
+    if response.is_error:
+        return _classify_verify_response(response, kind="video", is_siliconflow=True)
+    try:
+        payload = response.json()
+    except ValueError:
+        return {"ok": False, "error": "SiliconFlow returned invalid JSON"}
+    if not isinstance(payload, dict) or not isinstance(payload.get("requestId"), str):
+        return {"ok": False, "error": "SiliconFlow video test returned no requestId"}
+    return {"ok": True}
+
+
+def _classify_verify_response(
+    response: httpx.Response,
+    *,
+    kind: str,
+    is_siliconflow: bool,
+) -> dict[str, object]:
+    """Shared error extraction for provider probe responses."""
+    provider_name = "SiliconFlow" if is_siliconflow else "OpenAI-compatible"
+    if response.is_error:
+        try:
+            payload = response.json()
+        except ValueError:
+            payload = None
+        detail = ""
+        if isinstance(payload, dict):
+            error = payload.get("error")
+            if isinstance(error, dict):
+                code = error.get("code")
+                message = error.get("message")
+                detail = ": ".join(str(value) for value in (code, message) if value)
+            elif error:
+                detail = str(error)
+            if not detail and payload.get("message"):
+                detail = str(payload["message"])
+        if response.status_code in {401, 403}:
+            return {"ok": False, "error": f"provider API key authentication failed ({response.status_code})"}
+        if response.status_code == 429 or "rate limit" in detail.lower():
+            return {"ok": False, "error": f"{provider_name} rate limited: {detail or response.status_code}"}
+        return {"ok": False, "error": detail or f"{provider_name} returned HTTP {response.status_code}"}
+    try:
+        payload = response.json()
+    except ValueError:
+        return {"ok": False, "error": f"{provider_name} returned invalid JSON"}
+    if not isinstance(payload, dict):
+        return {"ok": False, "error": f"{provider_name} returned an unexpected response"}
+    rows = payload.get("images" if is_siliconflow else "data")
+    if kind == "image" and not isinstance(rows, list):
+        return {"ok": False, "error": f"{provider_name} image test returned no output"}
+    return {"ok": True}
+
+
+async def verify_provider_media_model(
+    api_key: str,
+    *,
+    kind: MediaTestKind,
+    model: str,
+    provider: str,
+    base_url: str,
+    client: httpx.AsyncClient | None = None,
+) -> dict[str, object]:
+    """Run an explicit, potentially billable probe against one media model."""
+    if provider == "volcengine":
+        return await verify_ark_media_model(api_key, kind=kind, model=model, base_url=base_url, client=client)
+    if provider == "siliconflow":
+        if kind == "image":
+            return await _verify_siliconflow_image(api_key, model=model, base_url=base_url, client=client)
+        return await _verify_siliconflow_video(api_key, model=model, base_url=base_url, client=client)
+    if kind == "image":
+        return await _verify_openai_compatible_image(api_key, model=model, base_url=base_url, client=client)
+    return {"ok": False, "error": "the openai-compatible provider does not support video generation"}
 
 
 async def verify_ark_media_model(
@@ -202,6 +427,10 @@ class MediaGenerationSettingsStore:
         self._secrets = secret_repo
 
     def load(self) -> MediaGenerationSettings:
+        provider = (self._settings.get(_KEY_PROVIDER) or "volcengine").strip()
+        if provider not in SUPPORTED_MEDIA_PROVIDERS:
+            provider = "volcengine"
+        base_url = (self._settings.get(_KEY_BASE_URL) or default_media_base_url(provider)).strip()
         return MediaGenerationSettings(
             enabled=_stored_bool(self._settings, _KEY_ENABLED, default=False),
             image_enabled=_stored_bool(self._settings, _KEY_IMAGE_ENABLED, default=True),
@@ -209,6 +438,8 @@ class MediaGenerationSettingsStore:
             image_model=(self._settings.get(_KEY_IMAGE_MODEL) or DEFAULT_IMAGE_MODEL).strip(),
             video_model=(self._settings.get(_KEY_VIDEO_MODEL) or DEFAULT_VIDEO_MODEL).strip(),
             api_key_set=self._secrets.get(_SECRET_CREDENTIALS) is not None,
+            provider=provider,
+            base_url=base_url,
         )
 
     def save(
@@ -220,9 +451,21 @@ class MediaGenerationSettingsStore:
         image_model: str,
         video_model: str,
         api_key: str | None = None,
+        provider: str | None = None,
+        base_url: str | None = None,
     ) -> MediaGenerationSettings:
         image_model = image_model.strip()
         video_model = video_model.strip()
+        provider = (provider or self.load().provider).strip()
+        if provider not in SUPPORTED_MEDIA_PROVIDERS:
+            raise OctopError(
+                ErrorCode.SLASH_BAD_ARGS,
+                f"unsupported media generation provider {provider!r}; "
+                f"choose from {', '.join(SUPPORTED_MEDIA_PROVIDERS)}",
+            )
+        base_url = (base_url or default_media_base_url(provider)).strip()
+        if not base_url.startswith(("https://", "http://")):
+            raise OctopError(ErrorCode.SLASH_BAD_ARGS, "media generation base URL must be an HTTP(S) URL")
         has_stored_key = self._secrets.get(_SECRET_CREDENTIALS) is not None
         if enabled and not (image_enabled or video_enabled):
             raise OctopError(
@@ -234,8 +477,10 @@ class MediaGenerationSettingsStore:
         if enabled and video_enabled and not video_model:
             raise OctopError(ErrorCode.SLASH_BAD_ARGS, "video_model is required")
         if enabled and not (api_key or has_stored_key):
-            raise OctopError(ErrorCode.SLASH_BAD_ARGS, "Ark API key is required")
+            raise OctopError(ErrorCode.SLASH_BAD_ARGS, "the provider API key is required")
 
+        self._settings.set(_KEY_PROVIDER, provider)
+        self._settings.set(_KEY_BASE_URL, base_url)
         self._settings.set(_KEY_ENABLED, "true" if enabled else "false")
         self._settings.set(_KEY_IMAGE_ENABLED, "true" if image_enabled else "false")
         self._settings.set(_KEY_VIDEO_ENABLED, "true" if video_enabled else "false")
@@ -256,11 +501,20 @@ class MediaGenerationSettingsStore:
         value = decrypt_credentials(self._secrets, blob).get("api_key")
         return str(value) if value else None
 
-    async def test_connection(self, *, api_key: str | None = None) -> dict[str, object]:
+    async def test_connection(
+        self,
+        *,
+        api_key: str | None = None,
+        provider: str | None = None,
+        base_url: str | None = None,
+    ) -> dict[str, object]:
+        view = self.load()
+        provider = (provider or view.provider or "volcengine").strip()
+        base_url = (base_url or view.base_url or default_media_base_url(provider)).strip()
         key = (api_key or self.api_key() or "").strip()
         if not key:
-            raise OctopError(ErrorCode.SLASH_BAD_ARGS, "Ark API key is required")
-        return await verify_ark_api_key(key)
+            raise OctopError(ErrorCode.SLASH_BAD_ARGS, "provider API key is required")
+        return await verify_provider_api_key(key, provider=provider, base_url=base_url)
 
     async def test_model(
         self,
@@ -268,15 +522,26 @@ class MediaGenerationSettingsStore:
         kind: MediaTestKind,
         model: str,
         api_key: str | None = None,
+        provider: str | None = None,
+        base_url: str | None = None,
     ) -> dict[str, object]:
-        """Test that the selected Ark media model accepts a real request."""
+        """Test that the selected media model accepts a real request."""
+        view = self.load()
+        provider = (provider or view.provider or "volcengine").strip()
+        base_url = (base_url or view.base_url or default_media_base_url(provider)).strip()
         key = (api_key or self.api_key() or "").strip()
         model = model.strip()
         if not key:
-            raise OctopError(ErrorCode.SLASH_BAD_ARGS, "Ark API key is required")
+            raise OctopError(ErrorCode.SLASH_BAD_ARGS, "provider API key is required")
         if not model:
             raise OctopError(ErrorCode.SLASH_BAD_ARGS, "media model is required")
-        return await verify_ark_media_model(key, kind=kind, model=model)
+        return await verify_provider_media_model(
+            key,
+            kind=kind,
+            model=model,
+            provider=provider,
+            base_url=base_url,
+        )
 
     def harness_config(self) -> MediaGenerationConfig | None:
         """Build the runtime-only harness config, including the decrypted key."""
@@ -288,6 +553,7 @@ class MediaGenerationSettingsStore:
         from harness_agent import MediaGenerationConfig  # noqa: PLC0415
 
         return MediaGenerationConfig(
+            provider=view.provider,
             api_key=key,
             base_url=view.base_url,
             image_model=view.image_model,

--- a/src/octop/infra/voice/adapters.py
+++ b/src/octop/infra/voice/adapters.py
@@ -74,7 +74,7 @@ async def transcribe_openai(
     base_url = (row.base_url or "https://api.openai.com/v1").rstrip("/")
     await _guard_voice_base_url(base_url)
     extra = row.get_extra()
-    model = str(extra.get("model") or "whisper-1")
+    model = str(extra.get("stt_model") or extra.get("model") or "whisper-1")
     ext = "webm" if "webm" in mime else "wav"
     files = {"file": (f"audio.{ext}", audio, mime or "audio/webm")}
     data: dict[str, str] = {"model": model}
@@ -238,6 +238,34 @@ async def synthesize_edge(
     async for chunk in communicate.stream():
         if chunk["type"] == "audio":
             yield chunk["data"]
+
+
+async def synthesize_piper(
+    row: VoiceProviderRow,
+    text: str,
+    *,
+    voice_id: str | None,
+    speed: float,
+) -> AsyncIterator[bytes]:
+    """Local Piper TTS served by the qwerty companion service (127.0.0.1:8081).
+
+    Free, runs entirely on-device — no API token, no cloud billing. Voices:
+    ``zh`` (Huayan Chinese, default), ``en`` (Lessac English) and ``mix``
+    (auto-switching between the two by character class).
+    """
+    extra = row.get_extra()
+    base_url = (row.base_url or "http://127.0.0.1:8081").rstrip("/")
+    voice = voice_id or str(extra.get("voice_id") or "zh")
+    if voice not in {"zh", "en", "mix"}:
+        raise ValueError(f"local Piper voice must be zh, en or mix (received {voice!r})")
+    async with httpx.AsyncClient(timeout=60.0) as client:
+        resp = await client.get(
+            f"{base_url}/tts",
+            params={"voice": voice, "audio": text},
+        )
+        resp.raise_for_status()
+        if resp.content:
+            yield resp.content
 
 
 async def _guard_mimo_base_url(base_url: str) -> None:
@@ -448,6 +476,29 @@ async def test_tts(row: VoiceProviderRow | None, kind: str) -> dict[str, Any]:
                 id=0,
                 name="edge",
                 kind="edge",
+                capability="tts",
+                base_url=None,
+                api_key=None,
+                extra_json=None,
+                note=None,
+                enabled=1,
+                created_at=0,
+                updated_at=0,
+            ),
+            "ping",
+            voice_id=None,
+            speed=1.0,
+        ):
+            chunks.append(part)
+        return {"ok": bool(chunks), "bytes": sum(len(c) for c in chunks)}
+    if kind == "piper":
+        chunks: list[bytes] = []
+        async for part in synthesize_piper(
+            row
+            or VoiceProviderRow(
+                id=0,
+                name="piper",
+                kind="piper",
                 capability="tts",
                 base_url=None,
                 api_key=None,

--- a/src/octop/infra/voice/manager.py
+++ b/src/octop/infra/voice/manager.py
@@ -10,7 +10,16 @@ from octop.infra.db.repos.settings import SettingsRepo
 from octop.infra.db.repos.voice_providers import VoiceProviderRepo, VoiceProviderRow
 from octop.infra.errors import ErrorCode, OctopError
 from octop.infra.voice import adapters
-from octop.infra.voice.presets import is_builtin_preset
+from octop.infra.voice.presets import is_builtin_preset, load_voice_presets
+
+
+# Preset ids may carry an adapter kind that differs from the id (siliconflow /
+# openai-compatible both speak the openai wire protocol).
+_PRESET_KIND: dict[str, str] = {preset["id"]: str(preset["kind"]) for preset in load_voice_presets()}
+
+
+def _preset_kind(name: str) -> str:
+    return _PRESET_KIND.get(name, name)
 
 
 @dataclass(frozen=True)
@@ -50,9 +59,14 @@ class VoiceManager:
 
     def _validate_provider_name(self, name: str, *, capability: str) -> None:
         if is_builtin_preset(name):
-            if name == "edge" and capability == "stt":
+            kind = _preset_kind(name)
+            if kind == "edge" and capability == "stt":
                 raise OctopError(
                     ErrorCode.VOICE_CAPABILITY_MISMATCH, "Edge TTS does not support STT"
+                )
+            if kind == "piper" and capability == "stt":
+                raise OctopError(
+                    ErrorCode.VOICE_CAPABILITY_MISMATCH, "local Piper does not support STT"
                 )
             if name == "browser":
                 return
@@ -73,7 +87,11 @@ class VoiceManager:
 
     def resolve(self, name: str) -> ResolvedVoiceProvider:
         if is_builtin_preset(name):
-            return ResolvedVoiceProvider(name=name, kind=name, row=self._repo.get_by_name(name))
+            return ResolvedVoiceProvider(
+                name=name,
+                kind=_preset_kind(name),
+                row=self._repo.get_by_name(name),
+            )
         row = self._repo.get_by_name(name)
         if row is None:
             raise OctopError(ErrorCode.NOT_FOUND, f"voice provider {name!r} not found")
@@ -87,7 +105,7 @@ class VoiceManager:
         """HTTP content type of the synthesize() stream for the given provider."""
         name = provider_name or self.get_active()["tts"]
         kind = self.resolve(name).kind
-        return "audio/wav" if kind == "mimo" else "audio/mpeg"
+        return "audio/wav" if kind in {"mimo", "piper"} else "audio/mpeg"
 
     async def transcribe(
         self,
@@ -154,6 +172,25 @@ class VoiceManager:
                 updated_at=0,
             )
             async for chunk in adapters.synthesize_edge(
+                source, text, voice_id=voice_id, speed=speed
+            ):
+                yield chunk
+            return
+        if kind == "piper":
+            source = row or VoiceProviderRow(
+                id=0,
+                name="piper",
+                kind="piper",
+                capability="tts",
+                base_url=None,
+                api_key=None,
+                extra_json=None,
+                note=None,
+                enabled=1,
+                created_at=0,
+                updated_at=0,
+            )
+            async for chunk in adapters.synthesize_piper(
                 source, text, voice_id=voice_id, speed=speed
             ):
                 yield chunk

--- a/src/octop/infra/voice/presets.py
+++ b/src/octop/infra/voice/presets.py
@@ -6,7 +6,9 @@ from typing import Any, Literal
 
 VoiceCapability = Literal["stt", "tts", "both"]
 
-_BUILTIN_PRESET_IDS = frozenset({"browser", "edge", "tencent", "openai", "mimo"})
+_BUILTIN_PRESET_IDS = frozenset(
+    {"browser", "edge", "tencent", "openai", "mimo", "siliconflow", "openai-compatible", "piper"}
+)
 
 
 def is_builtin_preset(name: str) -> bool:
@@ -34,6 +36,15 @@ def load_voice_presets() -> list[dict[str, Any]]:
             "description": "Free Microsoft Edge neural voices via edge-tts.",
         },
         {
+            "id": "piper",
+            "name": "本地 Piper（免费）",
+            "kind": "piper",
+            "capability": "tts",
+            "free": True,
+            "requires_key": False,
+            "description": "本机 Piper TTS（127.0.0.1:8081）——零成本零 token；中文华妍 / 英文 lessac / 中英 mix 自动切换。",
+        },
+        {
             "id": "tencent",
             "name": "Tencent Cloud",
             "kind": "tencent",
@@ -50,6 +61,24 @@ def load_voice_presets() -> list[dict[str, Any]]:
             "free": False,
             "requires_key": True,
             "description": "Whisper STT and OpenAI TTS.",
+        },
+        {
+            "id": "siliconflow",
+            "name": "SiliconFlow",
+            "kind": "openai",
+            "capability": "both",
+            "free": False,
+            "requires_key": True,
+            "description": "SiliconFlow cloud TTS (CosyVoice2) and STT (SenseVoice) via the OpenAI-compatible API.",
+        },
+        {
+            "id": "openai-compatible",
+            "name": "OpenAI Compatible",
+            "kind": "openai",
+            "capability": "both",
+            "free": False,
+            "requires_key": True,
+            "description": "Any OpenAI-compatible relay or gateway (one-api, new-api, custom endpoint).",
         },
         {
             "id": "mimo-stt",

--- a/tests/unit/agents/test_media_generation_settings.py
+++ b/tests/unit/agents/test_media_generation_settings.py
@@ -145,3 +145,117 @@ async def test_verify_ark_video_model_cancels_accepted_task() -> None:
         ("POST", "/api/v3/contents/generations/tasks"),
         ("DELETE", "/api/v3/contents/generations/tasks/video-test-task"),
     ]
+
+
+def test_media_generation_save_provider_and_base_url(
+    store: tuple[MediaGenerationSettingsStore, SecretRepo],
+) -> None:
+    settings, _ = store
+    settings.save(
+        enabled=True,
+        image_enabled=True,
+        video_enabled=False,
+        image_model="Qwen/Qwen-Image",
+        video_model="",
+        api_key="sk-test",
+        provider="siliconflow",
+        base_url="https://api.siliconflow.cn/v1",
+    )
+
+    view = settings.load()
+    assert view.provider == "siliconflow"
+    assert view.base_url == "https://api.siliconflow.cn/v1"
+    assert view.image_model == "Qwen/Qwen-Image"
+
+    config = settings.harness_config()
+    assert config is not None
+    assert config.provider == "siliconflow"
+    assert config.base_url == "https://api.siliconflow.cn/v1"
+
+
+def test_media_generation_default_base_url_follows_provider(
+    store: tuple[MediaGenerationSettingsStore, SecretRepo],
+) -> None:
+    settings, _ = store
+    settings.save(
+        enabled=True,
+        image_enabled=True,
+        video_enabled=False,
+        image_model="m",
+        video_model="",
+        api_key="sk-test",
+        provider="openai-compatible",
+        base_url="",
+    )
+
+    view = settings.load()
+    assert view.provider == "openai-compatible"
+    assert view.base_url == "https://api.openai.com/v1"
+
+
+@pytest.mark.asyncio
+async def test_verify_provider_api_key_siliconflow_uses_models() -> None:
+    seen: dict[str, str | None] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["url"] = str(request.url)
+        seen["auth"] = request.headers.get("Authorization")
+        return httpx.Response(200, json={"data": []})
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        from octop.infra.agents.media_generation import verify_provider_api_key
+
+        result = await verify_provider_api_key(
+            "sk-test",
+            provider="siliconflow",
+            base_url="https://api.siliconflow.cn/v1",
+            client=client,
+        )
+
+    assert result == {"ok": True}
+    assert seen == {
+        "url": "https://api.siliconflow.cn/v1/models",
+        "auth": "Bearer sk-test",
+    }
+
+
+@pytest.mark.asyncio
+async def test_verify_siliconflow_image_probe_uses_image_size() -> None:
+    seen: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["path"] = request.url.path
+        seen["body"] = request.content.decode()
+        return httpx.Response(200, json={"images": [{"url": "https://example.com/test.png"}]})
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        from octop.infra.agents.media_generation import verify_provider_media_model
+
+        result = await verify_provider_media_model(
+            "sk-test",
+            kind="image",
+            model="Qwen/Qwen-Image",
+            provider="siliconflow",
+            base_url="https://api.siliconflow.cn/v1",
+            client=client,
+        )
+
+    assert result == {"ok": True}
+    assert seen["path"] == "/v1/images/generations"
+    assert '"image_size":"1024x1024"' in str(seen["body"])
+
+
+@pytest.mark.asyncio
+async def test_verify_openai_compatible_video_unsupported() -> None:
+    from octop.infra.agents.media_generation import verify_provider_media_model
+
+    result = await verify_provider_media_model(
+        "sk-test",
+        kind="video",
+        model="gen-1",
+        provider="openai-compatible",
+        base_url="https://relay.example.com/v1",
+    )
+
+    assert result.get("ok") is False
+    assert "video" in str(result.get("error")).lower()

--- a/tests/unit/test_voice_manager.py
+++ b/tests/unit/test_voice_manager.py
@@ -86,3 +86,66 @@ async def test_configuration_probe_uses_unsaved_values(
     assert captured_row.name == "draft"
     assert captured_row.api_key == "sk-draft"
     assert captured_row.base_url == "https://example.test/v1"
+
+
+def test_set_active_siliconflow_preset(voice_mgr: VoiceManager) -> None:
+    active = voice_mgr.set_active(tts="siliconflow")
+    assert active["tts"] == "siliconflow"
+    assert active["stt"] == "browser"
+
+
+def test_resolve_siliconflow_preset_kind_is_openai(voice_mgr: VoiceManager) -> None:
+    resolved = voice_mgr.resolve("siliconflow")
+    assert resolved.kind == "openai"
+
+
+def test_resolve_openai_compatible_preset_kind_is_openai(voice_mgr: VoiceManager) -> None:
+    resolved = voice_mgr.resolve("openai-compatible")
+    assert resolved.kind == "openai"
+
+
+@pytest.mark.asyncio
+async def test_configuration_probe_openai_compatible_custom_base_url(
+    voice_mgr: VoiceManager, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    captured: dict[str, object] = {}
+
+    async def fake_test_tts(row: VoiceProviderRow | None, kind: str) -> dict[str, object]:
+        assert row is not None
+        captured["base_url"] = row.base_url
+        captured["extra"] = row.get_extra()
+        return {"ok": True}
+
+    monkeypatch.setattr(adapters, "test_tts", fake_test_tts)
+
+    result = await voice_mgr.test_configuration(
+        name="draft-relay",
+        kind="openai",
+        capability="tts",
+        base_url="https://relay.example.com/v1",
+        api_key="sk-test",
+        extra_json='{"model":"tts-custom","stt_model":"whisper-1","voice_id":"alloy"}',
+        mode="tts",
+    )
+
+    assert result == {"ok": True}
+    assert captured["base_url"] == "https://relay.example.com/v1"
+    assert captured["extra"].get("model") == "tts-custom"
+
+
+def test_set_active_piper_preset(voice_mgr: VoiceManager) -> None:
+    active = voice_mgr.set_active(tts="piper")
+    assert active["tts"] == "piper"
+    assert active["stt"] == "browser"
+
+
+def test_resolve_piper_preset_kind() -> None:
+    from octop.infra.voice.manager import _preset_kind
+
+    assert _preset_kind("piper") == "piper"
+
+
+def test_piper_cannot_be_stt(voice_mgr: VoiceManager) -> None:
+    with pytest.raises(OctopError) as exc:
+        voice_mgr.set_active(stt="piper")
+    assert exc.value.code == ErrorCode.VOICE_CAPABILITY_MISMATCH


### PR DESCRIPTION
## 概要

让模型配置页（Settings → Models）支持多服务商与免费本地 TTS：

- **媒体生成（Generation 页）**：服务商从写死火山方舟放开为 `volcengine / siliconflow / openai-compatible` 三选，`base_url` 可编辑（中转站填自己的地址）。生图模型预置 Qwen/Qwen-Image、Kwai-Kolors/Kolors、dall-e-3；视频预置 Wan2.2 T2V/I2V。
- **语音（Voice 页）**：新增三个预置——SiliconFlow（CosyVoice2 TTS + SenseVoice STT）、OpenAI Compatible（任意 OpenAI 兼容中转站/网关，endpoint/模型/音色可配）、本地 Piper（127.0.0.1:8081 qwerty 服务，免费零 token，中文华妍 / 英文 Lessac / 中英 mix 自动切换）。

## 设计要点

- 预设 id 与适配器 kind 解耦：`siliconflow` / `openai-compatible` 均映射到已有的 `openai` wire 协议（`/v1/audio/speech`、`/v1/audio/transcriptions`），复用现成 adapter 零重复；`piper` 是独立本地 adapter（HTTP GET 到本机服务，WAV 直出，无 key、无 SSRF 担忧——固定 localhost 默认地址可被 base_url 覆盖）。
- STT / TTS 模型分开存（`extra.stt_model` / `extra.model`），顺带修正 OpenAI 官方卡片此前只存 `whisper-1` 导致 TTS 拿到错误模型的缺陷。
- 媒体生成按 provider 方言探测：volcengine `size=2K` / siliconflow `image_size=1024x1024` / openai-compatible `size+n+response_format=url`；凭证验证 volcengine 走 `/ping`、其余走 `GET /models`（不产生费用）。视频在 openai-compatible 上如实报不支持（OpenAI 协议无标准），引导换 provider。
- harness 端 provider 选择通过 `MediaGenerationConfig.provider` 透传（本仓只传配置；harness-agent 侧在 PyPI 包维护，上游仓库未公开，PR 合并后需同步发布）。

## 测试

- 新增/更新 22 个单测（media settings provider 保存与方言探测、voice preset 解析、piper 激活/STT 拒绝），相关文件 33 passed
- 本机实测：硅基凭证验证、Qwen-Image 真实生图（12.5s）、CosyVoice2 中文合成（mp3）、本地 Piper 合成（WAV 22050Hz）全部通过

## 前端构建

`dashboard/` 三处（MediaGeneration / Voice 面板 + locales zh/en），`vite build` 产物不入库（.gitignore），部署时构建。