### PR TITLE
fix(backup): pack workspace archive from the workspace, not the backe…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@
 - SQLite 历史回填为 checkpoint 内容引用创建绑定只读连接的独立解码器和缓存，并在同一读事务内读取，避免访问运行中的 saver 连接；兼容原有 inline 格式。新格式需要配套安装提供 `CheckpointSerializer.with_connection` 的 harness-memory。PostgreSQL 保持原生 graph 历史读取路径。
 - 共享连接器卡片标题被「来自 X」标签挤压截断看不清：标签移至标题下方独立一行；连接器实例与内置目录卡片的长标题截断后悬停均可显示完整标题（#626）
 - 暗色模式下 Tooltip 背景近乎透明、文字与页面内容叠印无法阅读（#626）
+- 下载 Agent 工作区 zip（`GET /agents/{id}/workspace/archive`）时，backend `root_dir` 下的同名文件（如用户主目录的 `AGENTS.md`）会顶替 workspace 自身的同名文件：条目名与包结构都正确、只有内容错误，zip 校验和无法察觉。现在按 workspace 目录读取，并把越出 workspace 的条目跳过不入包（含仍保留 legacy 根 `skills/` 的工作区）。
+- 工作区 zip 的 `replace` 导入会删除隐藏的系统状态（`.octop` 下的会话 / 技能 / 认证），而导出不包含隐藏项、导入无法恢复，造成静默数据丢失；现在清空本地工作区时保留隐藏项。
 
 ### 变更
 

--- a/src/octop/infra/backup/workspace_archive.py
+++ b/src/octop/infra/backup/workspace_archive.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+import asyncio
 import io
 import shutil
 import zipfile
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal
+
+from harness_agent.backends.utils import materialize_storage_path
 
 if TYPE_CHECKING:
     from harness_agent.backends.workspace import BackendWorkspace
@@ -53,10 +56,17 @@ async def _list_file_paths(workspace: BackendWorkspace) -> list[str]:
 
 
 def _clear_local_workspace(workspace_dir: Path) -> None:
+    """Clear local workspace content, keeping entries an archive cannot restore.
+
+    The export glob never matches hidden paths, so harness system state (``.octop``
+    sessions / skills / auth, legacy ``.octop-auth``, ``.env``) is absent from every
+    archive. Deleting it here would destroy data the import can never put back, so
+    hidden entries are left untouched.
+    """
     if not workspace_dir.is_dir():
         return
     for child in workspace_dir.iterdir():
-        if child.name in _SKIP_DIR_NAMES:
+        if child.name in _SKIP_DIR_NAMES or child.name.startswith("."):
             continue
         if child.is_dir():
             shutil.rmtree(child)
@@ -77,13 +87,58 @@ def _iter_zip_entries(data: bytes) -> list[tuple[str, bytes]]:
     return out
 
 
+def _local_mount(workspace: BackendWorkspace) -> Path | None:
+    """Host disk mount backing *workspace*, or ``None`` when files live elsewhere.
+
+    Mirrors harness ``_has_backend_mount``: sandbox backends keep content inside
+    the sandbox, and remote backends (COS/S3/…) expose no local mount. Only a
+    host-mounted workspace may be read from an explicit local path.
+    """
+    backend = workspace.backend
+    if getattr(backend, "sandbox_fs", False):
+        return None
+    return materialize_storage_path("/", backend=backend, must_exist=False)
+
+
+def _read_entry_bytes(workspace: BackendWorkspace, rel: str) -> bytes | None:
+    """Read one workspace entry without backend-root shadowing (blocking).
+
+    ``BackendWorkspace`` probes ``{root_dir}/{rel}`` ahead of ``{workspace_dir}/{rel}``
+    under ``virtual_mode``, so a same-named file at the backend root (e.g. a user's
+    ``~/AGENTS.md``) would otherwise be packed in place of the workspace's own file.
+
+    Host-mounted workspaces are therefore read from ``workspace_dir`` — the base
+    ``present_path`` reports entries against — rather than through
+    ``resolve_path()``, which re-maps system entries (``skills/``, ``agents/``,
+    ``sessions/``, …) under ``system_files_path`` and would miss a workspace that
+    still keeps them at its root. Names escaping the workspace are skipped rather
+    than packed. Remote and sandbox backends keep going through the backend
+    protocol so stale local files cannot shadow remote objects.
+
+    Kept synchronous so callers can run it in one thread hop (see
+    :func:`export_workspace_zip`) instead of blocking the event loop.
+    """
+    if _local_mount(workspace) is not None:
+        root = workspace.workspace_dir
+        local = (root / rel).resolve()
+        try:
+            local.relative_to(root)
+        except ValueError:
+            return None
+        if local.is_file():
+            blob = workspace.download_bytes(str(local))
+            if blob is not None:
+                return blob
+    return workspace.download_bytes(rel)
+
+
 async def export_workspace_zip(workspace: BackendWorkspace) -> bytes:
     """Pack workspace files into a zip archive."""
     paths = await _list_file_paths(workspace)
     buf = io.BytesIO()
     with zipfile.ZipFile(buf, "w", compression=zipfile.ZIP_DEFLATED) as zf:
         for path in paths:
-            blob = await workspace.adownload_bytes(path)
+            blob = await asyncio.to_thread(_read_entry_bytes, workspace, path)
             if blob is None:
                 continue
             zf.writestr(path.lstrip("/"), blob)

--- a/tests/unit/backup/test_workspace_archive.py
+++ b/tests/unit/backup/test_workspace_archive.py
@@ -5,9 +5,12 @@ from __future__ import annotations
 import io
 import zipfile
 from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
 
 import pytest
 from deepagents.backends.local_shell import LocalShellBackend
+from harness_agent.backends import resolve_backend
 from harness_agent.backends.workspace import BackendWorkspace
 
 from octop.infra.backup.workspace_archive import export_workspace_zip, import_workspace_zip
@@ -56,3 +59,119 @@ async def test_replace_clears_local_dir(tmp_path: Path) -> None:
     assert result["imported"] == 1
     assert not (ws / "old.txt").exists()
     assert (ws / "new.txt").read_bytes() == b"new"
+
+
+@pytest.mark.asyncio
+async def test_export_ignores_same_named_file_at_backend_root(tmp_path: Path) -> None:
+    """A same-named file at the backend root must not shadow the workspace's own file.
+
+    Regression: under ``virtual_mode`` with a scoped ``root_dir`` that contains the
+    workspace, ``BackendWorkspace`` probed ``{root_dir}/{rel}`` before
+    ``{workspace_dir}/{rel}``, so the archive carried the backend-root ``AGENTS.md``
+    while the entry name still said ``AGENTS.md``.
+    """
+    home = tmp_path / "home"
+    workspace_dir = home / ".octop" / "workspaces" / "AGT1"
+    workspace_dir.mkdir(parents=True)
+
+    (home / "AGENTS.md").write_bytes(b"backend-root AGENTS.md")
+    (workspace_dir / "AGENTS.md").write_bytes(b"workspace AGENTS.md")
+    (workspace_dir / "SOUL.md").write_bytes(b"workspace SOUL.md")
+
+    backend = resolve_backend(
+        {"type": "filesystem", "root_dir": str(home), "virtual_mode": True},
+        workspace_dir=workspace_dir,
+    )
+    workspace = BackendWorkspace(backend, workspace_dir, system_files_path=".octop")
+
+    blob = await export_workspace_zip(workspace)
+    with zipfile.ZipFile(io.BytesIO(blob), "r") as zf:
+        assert zf.read("AGENTS.md") == b"workspace AGENTS.md"
+        assert zf.read("SOUL.md") == b"workspace SOUL.md"
+
+
+@pytest.mark.asyncio
+async def test_replace_import_keeps_system_state(tmp_path: Path) -> None:
+    """``replace`` must not delete state an archive can never carry.
+
+    Hidden paths are outside the export glob, so ``.octop`` (sessions / skills /
+    auth) is absent from every archive; clearing it on replace destroyed data that
+    the import could not restore.
+    """
+    ws = tmp_path / "ws"
+    (ws / ".octop" / "sessions").mkdir(parents=True)
+    (ws / ".octop" / "sessions" / "state.db").write_bytes(b"SESSION DB")
+    (ws / ".octop" / "auth").mkdir(parents=True)
+    (ws / ".octop" / "auth" / "token.json").write_bytes(b"TOKEN")
+    (ws / "old.txt").write_text("old", encoding="utf-8")
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("new.txt", "new")
+    data = buf.getvalue()
+
+    backend = LocalShellBackend(root_dir=str(ws), virtual_mode=False)
+    workspace = BackendWorkspace(backend, ws)
+    result = await import_workspace_zip(workspace, data, mode="replace", local_workspace_dir=ws)
+
+    assert result["imported"] == 1
+    assert not (ws / "old.txt").exists()  # visible content is still replaced
+    assert (ws / "new.txt").read_bytes() == b"new"
+    assert (ws / ".octop" / "sessions" / "state.db").read_bytes() == b"SESSION DB"
+    assert (ws / ".octop" / "auth" / "token.json").read_bytes() == b"TOKEN"
+
+
+@pytest.mark.asyncio
+async def test_export_reads_legacy_root_system_dir_from_workspace(tmp_path: Path) -> None:
+    """A legacy root ``skills/`` must not be shadowed by the backend root either.
+
+    ``workspace.resolve_path()`` re-maps ``skills/`` under ``system_files_path``
+    (``.octop``), so probing it for a workspace that still keeps legacy root
+    ``skills/`` misses and falls back to the shadowed relative read.
+    """
+    home = tmp_path / "home"
+    workspace_dir = home / ".octop" / "workspaces" / "AGT1"
+    (workspace_dir / "skills" / "demo").mkdir(parents=True)
+    (home / "skills" / "demo").mkdir(parents=True)
+
+    (home / "skills" / "demo" / "SKILL.md").write_bytes(b"backend-root SKILL")
+    (workspace_dir / "skills" / "demo" / "SKILL.md").write_bytes(b"workspace SKILL")
+
+    backend = resolve_backend(
+        {"type": "filesystem", "root_dir": str(home), "virtual_mode": True},
+        workspace_dir=workspace_dir,
+    )
+    workspace = BackendWorkspace(backend, workspace_dir, system_files_path=".octop")
+
+    blob = await export_workspace_zip(workspace)
+    with zipfile.ZipFile(io.BytesIO(blob), "r") as zf:
+        assert zf.read("skills/demo/SKILL.md") == b"workspace SKILL"
+
+
+class _MountlessBackend:
+    """Backend exposing no host mount, so its files live outside the local disk."""
+
+    def __init__(self, files: dict[str, bytes]) -> None:
+        self._files = files
+
+    async def aglob(self, pattern: str, path: str = "/") -> Any:  # noqa: ARG002
+        return SimpleNamespace(
+            error=None,
+            matches=[{"path": name, "is_dir": False} for name in sorted(self._files)],
+        )
+
+    def download_files(self, paths: list[str]) -> list[Any]:
+        return [
+            SimpleNamespace(path=name, content=self._files.get(name), error=None) for name in paths
+        ]
+
+
+@pytest.mark.asyncio
+async def test_export_reads_remote_backend_over_stale_local_copy(tmp_path: Path) -> None:
+    """A mountless backend must be read via the protocol, not from a stale local file."""
+    (tmp_path / "AGENTS.md").write_bytes(b"stale local AGENTS.md")
+    workspace = BackendWorkspace(_MountlessBackend({"/AGENTS.md": b"remote AGENTS.md"}), tmp_path)
+
+    blob = await export_workspace_zip(workspace)
+    with zipfile.ZipFile(io.BytesIO(blob), "r") as zf:
+        assert zf.read("AGENTS.md") == b"remote AGENTS.md"


### PR DESCRIPTION
…nd root

Downloading a workspace zip (GET /agents/{id}/workspace/archive) could carry a same-named file from the backend root_dir instead of the workspace's own file. With virtual_mode and a scoped root_dir that contains the workspace, harness BackendWorkspace probes {root_dir}/{rel} before {workspace_dir}/{rel}, so a user's ~/AGENTS.md replaced the workspace copy while the entry name still read AGENTS.md - invisible to zip checksums.

_read_entry_bytes() now reads host-mounted entries from workspace_dir, the base present_path reports entries against. Routing through resolve_path() is not enough: it re-maps system entries (skills/, agents/, sessions/, ...) under system_files_path, so a workspace still keeping legacy root skills/ fell back to the shadowed read. Entry names escaping the workspace are skipped rather than packed, and remote / sandbox backends keep reading through the backend protocol so stale local files cannot shadow remote objects.

Also stop replace imports from deleting state an archive can never carry: the export glob does not match hidden paths, so .octop (sessions / skills / auth) was removed by _clear_local_workspace() and could never be restored.

Tests: shadowing at the backend root, legacy root skills/, and replace import preserving system state.

## Summary
修复 Agent 工作区 zip 导出与导入的两处问题。

**1. 导出取到 backend `root_dir` 下的同名文件（主 bug）**

下载工作区 zip（`GET /agents/{id}/workspace/archive`）时，若 backend 为 `virtual_mode: true` 且 `root_dir` 是包含 workspace 的 scoped 目录（例如用户主目录），harness `BackendWorkspace` 会先探测 `{root_dir}/{rel}`、再探测 `{workspace_dir}/{rel}`。因此只要 `root_dir` 下存在同名文件（最常见的是用户主目录的 `AGENTS.md`），它就会顶替 workspace 自身那份 —— **条目名与包结构都正确，只有内容错误，zip 校验和完全查不出来**。

现在 `_read_entry_bytes()` 对 host 挂载的 workspace 直接按 `workspace_dir` 读取（即 `present_path` 汇报条目所依据的基准）。这里刻意没有走 `resolve_path()`：它会把 `skills/`、`agents/`、`sessions/` 等系统条目按 `system_files_path` 重映射，导致仍保留 legacy 根 `skills/` 的工作区回落到被遮蔽的读法。越出 workspace 的条目名会被跳过而不是照单入包；远端 / 沙箱后端仍走 backend 协议读取，保证本地陈旧文件不会反向遮蔽远端对象。

**2. `replace` 导入会删除归档无法带回的系统状态**

导出 glob 不匹配隐藏路径，因此 `.octop`（会话
<!-- What does this PR change and why? -->

## Target branch

- [x] Base is **`develop`** (feature / fix — default)
- [ ] Base is **`main`** (`release/*` or `hotfix/*` only)

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / chore
- [ ] Release / hotfix

## Test plan

<!-- How did you verify this? Include commands run (e.g. `make all`). -->

- [ ] `make all` passes locally
- [x] Added/updated tests

## Checklist

- [x] Updated `CHANGELOG.md` (if user-facing)
- [ ] README / docs updated (if needed)
