### PR TITLE
fix(models): validate active-model ref before persisting; avoid free-tier fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 ## [Unreleased]
 
+### 修复
+
+- 默认模型设置校验：`set_active_model` 现在校验 provider 存在/启用且模型在列表中，配置错误的默认模型立即 400 报错，不再静默写入死引用（死引用会导致每轮对话 fallback 到免费模型并触发 429 限流）。
+- 默认模型 fallback 跳过免费档：`resolve_first_model_ref` 把 id 含 `free` 的模型排到最后，free 档有日配额，作为 fallback 会在配置异常时触发限流误报。
+
 ## [0.9.32] - 2026-09-06
 
 ### 新增

--- a/src/octop/api/routers/providers.py
+++ b/src/octop/api/routers/providers.py
@@ -177,7 +177,25 @@ async def set_active_model(
     _: Any = Depends(require_permission("providers")),
     server: Any = Depends(get_server),
 ) -> dict[str, str]:
-    """Set the globally preferred model used when no agent override applies."""
+    """Set the globally preferred model used when no agent override applies.
+
+    Validates the ref before persisting: setting an unknown / disabled provider
+    or a model not in the provider's model list used to silently write a dead
+    ref, after which every turn fell back to the first available model (often a
+    free-tier one with a daily quota) and surfaced as confusing 429 rate-limit
+    errors. A bad ref is now rejected with 400 immediately.
+    """
+    provider = server.services.provider_repo.get_by_name(body.provider_name)
+    if provider is None or not provider.enabled or not provider.api_key or not provider.base_url:
+        raise OctopError(
+            ErrorCode.SLASH_BAD_ARGS,
+            f"provider {body.provider_name!r} does not exist or is disabled",
+        )
+    if not any(str(m.get("id") or "") == body.model for m in provider.get_models()):
+        raise OctopError(
+            ErrorCode.SLASH_BAD_ARGS,
+            f"model {body.model!r} is not in provider {body.provider_name!r} model list",
+        )
     server.services.settings_repo.set_active_model(body.provider_name, body.model)
     if server.app_runtime is not None:
         await server.app_runtime.agent_registry.on_provider_changed(active_model_changed=True)

--- a/src/octop/infra/agents/providers/store.py
+++ b/src/octop/infra/agents/providers/store.py
@@ -215,13 +215,22 @@ class ProviderStore:
         return upgraded or ref
 
     def resolve_first_model_ref(self) -> str | None:
-        """First chat-eligible enabled model across usable providers."""
+        """First chat-eligible enabled model across usable providers.
+
+        Free-tier models (id containing ``free``) are sorted last: they carry a
+        small daily quota, so falling back to one surfaced as confusing 429
+        rate-limit errors whenever the configured default model was unusable.
+        """
         for row in self.iter_usable_rows():
-            for model in row.get_models():
-                if not is_chat_eligible_model(
-                    model, provider_name=row.name, provider_api_key=row.api_key
-                ):
-                    continue
+            models = [
+                m
+                for m in row.get_models()
+                if is_chat_eligible_model(
+                    m, provider_name=row.name, provider_api_key=row.api_key
+                )
+            ]
+            models.sort(key=lambda m: "free" in str(m.get("id") or "").lower())
+            for model in models:
                 model_id = str(model.get("id") or "").strip()
                 if model_id:
                     return f"{row.name}/{model_id}"


### PR DESCRIPTION
## 背景（问题链）

用户把默认偏好模型（/admin/models 的 active-model）设成还没配置好的模型时：

1. `set_active_model` 不校验 ref 可用性，把死引用（不存在的 provider / 未启用的模型）静默写入 settings
2. 后续每轮对话模型解析失败 → 自动 fallback 到第一个可用模型（通常是 openrouter 的 free 档，id 含 free）
3. free 档有日配额（如 50 次/天），用完 → 429 `stream_error / model_retry` 限流报错
4. 表现为"手动设置的默认模型不起效果，反而报限流错"——排查困难（真实根因在配置校验缺失）

## 修改

**1. `octop/api/routers/providers.py` `set_active_model` 加校验**

- provider 不存在 / 未启用 / 无 key / 无 base_url → 400 `SLASH_BAD_ARGS`，不写库
- 模型不在该 provider 的 models 列表 → 400，不写库
- 合法 ref → 正常写入 + `on_provider_changed`

**2. `octop/infra/agents/providers/store.py` `resolve_first_model_ref` 避开免费档**

- id 含 `free` 的模型排到最后，fallback 优先选付费/本地模型
- free 档有日配额，作为静默 fallback 会在配置异常时触发 429 限流误报

## 验证

- PUT active-model 不存在的 provider → 400
- PUT active-model 模型不在列表 → 400
- PUT active-model 合法 ref → 200
- fallback 排序：free 模型排在可用非免费模型之后