### PR TITLE
fix(dashboard): clarify skill package copy fallback

### DIFF
--- a/dashboard/src/locales/en.json
+++ b/dashboard/src/locales/en.json
@@ -1761,7 +1761,7 @@
     "pushSkillFailed": "Failed to push skill",
     "packageConflictHint": "The workspace skill “{{slug}}” shadows this package skill.",
     "mountBackendHint": "Skill packages need local storage with root /.",
-    "skillPackagesUnsupportedHint": "Skill packages unavailable: when the storage root is not /, the sandbox cannot reach skill-package directories, so packages cannot be used.",
+    "skillPackagesUnsupportedHint": "Skill packages cannot be used directly: when the storage root is not /, the sandbox cannot reach skill-package directories, but you can use Copy skills to copy them to the agent workspace.",
     "installedSkillsDesc": "Manage installed built-in and customized skills.",
     "tencentSkillHubDesc": "Browse and install community skills from Tencent SkillHub.",
     "install": "Install",

--- a/dashboard/src/locales/zh.json
+++ b/dashboard/src/locales/zh.json
@@ -1760,7 +1760,7 @@
     "pushSkillFailed": "推送技能失败",
     "packageConflictHint": "工作区技能“{{slug}}”会覆盖此技能包中的同名技能。",
     "mountBackendHint": "技能包需本地存储，且根目录为 /。",
-    "skillPackagesUnsupportedHint": "无法使用技能包：存储根目录不是 / 时，因沙箱限制无法访问技能包的相关文件目录，因此技能包不可用。",
+    "skillPackagesUnsupportedHint": "无法直接使用技能包：存储根目录不是 / 时，因沙箱限制无法访问技能包的相关文件目录，但可以使用“复制技能”将技能复制到专家工作区。",
     "installedSkillsDesc": "管理已安装的内置和自定义技能。",
     "tencentSkillHubDesc": "浏览和安装来自腾讯 SkillHub 的社区技能。",
     "install": "安装",


### PR DESCRIPTION
## Summary

- clarify that skill packages cannot be mounted directly in sandbox storage mode
- tell users they can still copy skills into the agent workspace
- keep Chinese and English messages aligned

## Verification

- JSON parsing
- Prettier check for both locale files
- Ruff check and formatting
- mypy typecheck