### PR TITLE
style(dashboard): refine dashboard push toast appearance

### DIFF
--- a/dashboard/src/hooks/useDashboardPushToast.module.less
+++ b/dashboard/src/hooks/useDashboardPushToast.module.less
@@ -8,16 +8,18 @@
 
 .notice {
   cursor: pointer;
-  border-radius: 10px !important;
+  border-radius: 12px !important;
   border: 1px solid var(--fn-border-secondary) !important;
-  box-shadow: 0 4px 16px rgba(15, 23, 42, 0.08) !important;
-  transition:
-    border-color 0.18s ease,
-    box-shadow 0.18s ease;
+  border-left: 4px solid var(--push-accent, var(--fn-color-brand)) !important;
+  box-shadow:
+    0 10px 28px rgba(15, 23, 42, 0.1),
+    0 2px 8px rgba(15, 23, 42, 0.04) !important;
+  transition: box-shadow 0.18s ease;
 
   &:hover {
-    border-color: var(--fn-border-primary) !important;
-    box-shadow: 0 6px 20px rgba(15, 23, 42, 0.1) !important;
+    box-shadow:
+      0 14px 32px rgba(15, 23, 42, 0.14),
+      0 4px 10px rgba(15, 23, 42, 0.06) !important;
   }
 }
 


### PR DESCRIPTION
## Summary

- Restyle dashboard push toasts with a stronger left accent, larger radius, and deeper shadow so they read more clearly and hover more distinctly.

## Target branch

- [x] Base is **`develop`** (feature / fix — default)
- [ ] Base is **`main`** (`release/*` or `hotfix/*` only)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactor / chore
- [ ] Release / hotfix

## Test plan

Visual polish only in `dashboard/src/hooks/useDashboardPushToast.module.less`. No tests added.

- [ ] `make all` passes locally
- [ ] Added/updated tests

## Checklist

- [ ] Updated `CHANGELOG.md` (if user-facing)
- [ ] README / docs updated (if needed)