### PR TITLE
feat: polish dashboard overlays, color pickers, and Ant Design overlay APIs

### DIFF
--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -33,7 +33,7 @@
         "react-router-dom": "^7.13.0",
         "react-syntax-highlighter": "^16.1.1",
         "react-virtuoso": "^4.18.10",
-        "recharts": "^3.8.0",
+        "recharts": "^3.10.1",
         "rehype-katex": "^7.0.1",
         "remark-gfm": "^4.0.1",
         "remark-math": "^6.0.0",
@@ -3325,16 +3325,6 @@
         "react-redux": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@reduxjs/toolkit/node_modules/immer": {
-      "version": "11.1.8",
-      "resolved": "https://mirrors.tencent.com/npm/immer/-/immer-11.1.8.tgz",
-      "integrity": "sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/immer"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -8234,9 +8224,9 @@
       "license": "MIT"
     },
     "node_modules/immer": {
-      "version": "10.2.0",
-      "resolved": "https://mirrors.tencent.com/npm/immer/-/immer-10.2.0.tgz",
-      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "version": "11.1.18",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.18.tgz",
+      "integrity": "sha512-EQyQtLiYW029lyoczMl/Hh4Xu7cDecSc58JRYpHyL4tIAu3eqd1yJzQX04d2BZHDkzFFvm6qJEJWOtfDSWAXbQ==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -12095,9 +12085,9 @@
       }
     },
     "node_modules/recharts": {
-      "version": "3.8.1",
-      "resolved": "https://mirrors.tencent.com/npm/recharts/-/recharts-3.8.1.tgz",
-      "integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.10.1.tgz",
+      "integrity": "sha512-QXFrvt6IVcw7eeZCoyXTwkIJAX3Dv1nyVhMicXJ47GsGDDpcN8z6o644DibE9XjpBTThtsomLKnTV6lc+cVFUA==",
       "license": "MIT",
       "workspaces": [
         "www"
@@ -12108,9 +12098,9 @@
         "decimal.js-light": "^2.5.1",
         "es-toolkit": "^1.39.3",
         "eventemitter3": "^5.0.1",
-        "immer": "^10.1.1",
+        "immer": "^11.1.8",
         "react-redux": "8.x.x || 9.x.x",
-        "reselect": "5.1.1",
+        "reselect": "5.2.0",
         "tiny-invariant": "^1.3.3",
         "use-sync-external-store": "^1.2.2",
         "victory-vendor": "^37.0.2"
@@ -12391,9 +12381,9 @@
       }
     },
     "node_modules/reselect": {
-      "version": "5.1.1",
-      "resolved": "https://mirrors.tencent.com/npm/reselect/-/reselect-5.1.1.tgz",
-      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.2.0.tgz",
+      "integrity": "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==",
       "license": "MIT"
     },
     "node_modules/resize-observer-polyfill": {

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -45,7 +45,7 @@
     "react-router-dom": "^7.13.0",
     "react-syntax-highlighter": "^16.1.1",
     "react-virtuoso": "^4.18.10",
-    "recharts": "^3.8.0",
+    "recharts": "^3.10.1",
     "rehype-katex": "^7.0.1",
     "remark-gfm": "^4.0.1",
     "remark-math": "^6.0.0",

--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -114,6 +114,7 @@ function ThemedApp() {
           DatePicker: { colorBgBase: "#0f1117" },
           Segmented: { itemSelectedBg: "#1a1c28" },
           Card: { colorBgContainer: "#161822" },
+          Tooltip: { colorBgSpotlight: "#424242" },
         }
       : {},
   };

--- a/dashboard/src/components/ExpertColorPicker.tsx
+++ b/dashboard/src/components/ExpertColorPicker.tsx
@@ -62,7 +62,7 @@ export default function ExpertColorPicker({
           role="button"
         >
           <ColorPicker
-            value={curated ? undefined : value}
+            value={curated ? PALETTE_SWATCH[value] : value}
             onChangeComplete={(color: AggregationColor) => {
               onChange(color.toHexString());
             }}

--- a/dashboard/src/components/PaletteSwitcher.tsx
+++ b/dashboard/src/components/PaletteSwitcher.tsx
@@ -51,7 +51,7 @@ export default function PaletteSwitcher() {
           role="button"
         >
           <ColorPicker
-            value={isCustom ? customColor : undefined}
+            value={customColor}
             onChangeComplete={(color: AggregationColor) => {
               setCustomColor(color.toHexString());
             }}

--- a/dashboard/src/layouts/Sidebar.module.less
+++ b/dashboard/src/layouts/Sidebar.module.less
@@ -12,7 +12,7 @@
   justify-content: space-between;
   gap: 6px;
   width: 100%;
-  padding: 12px 10px 5px;
+  padding: 8px 10px;
   border: none;
   background: transparent;
   cursor: pointer;

--- a/dashboard/src/layouts/Sidebar.tsx
+++ b/dashboard/src/layouts/Sidebar.tsx
@@ -68,6 +68,11 @@ function useNavGroupCollapse(navSections: NavSection[], selectedKey: string) {
   const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(() =>
     loadCollapsedGroups(),
   );
+  const activeGroupKey = navSections.find(
+    (section) =>
+      section.groupKey &&
+      section.items.some((item) => item.key === selectedKey),
+  )?.groupKey;
 
   const toggleGroup = useCallback((groupKey: string) => {
     setCollapsedGroups((prev) => {
@@ -85,20 +90,15 @@ function useNavGroupCollapse(navSections: NavSection[], selectedKey: string) {
   );
 
   useEffect(() => {
-    const activeSection = navSections.find(
-      (section) =>
-        section.groupKey &&
-        section.items.some((item) => item.key === selectedKey),
-    );
-    if (!activeSection?.groupKey) return;
+    if (!activeGroupKey) return;
     setCollapsedGroups((prev) => {
-      if (!prev.has(activeSection.groupKey!)) return prev;
+      if (!prev.has(activeGroupKey)) return prev;
       const next = new Set(prev);
-      next.delete(activeSection.groupKey!);
+      next.delete(activeGroupKey);
       saveCollapsedGroups(next);
       return next;
     });
-  }, [selectedKey, navSections]);
+  }, [activeGroupKey, selectedKey]);
 
   return { toggleGroup, isGroupCollapsed };
 }

--- a/dashboard/src/pages/Agent/Skills/components/SkillDrawer.tsx
+++ b/dashboard/src/pages/Agent/Skills/components/SkillDrawer.tsx
@@ -831,6 +831,7 @@ export function SkillDrawer({
       title={drawerTitle}
       open={open}
       onClose={onClose}
+      forceRender
       destroyOnHidden
       styles={{
         body: {

--- a/dashboard/src/pages/Agent/Skills/components/SkillPackagesTab.tsx
+++ b/dashboard/src/pages/Agent/Skills/components/SkillPackagesTab.tsx
@@ -342,7 +342,7 @@ export default function SkillPackagesTab({
           setDetailPackage(null);
         }}
         width={480}
-        destroyOnClose
+        destroyOnHidden
       >
         {detailLoading ? (
           <Spin className={styles.skillPackagesLoading} />

--- a/dashboard/src/pages/Chat/chatInputCore.partial.less
+++ b/dashboard/src/pages/Chat/chatInputCore.partial.less
@@ -343,7 +343,8 @@
   :global(.ant-popover-inner),
   :global(.octop-popover-inner) {
     padding: 0;
-    background: transparent;
+    border-radius: 12px;
+    background: var(--fn-bg-elevated, #1f1f1f);
   }
 
   :global(.ant-popover-arrow)::before,
@@ -355,16 +356,10 @@
 .contextUsagePanel {
   width: 280px;
   padding: 14px 16px;
-  border-radius: 12px;
-  background: var(--fn-bg-elevated, #1f1f1f);
-  border: 1px solid var(--fn-border-secondary, rgba(255, 255, 255, 0.08));
 
   @media (max-width: 767px) {
     width: 100%;
     padding: 0;
-    border: none;
-    box-shadow: none;
-    background: transparent;
   }
 }
 

--- a/dashboard/src/pages/Chat/chatInputCore.partial.less
+++ b/dashboard/src/pages/Chat/chatInputCore.partial.less
@@ -338,11 +338,17 @@
   padding: 0;
 }
 
+/* App uses ConfigProvider prefixCls="octop"; keep ant-* as fallback. */
 .contextUsagePopover {
-  :global(.ant-popover-inner) {
+  :global(.ant-popover-inner),
+  :global(.octop-popover-inner) {
     padding: 0;
     background: transparent;
-    box-shadow: none;
+  }
+
+  :global(.ant-popover-arrow)::before,
+  :global(.octop-popover-arrow)::before {
+    background: var(--fn-bg-elevated, #1f1f1f);
   }
 }
 
@@ -352,7 +358,6 @@
   border-radius: 12px;
   background: var(--fn-bg-elevated, #1f1f1f);
   border: 1px solid var(--fn-border-secondary, rgba(255, 255, 255, 0.08));
-  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.28);
 
   @media (max-width: 767px) {
     width: 100%;

--- a/dashboard/src/pages/Chat/chatInputPickers.partial.less
+++ b/dashboard/src/pages/Chat/chatInputPickers.partial.less
@@ -23,16 +23,22 @@
   gap: 2px;
 }
 
+.modelMenuDivider {
+  width: 100%;
+  height: 1px;
+  margin: 4px 0;
+  background: var(--fn-border-secondary, rgba(0, 0, 0, 0.06));
+}
+
 .modelMenuFooter {
   display: flex;
   align-items: center;
   justify-content: center;
   gap: 6px;
   width: 100%;
-  margin-top: 4px;
-  padding: 10px 12px;
+  padding: 6px 12px;
   border: none;
-  border-top: 1px solid var(--fn-border-secondary, rgba(0, 0, 0, 0.06));
+  border-radius: 8px;
   background: transparent;
   color: var(--fn-text-secondary);
   font-size: 13px;
@@ -42,7 +48,7 @@
     color 0.15s ease;
 
   &:hover {
-    background: var(--fn-bg-hover, rgba(0, 0, 0, 0.04));
+    background: var(--fn-sidebar-item-hover, rgba(0, 0, 0, 0.04));
     color: var(--fn-text-primary);
   }
 }

--- a/dashboard/src/pages/Chat/chatMessages.partial.less
+++ b/dashboard/src/pages/Chat/chatMessages.partial.less
@@ -92,7 +92,11 @@
   pointer-events: auto;
 
   &:hover {
-    background: var(--fn-bg-hover);
+    background: color-mix(
+      in srgb,
+      var(--fn-color-brand) 8%,
+      var(--fn-bg-elevated, var(--fn-bg-primary))
+    );
     color: var(--fn-text-brand);
     border-color: color-mix(in srgb, var(--fn-color-brand) 55%, transparent);
     box-shadow:

--- a/dashboard/src/pages/Chat/components/ChatInputActionsRow.tsx
+++ b/dashboard/src/pages/Chat/components/ChatInputActionsRow.tsx
@@ -470,6 +470,7 @@ export default function ChatInputActionsRow({
               );
             })}
           </div>
+          <div className={styles.modelMenuDivider} />
           <button
             type="button"
             className={styles.modelMenuFooter}

--- a/dashboard/src/pages/Control/CronJobs/index.module.less
+++ b/dashboard/src/pages/Control/CronJobs/index.module.less
@@ -577,7 +577,6 @@
   background: var(--fn-bg-secondary);
   border: 1px solid var(--fn-border-primary);
   font-size: 14px;
-  font-weight: 600;
   color: var(--fn-text-primary);
   word-break: break-word;
 }

--- a/dashboard/src/pages/Experts/components/CreateFromExpertDrawer.tsx
+++ b/dashboard/src/pages/Experts/components/CreateFromExpertDrawer.tsx
@@ -450,7 +450,7 @@ export default function CreateFromExpertDrawer({
           showIcon
           message={t("experts.noModelsWarning")}
           action={
-            <a href="/admin/providers" style={{ whiteSpace: "nowrap" }}>
+            <a href="/admin/models" style={{ whiteSpace: "nowrap" }}>
               {t("experts.goToAdmin")}
             </a>
           }

--- a/dashboard/src/pages/Experts/components/RootDirSelect.module.less
+++ b/dashboard/src/pages/Experts/components/RootDirSelect.module.less
@@ -1,4 +1,4 @@
-/* Dropdown is portaled — scope tree layout to popupClassName. */
+/* Dropdown is portaled — scope tree layout to its popup class. */
 .rootDirDropdown :global(.ant-select-tree-node-content-wrapper) {
   flex: 1 1 auto !important;
   width: 100%;

--- a/dashboard/src/pages/Experts/components/RootDirSelect.tsx
+++ b/dashboard/src/pages/Experts/components/RootDirSelect.tsx
@@ -393,11 +393,10 @@ export default function RootDirSelect({
   return (
     <TreeSelect
       className={styles.rootDirSelect}
-      popupClassName={styles.rootDirDropdown}
       classNames={{ popup: { root: styles.rootDirDropdown } }}
       disabled={disabled}
       open={disabled ? false : open}
-      onDropdownVisibleChange={(next) => {
+      onOpenChange={(next) => {
         if (disabled) return;
         if (!next && editingPathRef.current) return;
         setOpen(next);
@@ -422,7 +421,7 @@ export default function RootDirSelect({
       notFoundContent={<Spin size="small" />}
       style={{ width: "100%" }}
       popupMatchSelectWidth
-      dropdownStyle={{ maxHeight: 360 }}
+      styles={{ popup: { root: { maxHeight: 360 } } }}
       filterTreeNode={(input, node) => {
         const q = input.trim().toLowerCase();
         const path = String(node.value ?? "").toLowerCase();

--- a/dashboard/src/pages/KnowledgeBases/TextDocumentEditorModal.tsx
+++ b/dashboard/src/pages/KnowledgeBases/TextDocumentEditorModal.tsx
@@ -231,7 +231,7 @@ export default function TextDocumentEditorModal({
         </div>
       }
       onClose={onCancel}
-      destroyOnClose
+      destroyOnHidden
       width={drawerWidth}
       className={styles.textEditorDrawer}
       styles={{

--- a/dashboard/src/pages/KnowledgeBases/index.tsx
+++ b/dashboard/src/pages/KnowledgeBases/index.tsx
@@ -2243,7 +2243,7 @@ export default function KnowledgeBasesPage() {
           ) : null
         }
         width={previewKind || previewAsMarkdown ? "min(1200px, 92vw)" : 720}
-        destroyOnClose
+        destroyOnHidden
         styles={{
           body:
             previewKind || previewAsMarkdown
@@ -2305,7 +2305,7 @@ export default function KnowledgeBasesPage() {
         onOk={() => void createFolder()}
         okText={t("common.create")}
         cancelText={t("common.cancel")}
-        destroyOnClose
+        destroyOnHidden
       >
         <Input
           value={folderName}
@@ -2322,7 +2322,7 @@ export default function KnowledgeBasesPage() {
         onOk={() => void renameFolder()}
         okText={t("common.save")}
         cancelText={t("common.cancel")}
-        destroyOnClose
+        destroyOnHidden
       >
         <Input
           value={renameName}

--- a/dashboard/src/pages/Settings/Models/components/modals/CustomProviderModal.tsx
+++ b/dashboard/src/pages/Settings/Models/components/modals/CustomProviderModal.tsx
@@ -45,7 +45,9 @@ export function CustomProviderModal({
     api_key?: string;
     note?: string;
   }>();
+  const name = Form.useWatch("name", form) as string | undefined;
   const kind = Form.useWatch("kind", form) as string | undefined;
+  const baseUrl = Form.useWatch("base_url", form) as string | undefined;
   const apiKey = Form.useWatch("api_key", form) as string | undefined;
   const [models, setModels] = useState<ProviderModel[]>([]);
   const canTest = !!apiKey?.trim();
@@ -53,15 +55,15 @@ export function CustomProviderModal({
   const draftProvider = useMemo<ProviderRow>(
     () => ({
       id: 0,
-      name: (form.getFieldValue("name") as string | undefined) || "draft",
-      kind: (form.getFieldValue("kind") as string | undefined) || "openai",
-      base_url: (form.getFieldValue("base_url") as string | undefined) || null,
-      api_key: (form.getFieldValue("api_key") as string | undefined) || null,
+      name: name || "draft",
+      kind: kind || "openai",
+      base_url: baseUrl || null,
+      api_key: apiKey || null,
       models,
       note: null,
       enabled: true,
     }),
-    [form, models],
+    [apiKey, baseUrl, kind, models, name],
   );
 
   useEffect(() => {
@@ -310,7 +312,7 @@ export function CustomProviderModal({
                     : "";
                 message.success(
                   t("models.testConnectionSuccess", {
-                    name: (form.getFieldValue("name") as string) || "draft",
+                    name: name || "draft",
                     latency,
                   }),
                 );

--- a/dashboard/src/pages/Settings/Models/index.module.less
+++ b/dashboard/src/pages/Settings/Models/index.module.less
@@ -19,6 +19,14 @@
   color: var(--fn-text-tertiary);
 }
 
+.modelTabLabel {
+  align-items: center;
+
+  svg {
+    display: block;
+  }
+}
+
 /* ---- Sections ---- */
 
 .section {

--- a/dashboard/src/pages/Settings/Models/index.tsx
+++ b/dashboard/src/pages/Settings/Models/index.tsx
@@ -202,7 +202,7 @@ export default function ModelsPage() {
                 {
                   key: "chat",
                   label: (
-                    <Space size={6}>
+                    <Space className={styles.modelTabLabel} size={6}>
                       <MessageSquareText size={15} />
                       {t("models.chatModelsTab")}
                     </Space>
@@ -215,7 +215,7 @@ export default function ModelsPage() {
                 {
                   key: "generation",
                   label: (
-                    <Space size={6}>
+                    <Space className={styles.modelTabLabel} size={6}>
                       <Images size={15} />
                       {t("models.generationModelsTab")}
                     </Space>
@@ -228,7 +228,7 @@ export default function ModelsPage() {
                 {
                   key: "voice",
                   label: (
-                    <Space size={6}>
+                    <Space className={styles.modelTabLabel} size={6}>
                       <Mic2 size={15} />
                       {t("models.voiceModelsTab")}
                     </Space>
@@ -241,7 +241,7 @@ export default function ModelsPage() {
                 {
                   key: "search",
                   label: (
-                    <Space size={6}>
+                    <Space className={styles.modelTabLabel} size={6}>
                       <Search size={15} />
                       {t("models.searchModelsTab")}
                     </Space>

--- a/dashboard/src/pages/SkillPackages/SkillsetFromHubDrawer.tsx
+++ b/dashboard/src/pages/SkillPackages/SkillsetFromHubDrawer.tsx
@@ -80,7 +80,7 @@ export function SkillsetFromHubDrawer({
       open={open}
       onClose={onClose}
       width={720}
-      destroyOnClose
+      destroyOnHidden
     >
       <Typography.Paragraph type="secondary" className={styles.hint}>
         {t("skillPackages.fromSkillHubHint")}

--- a/dashboard/src/pages/SkillPackages/index.tsx
+++ b/dashboard/src/pages/SkillPackages/index.tsx
@@ -1064,7 +1064,7 @@ export default function SkillPackagesPage() {
         open={hubOpen}
         onClose={() => setHubOpen(false)}
         width={860}
-        destroyOnClose
+        destroyOnHidden
       >
         {selected ? (
           <SkillHubTab


### PR DESCRIPTION
## Summary

- Keep curated and custom ColorPicker values visible and editable in expert palettes and the theme switcher.
- Tighten sidebar group padding and keep the active nav group expanded without extra effect churn.
- Migrate modal, drawer, and TreeSelect overlay props to the current Ant Design API (`destroyOnHidden`, `onOpenChange`, `classNames`/`styles.popup`), using `forceRender` where mounted form state must survive hide.
- Point the expert-drawer no-model warning at `/admin/models`, and align model-tab icon/label spacing.
- Drive custom-provider preview and connection-test copy from live form watches instead of stale `getFieldValue` snapshots.
- Use an opaque dark Tooltip background, and restyle the chat context-usage popover for `octop` prefixCls so the panel and arrow share the elevated surface.
- Bump `recharts` (and its `immer` tree) to clear the dashboard dependency warning.

## Testing

- `make all` (2947 passed, 15 skipped)
- `cd dashboard && npm run build`