### PR TITLE
feat(update): 检查更新错误提示本地化并透出来源，不改探测与缓存逻辑

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - 共享专家的技能列表现在会在聊天输入框中加载，非所有者可查看并选择专家已配置的技能
 - 知识库文本文档编辑抽屉在「编辑」模式下点「保存」无响应（`name`/`format` 字段未挂载时 `validateFields` 缺值导致抛错被吞掉；#592）
 - 知识库文本文档编辑内容未改时点「保存」只关闭抽屉，不触发更新与重建索引
+- 版本升级界面的检查失败提示支持中英本地化：`/update/status` 与 `/update/check` 增加 `error_code` 字段（`pypi_unreachable`），界面按语言展示可读文案；版本信息来自镜像时显示来源提示；`octop update` 失败提示补充网络/代理排查建议
 - SQLite 历史回填为 checkpoint 内容引用创建绑定只读连接的独立解码器和缓存，并在同一读事务内读取，避免访问运行中的 saver 连接；兼容原有 inline 格式。新格式需要配套安装提供 `CheckpointSerializer.with_connection` 的 harness-memory。PostgreSQL 保持原生 graph 历史读取路径。
 
 ### 变更

--- a/dashboard/src/api/modules/update.ts
+++ b/dashboard/src/api/modules/update.ts
@@ -10,6 +10,10 @@ export interface UpdateStatus {
   /** True when Octop is spawned by the Wails desktop shell (or ``OCTOP_DESKTOP=1``). */
   desktop?: boolean;
   error: string | null;
+  /** Stable error code (e.g. "pypi_unreachable") for localized UI messages; null on success. */
+  error_code: string | null;
+  /** Mirror that served the version info (null/`pypi.org` = official source). */
+  source: string | null;
   last_check_time: string | null;
   /** Markdown changelog for latest_version, null if not available. */
   release_notes: string | null;

--- a/dashboard/src/hooks/useUpdateStatus.test.ts
+++ b/dashboard/src/hooks/useUpdateStatus.test.ts
@@ -26,6 +26,8 @@ const sample: UpdateStatus = {
   is_editable: false,
   service_mode: null,
   error: null,
+  error_code: null,
+  source: null,
   last_check_time: "2026-07-14T00:00:00Z",
   release_notes: null,
 };

--- a/dashboard/src/locales/en.json
+++ b/dashboard/src/locales/en.json
@@ -2973,6 +2973,10 @@
       "restartCommand": "Restart command",
       "editableHint": "Development install detected. Use git pull to update.",
       "networkError": "Could not reach update server. Check your network.",
+      "mirrorSource": "Version info served by mirror {{source}}; it may lag slightly behind pypi.org.",
+      "errors": {
+        "pypi_unreachable": "Could not reach PyPI. Check your network and try again."
+      },
       "notChecked": "Not checked yet",
       "stageStarting": "Starting...",
       "stageDownloading": "Downloading...",

--- a/dashboard/src/locales/zh.json
+++ b/dashboard/src/locales/zh.json
@@ -2970,6 +2970,10 @@
       "restartCommand": "重启命令",
       "editableHint": "检测到开发版安装，请使用 git pull 更新。",
       "networkError": "无法连接更新服务器，请检查网络。",
+      "mirrorSource": "版本信息来自镜像 {{source}}，可能略滞后于官方源。",
+      "errors": {
+        "pypi_unreachable": "无法连接 PyPI，请检查网络后重试。"
+      },
       "notChecked": "尚未检查",
       "stageStarting": "启动中...",
       "stageDownloading": "下载中...",

--- a/dashboard/src/pages/Settings/AdvancedSettings/UpdateConfig.tsx
+++ b/dashboard/src/pages/Settings/AdvancedSettings/UpdateConfig.tsx
@@ -4,6 +4,7 @@ import { Collapse } from "antd";
 import {
   BookOpen,
   CheckCircle,
+  Info,
   RefreshCw,
   XCircle,
   AlertTriangle,
@@ -346,7 +347,24 @@ export default function UpdateConfig() {
           {status?.error && (
             <div className={`${styles.alert} ${styles.alertError}`}>
               <XCircle size={15} />
-              <span>{status.error}</span>
+              <span>
+                {status.error_code
+                  ? t(`advancedSettings.update.errors.${status.error_code}`, {
+                      defaultValue: status.error,
+                    })
+                  : status.error}
+              </span>
+            </div>
+          )}
+
+          {status?.source && status.source !== "pypi.org" && !status.error && (
+            <div className={`${styles.alert} ${styles.alertInfo}`}>
+              <Info size={15} />
+              <span>
+                {t("advancedSettings.update.mirrorSource", {
+                  source: status.source,
+                })}
+              </span>
             </div>
           )}
 

--- a/dashboard/src/utils/updateStatusCache.test.ts
+++ b/dashboard/src/utils/updateStatusCache.test.ts
@@ -18,6 +18,8 @@ const sample: UpdateStatus = {
   is_editable: false,
   service_mode: null,
   error: null,
+  error_code: null,
+  source: null,
   last_check_time: "2026-07-14T00:00:00Z",
   release_notes: null,
 };

--- a/src/octop/api/routers/update.py
+++ b/src/octop/api/routers/update.py
@@ -49,11 +49,16 @@ def _build_status(
     *,
     latest: str | None = None,
     error: str | None = None,
+    error_code: str | None = None,
+    source: str | None = None,
     release_notes: str | None = None,
 ) -> dict[str, Any]:
     current = get_local_version()
     if latest is None and error is None:
-        latest = fetch_latest_pypi_version()
+        info = fetch_pypi_info()
+        if info is not None:
+            latest = info.version
+            source = info.source
     has_update = bool(latest and is_newer(latest, current))
     payload = {
         "current_version": current,
@@ -63,6 +68,8 @@ def _build_status(
         "service_mode": detect_service_mode(),
         "desktop": _is_desktop_process(),
         "error": error,
+        "error_code": error_code if error else None,
+        "source": source if latest is not None else None,
         "last_check_time": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
         "release_notes": release_notes if has_update else None,
     }
@@ -83,10 +90,18 @@ async def update_status(_: Any = Depends(current_user)) -> dict[str, Any]:
 async def check_for_updates(_: Any = Depends(require_permission("update"))) -> dict[str, Any]:
     pypi_info = await asyncio.to_thread(fetch_pypi_info)
     if pypi_info is None:
-        return await asyncio.to_thread(_build_status, latest=None, error="could not reach PyPI")
+        return await asyncio.to_thread(
+            _build_status,
+            latest=None,
+            error="could not reach PyPI",
+            error_code="pypi_unreachable",
+        )
     release_notes = parse_changelog_for_version(pypi_info.description, pypi_info.version)
     return await asyncio.to_thread(
-        _build_status, latest=pypi_info.version, release_notes=release_notes
+        _build_status,
+        latest=pypi_info.version,
+        source=pypi_info.source,
+        release_notes=release_notes,
     )
 
 

--- a/src/octop/cli/commands/update.py
+++ b/src/octop/cli/commands/update.py
@@ -24,7 +24,10 @@ def update(check: bool, yes: bool, verbose: bool) -> None:
     latest = fetch_latest_pypi_version()
     click.echo(f"installed: {current}")
     if latest is None:
-        click.echo("could not reach PyPI", err=True)
+        click.echo(
+            "could not reach PyPI — check your network or proxy settings and retry",
+            err=True,
+        )
         raise SystemExit(1)
     click.echo(f"latest:    {latest}")
     if not is_newer(latest, current):

--- a/src/octop/infra/setup/self_update.py
+++ b/src/octop/infra/setup/self_update.py
@@ -116,6 +116,10 @@ def fetch_latest_pypi_version(timeout: int = 10) -> str | None:
 class PyPIInfo:
     version: str
     description: str | None = None
+    """Package long description."""
+
+    source: str | None = None
+    """Label of the source that served this payload (e.g. ``pypi.org``)."""
 
 
 def fetch_pypi_info(timeout: int = 10) -> PyPIInfo | None:
@@ -134,6 +138,7 @@ def fetch_pypi_info(timeout: int = 10) -> PyPIInfo | None:
         return PyPIInfo(
             version=str(info["version"]),
             description=info.get("description"),
+            source="pypi.org",
         )
     except (urllib.error.URLError, TimeoutError, KeyError, json.JSONDecodeError) as exc:
         logger.warning("failed to fetch PyPI info: %s", exc)

--- a/tests/unit/api/test_update_router.py
+++ b/tests/unit/api/test_update_router.py
@@ -12,6 +12,7 @@ from octop.api.routers import update as update_router
 from octop.api.routers import update_store
 from octop.api.routers.update_store import UpgradeTaskStatus, create_task, get_task
 from octop.infra.errors import ErrorCode, OctopError
+from octop.infra.setup import self_update
 from octop.infra.setup.self_update import UpgradeResult
 
 
@@ -253,3 +254,54 @@ async def test_upgrade_worker_advances_percent_while_installing(
     assert stored is not None
     assert stored.status == UpgradeTaskStatus.COMPLETE
     assert 25 in percents
+
+
+def test_build_status_success_reports_source(monkeypatch: pytest.MonkeyPatch) -> None:
+    info = self_update.PyPIInfo(version="1.2.3", description="desc", source="mirrors.aliyun.com")
+    monkeypatch.setattr(update_router, "fetch_pypi_info", lambda: info)
+
+    payload = update_router._build_status()
+
+    assert payload["latest_version"] == "1.2.3"
+    assert payload["error"] is None
+    assert payload["error_code"] is None
+    assert payload["source"] == "mirrors.aliyun.com"
+
+
+def test_build_status_failure_via_check_keeps_error_code(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = update_router._build_status(
+        latest=None, error="could not reach PyPI", error_code="pypi_unreachable"
+    )
+
+    assert payload["latest_version"] is None
+    assert payload["error"] == "could not reach PyPI"
+    assert payload["error_code"] == "pypi_unreachable"
+
+
+@pytest.mark.asyncio
+async def test_check_endpoint_reports_error_code_when_pypi_unreachable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(update_router, "fetch_pypi_info", lambda: None)
+
+    result = await update_router.check_for_updates(_=None)
+
+    assert result["latest_version"] is None
+    assert result["error"] == "could not reach PyPI"
+    assert result["error_code"] == "pypi_unreachable"
+
+
+@pytest.mark.asyncio
+async def test_check_endpoint_success_passes_source(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    info = self_update.PyPIInfo(version="1.2.3", source="pypi.org")
+    monkeypatch.setattr(update_router, "fetch_pypi_info", lambda: info)
+
+    result = await update_router.check_for_updates(_=None)
+
+    assert result["latest_version"] == "1.2.3"
+    assert result["source"] == "pypi.org"
+    assert result["error"] is None


### PR DESCRIPTION
- /update/status 与 /update/check 增加 error_code（pypi_unreachable）与 source 字段；探测、重试、缓存行为保持不变
- 版本升级界面错误文案按语言展示（errors.pypi_unreachable），镜像来源 显示提示（mirrorSource）
- octop update 失败提示补充网络/代理排查建议
- PyPIInfo 增加 source 数据字段并标注 pypi.org 来源
- 单测覆盖字段透出，前端类型/文案同步

## Summary

<!-- What does this PR change and why? -->

## Target branch

- [ ] Base is **`develop`** (feature / fix — default)
- [ ] Base is **`main`** (`release/*` or `hotfix/*` only)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / chore
- [ ] Release / hotfix

## Test plan

<!-- How did you verify this? Include commands run (e.g. `make all`). -->

- [ ] `make all` passes locally
- [ ] Added/updated tests

## Checklist

- [ ] Updated `CHANGELOG.md` (if user-facing)
- [ ] README / docs updated (if needed)
