### PR TITLE
docs: add contributors section to README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,3 +496,11 @@ For the customer WeCom support group, scan:
 ## 📄 License
 
 This project is licensed under the [MIT License](LICENSE).
+
+## ✨ Contributors
+
+Thanks to all contributors:
+
+<a href="https://github.com/tencentcloud/octop/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=tencentcloud/octop" />
+</a>

--- a/README_CN.md
+++ b/README_CN.md
@@ -504,3 +504,11 @@ cd dashboard && npx tsc --noEmit
 ### 📄 许可证
 
 本项目采用 [MIT License](LICENSE)。
+
+### ✨ 贡献者
+
+感谢所有贡献者：
+
+<a href="https://github.com/tencentcloud/octop/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=tencentcloud/octop" />
+</a>


### PR DESCRIPTION
## Summary

Add a Contributors section at the end of `README.md` and `README_CN.md`. Show contributor avatars via contrib.rocks for `tencentcloud/octop`, linking to the GitHub contributors page.

## Target branch

- [x] Base is **`develop`** (feature / fix — default)
- [ ] Base is **`main`** (`release/*` or `hotfix/*` only)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Refactor / chore
- [ ] Release / hotfix

## Test plan

README-only change; no code or tests.

- [ ] Preview the English README on GitHub and confirm the contributor image loads and the link opens the contributors page
- [ ] Preview the Chinese README and confirm the heading and copy render correctly
- [ ] `make all` passes locally
- [ ] Added/updated tests

## Checklist

- [ ] Updated `CHANGELOG.md` (if user-facing)
- [x] README / docs updated (if needed)