### PR TITLE
feat(chat): hang sender avatars beside a composer-aligned column

### DIFF
--- a/dashboard/src/pages/Chat/ChatAgentProfileContext.tsx
+++ b/dashboard/src/pages/Chat/ChatAgentProfileContext.tsx
@@ -1,0 +1,36 @@
+import { createContext, useContext, useMemo, type ReactNode } from "react";
+
+interface ChatAgentProfileContextValue {
+  openAgentProfile: () => void;
+  canOpen: boolean;
+}
+
+const ChatAgentProfileContext =
+  createContext<ChatAgentProfileContextValue | null>(null);
+
+export function ChatAgentProfileProvider({
+  canOpen,
+  onOpen,
+  children,
+}: {
+  canOpen: boolean;
+  onOpen: () => void;
+  children: ReactNode;
+}) {
+  const value = useMemo(
+    () => ({
+      canOpen,
+      openAgentProfile: onOpen,
+    }),
+    [canOpen, onOpen],
+  );
+  return (
+    <ChatAgentProfileContext.Provider value={value}>
+      {children}
+    </ChatAgentProfileContext.Provider>
+  );
+}
+
+export function useChatAgentProfile(): ChatAgentProfileContextValue | null {
+  return useContext(ChatAgentProfileContext);
+}

--- a/dashboard/src/pages/Chat/chatMessages.partial.less
+++ b/dashboard/src/pages/Chat/chatMessages.partial.less
@@ -145,14 +145,15 @@
 
 .messageListInner {
   overflow-anchor: none;
-  max-width: var(--chat-column-max, 960px);
+  --chat-column-max: 960px;
+  --chat-msg-avatar-slot: 44px;
+  /* Full list width; each row centers a 960px text track + avatar gutters
+     so history and live turns share the same column as the composer. */
+  box-sizing: border-box;
+  width: 100%;
   min-width: 280px;
   margin: 0 auto;
-  padding: 0 var(--chat-column-pad-x, 24px);
-
-  @media (max-width: 767px) {
-    padding: 0 12px;
-  }
+  padding-inline: var(--chat-column-pad-x, 24px);
 }
 
 .messageListLoading {
@@ -183,9 +184,19 @@
 }
 
 /* ---------- Message bubbles ---------- */
+/* 3 columns: expert avatar | composer-aligned text | user avatar */
+.chatMsgColumns() {
+  display: grid;
+  grid-template-columns:
+    var(--chat-msg-avatar-slot, 44px) minmax(0, var(--chat-column-max, 960px))
+    var(--chat-msg-avatar-slot, 44px);
+  justify-content: center;
+  width: 100%;
+}
+
 .messageBubble {
-  display: flex;
-  gap: 10px;
+  .chatMsgColumns();
+  align-items: start;
   margin-bottom: 16px;
 }
 
@@ -199,6 +210,15 @@
 
   .messageBubble {
     margin-bottom: 0;
+  }
+}
+
+.turnInset {
+  .chatMsgColumns();
+
+  > * {
+    grid-column: 2;
+    min-width: 0;
   }
 }
 
@@ -244,19 +264,29 @@
 }
 
 .userBubble {
-  flex-direction: row-reverse;
-  justify-content: flex-start;
   animation: fadeIn 0.25s ease;
 
-  /* User bubble content should shrink-to-fit, not stretch full width */
   .bubbleContent {
-    flex: 0 1 auto;
+    grid-column: 2;
+    justify-self: end;
     max-width: min(75%, 600px);
+  }
+
+  .avatarCol {
+    grid-column: 3;
+    justify-self: center;
   }
 }
 
 .assistantBubble {
-  flex-direction: row;
+  .bubbleContent {
+    grid-column: 2;
+  }
+
+  .avatarCol {
+    grid-column: 1;
+    justify-self: center;
+  }
 }
 
 .errorBubble .bubbleContent {
@@ -267,9 +297,62 @@
   color: var(--fn-color-danger);
 }
 
-.avatarCol {
+.msgSender {
   flex-shrink: 0;
   padding-top: 2px;
+  line-height: 0;
+}
+
+.msgSenderBtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0;
+  padding: 0;
+  border: none;
+  background: transparent;
+  line-height: 0;
+  cursor: pointer;
+  border-radius: 50%;
+
+  &:hover {
+    opacity: 0.85;
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--fn-color-brand);
+    outline-offset: 2px;
+  }
+}
+
+.msgAvatarPlain {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  overflow: hidden;
+  line-height: 0;
+}
+
+.msgUserAvatar {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--fn-color-brand);
+  color: #fff;
+  font-size: 15px;
+  font-weight: 600;
+  user-select: none;
+}
+
+.avatarCol {
+  display: flex;
+  justify-content: center;
+  padding-top: 2px;
+  min-width: 0;
 }
 
 .botAvatar {
@@ -295,7 +378,6 @@
 .bubbleContent {
   max-width: 100%;
   min-width: 0;
-  flex: 1;
 
   &:hover .msgCopyBtn {
     opacity: 1;
@@ -674,9 +756,18 @@
 
 /* ---------- Assistant turn process summary (tools + thinking) ---------- */
 .processSummaryRow {
-  display: block;
-  width: fit-content;
+  .chatMsgColumns();
+  align-items: start;
   max-width: 100%;
+
+  .avatarCol {
+    grid-column: 1;
+    justify-self: center;
+  }
+
+  .processSummary {
+    grid-column: 2;
+  }
 }
 
 .processSummary {

--- a/dashboard/src/pages/Chat/chatThemeOverrides.partial.less
+++ b/dashboard/src/pages/Chat/chatThemeOverrides.partial.less
@@ -630,16 +630,11 @@
 }
 
 .messageListInner {
-  max-width: 960px;
+  width: 100%;
   min-width: 280px;
   margin: 0 auto;
-  padding: 0 20px;
-  width: 100%;
+  padding-inline: var(--chat-column-pad-x, 24px);
   overflow-anchor: none;
-
-  @media (max-width: 767px) {
-    padding: 0 14px;
-  }
 }
 
 .inlineToolBlock {

--- a/dashboard/src/pages/Chat/components/AssistantTurnView.tsx
+++ b/dashboard/src/pages/Chat/components/AssistantTurnView.tsx
@@ -19,7 +19,11 @@ import {
 } from "../../../utils/parseWriteTodos";
 import MessageBubble from "./MessageBubble";
 import { ToolMediaStrip } from "./ToolMediaStrip";
-import { TurnProcessBlocks, turnHasVisibleProcess } from "./TurnProcessBlocks";
+import {
+  TurnProcessBlocks,
+  turnHasProcessSummary,
+  turnHasVisibleProcess,
+} from "./TurnProcessBlocks";
 import { collectTurnToolMedia } from "../../../utils/collectTurnToolMedia";
 import { collectTurnKnowledgeCitations } from "../../../utils/collectTurnKnowledgeCitations";
 import { KnowledgeCitationsStrip } from "./KnowledgeCitationsStrip";
@@ -139,8 +143,13 @@ export default function AssistantTurnView({
   const firstProcessSegmentIdx = compactProcess
     ? -1
     : segmentProcess.findIndex(({ split }) => hasProcessContent(split));
+  const firstSummaryIdx = compactProcess
+    ? -1
+    : segmentProcess.findIndex(({ split }) => turnHasProcessSummary(split));
   const showTrailingProcess =
     !compactProcess && hasProcessContent(trailingSplit);
+  const trailingHasSummary =
+    !compactProcess && turnHasProcessSummary(trailingSplit);
   const anyProcessShown = firstProcessSegmentIdx >= 0 || showTrailingProcess;
 
   const todoPanel =
@@ -155,7 +164,7 @@ export default function AssistantTurnView({
 
   return (
     <div className={styles.assistantTurn}>
-      {todoAtTop}
+      {todoAtTop ? <div className={styles.turnInset}>{todoAtTop}</div> : null}
       {segmentProcess.map(({ split, hitl }, idx) => {
         const showProcess = !compactProcess && hasProcessContent(split);
         // Freeze process spinner while a pending approval card is open.
@@ -174,12 +183,16 @@ export default function AssistantTurnView({
                   onAcpPermissionSelect={onAcpPermissionSelect}
                   hideToolMedia={hasToolMedia}
                   agentId={agentId}
+                  showAvatar={idx === firstSummaryIdx}
                 />
-                {todoPanel && idx === firstProcessSegmentIdx ? todoPanel : null}
+                {todoPanel && idx === firstProcessSegmentIdx ? (
+                  <div className={styles.turnInset}>{todoPanel}</div>
+                ) : null}
               </>
             ) : null}
             <MessageBubble
               message={hitl}
+              agentId={agentId}
               onHitlDecision={onHitlDecision}
               groupPosition="only"
             />
@@ -194,22 +207,29 @@ export default function AssistantTurnView({
             onAcpPermissionSelect={onAcpPermissionSelect}
             hideToolMedia={hasToolMedia}
             agentId={agentId}
+            showAvatar={firstSummaryIdx < 0 && trailingHasSummary}
           />
-          {todoPanel && firstProcessSegmentIdx < 0 ? todoPanel : null}
+          {todoPanel && firstProcessSegmentIdx < 0 ? (
+            <div className={styles.turnInset}>{todoPanel}</div>
+          ) : null}
         </>
       ) : null}
       {hasToolMedia && (
-        <ToolMediaStrip
-          images={toolMedia.images}
-          videos={toolMedia.videos}
-          files={toolMedia.files}
-          agentId={agentId}
-        />
+        <div className={styles.turnInset}>
+          <ToolMediaStrip
+            images={toolMedia.images}
+            videos={toolMedia.videos}
+            files={toolMedia.files}
+            agentId={agentId}
+          />
+        </div>
       )}
       {trailingSplit.answerMessage ? (
         <div className={styles.assistantTurnAnswer}>
           <MessageBubble
             message={toAnswerOnlyMessage(trailingSplit.answerMessage)}
+            agentId={agentId}
+            showAvatar={firstSummaryIdx < 0 && !trailingHasSummary}
             onRegenerate={onRegenerate}
             onEditUserMessage={onEditUserMessage}
             onForkAssistantMessage={onForkAssistantMessage}
@@ -222,60 +242,68 @@ export default function AssistantTurnView({
           />
         </div>
       ) : null}
-      <KnowledgeCitationsStrip citations={knowledgeCitations} />
+      {knowledgeCitations.length > 0 ? (
+        <div className={styles.turnInset}>
+          <KnowledgeCitationsStrip citations={knowledgeCitations} />
+        </div>
+      ) : null}
       {showOpenBrowser && (
-        <button
-          type="button"
-          className={`${styles.openBrowserPrompt} ${
-            turnStreaming ? styles.openBrowserPromptActive : ""
-          }`}
-          onClick={onOpenBrowser}
-          aria-label={t("chat.openBrowser")}
-        >
-          <Globe
-            size={16}
-            strokeWidth={2}
-            className={styles.openBrowserPromptIcon}
-            aria-hidden="true"
-          />
-          <span>{t("chat.openBrowser")}</span>
-          <ChevronRight
-            size={14}
-            className={styles.openBrowserPromptArrow}
-            aria-hidden="true"
-          />
-        </button>
+        <div className={styles.turnInset}>
+          <button
+            type="button"
+            className={`${styles.openBrowserPrompt} ${
+              turnStreaming ? styles.openBrowserPromptActive : ""
+            }`}
+            onClick={onOpenBrowser}
+            aria-label={t("chat.openBrowser")}
+          >
+            <Globe
+              size={16}
+              strokeWidth={2}
+              className={styles.openBrowserPromptIcon}
+              aria-hidden="true"
+            />
+            <span>{t("chat.openBrowser")}</span>
+            <ChevronRight
+              size={14}
+              className={styles.openBrowserPromptArrow}
+              aria-hidden="true"
+            />
+          </button>
+        </div>
       )}
       {showEditFile && (
-        <button
-          type="button"
-          className={`${styles.openBrowserPrompt} ${
-            turnStreaming ? styles.openBrowserPromptActive : ""
-          }`}
-          onClick={onEditFile}
-          aria-label={t("chat.editFileCard", {
-            count: Math.max(turnFileCount, 1),
-            defaultValue: "编辑了{{count}}个文件",
-          })}
-        >
-          <FilePen
-            size={16}
-            strokeWidth={2}
-            className={styles.openBrowserPromptIcon}
-            aria-hidden="true"
-          />
-          <span>
-            {t("chat.editFileCard", {
+        <div className={styles.turnInset}>
+          <button
+            type="button"
+            className={`${styles.openBrowserPrompt} ${
+              turnStreaming ? styles.openBrowserPromptActive : ""
+            }`}
+            onClick={onEditFile}
+            aria-label={t("chat.editFileCard", {
               count: Math.max(turnFileCount, 1),
               defaultValue: "编辑了{{count}}个文件",
             })}
-          </span>
-          <ChevronRight
-            size={14}
-            className={styles.openBrowserPromptArrow}
-            aria-hidden="true"
-          />
-        </button>
+          >
+            <FilePen
+              size={16}
+              strokeWidth={2}
+              className={styles.openBrowserPromptIcon}
+              aria-hidden="true"
+            />
+            <span>
+              {t("chat.editFileCard", {
+                count: Math.max(turnFileCount, 1),
+                defaultValue: "编辑了{{count}}个文件",
+              })}
+            </span>
+            <ChevronRight
+              size={14}
+              className={styles.openBrowserPromptArrow}
+              aria-hidden="true"
+            />
+          </button>
+        </div>
       )}
     </div>
   );

--- a/dashboard/src/pages/Chat/components/GeneratingIndicator.tsx
+++ b/dashboard/src/pages/Chat/components/GeneratingIndicator.tsx
@@ -22,32 +22,34 @@ export default function GeneratingIndicator({
   const showTimer = Boolean(showElapsed && startedAt != null && startedAt > 0);
 
   return (
-    <div
-      className={styles.generatingIndicator}
-      role="status"
-      aria-live="polite"
-    >
-      <span className={styles.thinkingDot} />
-      <span className={styles.thinkingDot} />
-      <span className={styles.thinkingDot} />
-      <span className={styles.generatingText}>
-        {showTimer
-          ? t("chat.generatingWithElapsed", {
-              seconds: elapsed,
-              defaultValue: "生成中 · {{seconds}}s",
-            })
-          : t("chat.generating", "生成中")}
-      </span>
-      {onCancel && (
-        <button
-          className={styles.thinkingCancelBtn}
-          onClick={onCancel}
-          type="button"
-          title={t("common.cancel")}
-        >
-          {t("common.cancel")}
-        </button>
-      )}
+    <div className={styles.turnInset}>
+      <div
+        className={styles.generatingIndicator}
+        role="status"
+        aria-live="polite"
+      >
+        <span className={styles.thinkingDot} />
+        <span className={styles.thinkingDot} />
+        <span className={styles.thinkingDot} />
+        <span className={styles.generatingText}>
+          {showTimer
+            ? t("chat.generatingWithElapsed", {
+                seconds: elapsed,
+                defaultValue: "生成中 · {{seconds}}s",
+              })
+            : t("chat.generating", "生成中")}
+        </span>
+        {onCancel && (
+          <button
+            className={styles.thinkingCancelBtn}
+            onClick={onCancel}
+            type="button"
+            title={t("common.cancel")}
+          >
+            {t("common.cancel")}
+          </button>
+        )}
+      </div>
     </div>
   );
 }

--- a/dashboard/src/pages/Chat/components/MessageBubble.tsx
+++ b/dashboard/src/pages/Chat/components/MessageBubble.tsx
@@ -40,6 +40,13 @@ import {
 import { MessageFileCard } from "./MessageFileCard";
 import AskQuestionCard from "./AskQuestionCard";
 import HitlApprovalCard from "./HitlApprovalCard";
+import MessageSender, { ExpertMessageAvatar } from "./MessageSender";
+import { useCurrentUser } from "../../../hooks/useCurrentUser";
+import { useAgent } from "../../../context/AgentContext";
+import {
+  accountDisplayName,
+  accountInitials,
+} from "../utils/accountDisplayName";
 import { extractAskQuestions, isAskHitl } from "../../../api/types/hitl";
 import styles from "../index.module.less";
 import {
@@ -77,6 +84,8 @@ interface MessageBubbleProps {
   compact?: boolean;
   /** Position within an assistant group — controls border-radius & meta visibility. */
   groupPosition?: "first" | "middle" | "last" | "only";
+  /** Assistant avatar. Hide when the turn already shows one on the process row. */
+  showAvatar?: boolean;
   onRunShellCommand?: (code: string) => void;
   shellCommandDisabled?: boolean;
   shellCommandDisabledTitle?: string;
@@ -524,6 +533,7 @@ function MessageBubble({
   onHitlDecision,
   compact,
   groupPosition = "only",
+  showAvatar = true,
   onRunShellCommand,
   shellCommandDisabled,
   shellCommandDisabledTitle,
@@ -531,6 +541,15 @@ function MessageBubble({
   const { t } = useTranslation();
   const navigate = useNavigate();
   const serverTimezone = useServerTimezone();
+  const user = useCurrentUser();
+  const { agents, activeAgent } = useAgent();
+  const expert = useMemo(
+    () =>
+      (agentId && agents.find((item) => item.agent_id === agentId)) ||
+      activeAgent,
+    [agentId, agents, activeAgent],
+  );
+  const userName = accountDisplayName(user);
 
   const [isEditing, setIsEditing] = useState(false);
   const [editText, setEditText] = useState(message.content);
@@ -592,36 +611,43 @@ function MessageBubble({
       const questions = extractAskQuestions(actions);
       return (
         <div
-          className={`${styles.bubble} ${styles.assistantBubble} ${
-            compact ? styles.compact : ""
+          className={`${styles.messageBubble} ${styles.assistantBubble} ${
+            compact ? styles.compactBubble : ""
           }`}
         >
-          <AskQuestionCard
-            questions={questions}
-            status={hitlStatus}
-            onSubmit={
-              onHitlDecision
-                ? (answer) =>
-                    onHitlDecision(
-                      actions.map(() => ({ type: "respond", message: answer })),
-                    )
-                : undefined
-            }
-          />
+          <div className={styles.bubbleContent}>
+            <AskQuestionCard
+              questions={questions}
+              status={hitlStatus}
+              onSubmit={
+                onHitlDecision
+                  ? (answer) =>
+                      onHitlDecision(
+                        actions.map(() => ({
+                          type: "respond",
+                          message: answer,
+                        })),
+                      )
+                  : undefined
+              }
+            />
+          </div>
         </div>
       );
     }
     return (
       <div
-        className={`${styles.bubble} ${styles.assistantBubble} ${
-          compact ? styles.compact : ""
+        className={`${styles.messageBubble} ${styles.assistantBubble} ${
+          compact ? styles.compactBubble : ""
         }`}
       >
-        <HitlApprovalCard
-          actions={actions}
-          status={hitlStatus}
-          onDecision={onHitlDecision}
-        />
+        <div className={styles.bubbleContent}>
+          <HitlApprovalCard
+            actions={actions}
+            status={hitlStatus}
+            onDecision={onHitlDecision}
+          />
+        </div>
       </div>
     );
   }
@@ -695,6 +721,27 @@ function MessageBubble({
         : ""
       : "";
 
+  const showSender =
+    (isUser || groupPosition === "first" || groupPosition === "only") &&
+    (isUser || showAvatar);
+  const senderAvatar = !showSender ? null : isUser ? (
+    <MessageSender
+      name={userName}
+      avatar={
+        <span className={styles.msgUserAvatar}>
+          {accountInitials(userName)}
+        </span>
+      }
+    />
+  ) : expert ? (
+    <ExpertMessageAvatar
+      name={expert.name}
+      color={expert.color}
+      iconName={expert.icon_name}
+      iconUrl={expert.icon_url}
+    />
+  ) : null;
+
   return (
     <div
       className={`${styles.messageBubble} ${
@@ -703,114 +750,122 @@ function MessageBubble({
         compact ? styles.compactBubble : ""
       }`}
     >
+      {!isUser && senderAvatar ? (
+        <div className={styles.avatarCol}>{senderAvatar}</div>
+      ) : null}
       <div className={styles.bubbleContent}>
         {isUser ? (
           <div className={styles.userMsgRow}>
-            {isEditing ? (
-              <div className={styles.editArea}>
-                <textarea
-                  ref={editTextareaRef}
-                  className={styles.editTextarea}
-                  value={editText}
-                  onChange={(e) => setEditText(e.target.value)}
-                  autoFocus
-                  rows={4}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter" && !e.shiftKey) {
-                      e.preventDefault();
-                      handleEditSubmit();
-                    }
-                    if (e.key === "Escape") handleEditCancel();
-                  }}
-                />
-                <div className={styles.editActions}>
-                  <button
-                    className={styles.editSaveBtn}
-                    onClick={handleEditSubmit}
-                    type="button"
-                  >
-                    {t("common.save", "保存并重新发送")}
-                  </button>
-                  <button
-                    className={styles.editCancelBtn}
-                    onClick={handleEditCancel}
-                    type="button"
-                  >
-                    {t("common.cancel", "取消")}
-                  </button>
-                </div>
-              </div>
-            ) : (
-              <div className={styles.userMsgColumn}>
-                <UserMessageComposerTags
-                  context={message.composerContext}
-                  lookups={composerLookups}
-                />
-                <div className={styles.userText}>
-                  {imageAttachments.length > 0 && (
-                    <ImageGallery images={imageAttachments} agentId={agentId} />
-                  )}
-                  {videoAttachments.length > 0 && (
-                    <div className={styles.messageMediaList}>
-                      {videoAttachments.map((attachment, idx) => (
-                        <ChatMediaPlayer
-                          key={`${attachment.url}-${idx}`}
-                          url={attachment.url}
-                          filename={attachment.filename}
-                          workspacePath={attachment.workspacePath}
-                          mediaType={attachment.mediaType}
-                          kind="video"
-                          agentId={agentId}
-                        />
-                      ))}
-                    </div>
-                  )}
-                  {audioAttachments.length > 0 && (
-                    <div className={styles.messageMediaList}>
-                      {audioAttachments.map((attachment, idx) => (
-                        <ChatMediaPlayer
-                          key={`${attachment.url}-${idx}`}
-                          url={attachment.url}
-                          filename={attachment.filename}
-                          workspacePath={attachment.workspacePath}
-                          mediaType={attachment.mediaType}
-                          kind="audio"
-                          agentId={agentId}
-                        />
-                      ))}
-                    </div>
-                  )}
-                  {fileAttachments.length > 0 && (
-                    <FileAttachmentList
-                      files={fileAttachments}
-                      agentId={agentId}
-                    />
-                  )}
-                  {message.content && <div>{message.content}</div>}
-                </div>
-                {(message.content || onEditUserMessage) && (
-                  <div className={styles.userMsgActions} role="group">
-                    {message.content ? (
-                      <CopyButton text={message.content} />
-                    ) : null}
-                    {onEditUserMessage ? (
-                      <button
-                        className={styles.msgActionBtn}
-                        onClick={() => {
-                          setEditText(message.content);
-                          setIsEditing(true);
-                        }}
-                        title={t("common.edit")}
-                        type="button"
-                        aria-label={t("common.edit")}
-                      >
-                        <Pencil size={14} />
-                      </button>
-                    ) : null}
+            <div className={styles.userMsgColumn}>
+              {isEditing ? (
+                <div className={styles.editArea}>
+                  <textarea
+                    ref={editTextareaRef}
+                    className={styles.editTextarea}
+                    value={editText}
+                    onChange={(e) => setEditText(e.target.value)}
+                    autoFocus
+                    rows={4}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" && !e.shiftKey) {
+                        e.preventDefault();
+                        handleEditSubmit();
+                      }
+                      if (e.key === "Escape") handleEditCancel();
+                    }}
+                  />
+                  <div className={styles.editActions}>
+                    <button
+                      className={styles.editSaveBtn}
+                      onClick={handleEditSubmit}
+                      type="button"
+                    >
+                      {t("common.save", "保存并重新发送")}
+                    </button>
+                    <button
+                      className={styles.editCancelBtn}
+                      onClick={handleEditCancel}
+                      type="button"
+                    >
+                      {t("common.cancel", "取消")}
+                    </button>
                   </div>
-                )}
-              </div>
-            )}
+                </div>
+              ) : (
+                <>
+                  <UserMessageComposerTags
+                    context={message.composerContext}
+                    lookups={composerLookups}
+                  />
+                  <div className={styles.userText}>
+                    {imageAttachments.length > 0 && (
+                      <ImageGallery
+                        images={imageAttachments}
+                        agentId={agentId}
+                      />
+                    )}
+                    {videoAttachments.length > 0 && (
+                      <div className={styles.messageMediaList}>
+                        {videoAttachments.map((attachment, idx) => (
+                          <ChatMediaPlayer
+                            key={`${attachment.url}-${idx}`}
+                            url={attachment.url}
+                            filename={attachment.filename}
+                            workspacePath={attachment.workspacePath}
+                            mediaType={attachment.mediaType}
+                            kind="video"
+                            agentId={agentId}
+                          />
+                        ))}
+                      </div>
+                    )}
+                    {audioAttachments.length > 0 && (
+                      <div className={styles.messageMediaList}>
+                        {audioAttachments.map((attachment, idx) => (
+                          <ChatMediaPlayer
+                            key={`${attachment.url}-${idx}`}
+                            url={attachment.url}
+                            filename={attachment.filename}
+                            workspacePath={attachment.workspacePath}
+                            mediaType={attachment.mediaType}
+                            kind="audio"
+                            agentId={agentId}
+                          />
+                        ))}
+                      </div>
+                    )}
+                    {fileAttachments.length > 0 && (
+                      <FileAttachmentList
+                        files={fileAttachments}
+                        agentId={agentId}
+                      />
+                    )}
+                    {message.content && <div>{message.content}</div>}
+                  </div>
+                  {(message.content || onEditUserMessage) && (
+                    <div className={styles.userMsgActions} role="group">
+                      {message.content ? (
+                        <CopyButton text={message.content} />
+                      ) : null}
+                      {onEditUserMessage ? (
+                        <button
+                          className={styles.msgActionBtn}
+                          onClick={() => {
+                            setEditText(message.content);
+                            setIsEditing(true);
+                          }}
+                          title={t("common.edit")}
+                          type="button"
+                          aria-label={t("common.edit")}
+                        >
+                          <Pencil size={14} />
+                        </button>
+                      ) : null}
+                    </div>
+                  )}
+                </>
+              )}
+            </div>
           </div>
         ) : (
           <>
@@ -983,6 +1038,9 @@ function MessageBubble({
             </div>
           )}
       </div>
+      {isUser && senderAvatar ? (
+        <div className={styles.avatarCol}>{senderAvatar}</div>
+      ) : null}
     </div>
   );
 }

--- a/dashboard/src/pages/Chat/components/MessageList.tsx
+++ b/dashboard/src/pages/Chat/components/MessageList.tsx
@@ -506,27 +506,29 @@ export default function MessageList(props: MessageListProps) {
   const historyHeader = useMemo(() => {
     if (!historyHasMore && !historyLoadingMore) return null;
     return (
-      <div className={styles.historyLoadMore}>
-        {historyLoadingMore ? (
-          <>
-            <Spin size="small" />
-            <span>{t("chat.loadingEarlierMessages")}</span>
-          </>
-        ) : (
-          <>
-            <span className={styles.historyLoadMoreHint}>
-              {t("chat.scrollForEarlierMessages")}
-            </span>
-            <Button
-              type="link"
-              size="small"
-              className={styles.historyLoadMoreBtn}
-              onClick={requestOlderMessages}
-            >
-              {t("chat.loadEarlierMessages")}
-            </Button>
-          </>
-        )}
+      <div className={styles.turnInset}>
+        <div className={styles.historyLoadMore}>
+          {historyLoadingMore ? (
+            <>
+              <Spin size="small" />
+              <span>{t("chat.loadingEarlierMessages")}</span>
+            </>
+          ) : (
+            <>
+              <span className={styles.historyLoadMoreHint}>
+                {t("chat.scrollForEarlierMessages")}
+              </span>
+              <Button
+                type="link"
+                size="small"
+                className={styles.historyLoadMoreBtn}
+                onClick={requestOlderMessages}
+              >
+                {t("chat.loadEarlierMessages")}
+              </Button>
+            </>
+          )}
+        </div>
       </div>
     );
   }, [historyHasMore, historyLoadingMore, requestOlderMessages, t]);
@@ -534,9 +536,11 @@ export default function MessageList(props: MessageListProps) {
   const refreshFooter = useMemo(() => {
     if (!historyRefreshing) return null;
     return (
-      <div className={styles.historyLoadMore}>
-        <Spin size="small" />
-        <span>{t("chat.refreshingMessages")}</span>
+      <div className={styles.turnInset}>
+        <div className={styles.historyLoadMore}>
+          <Spin size="small" />
+          <span>{t("chat.refreshingMessages")}</span>
+        </div>
       </div>
     );
   }, [historyRefreshing, t]);

--- a/dashboard/src/pages/Chat/components/MessageSender.test.tsx
+++ b/dashboard/src/pages/Chat/components/MessageSender.test.tsx
@@ -1,0 +1,35 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import MessageSender, { ExpertMessageAvatar } from "./MessageSender";
+import { ChatAgentProfileProvider } from "../ChatAgentProfileContext";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+describe("MessageSender", () => {
+  it("renders a plain avatar without a visible name", () => {
+    render(<MessageSender name="Ada" avatar={<span>A</span>} />);
+    expect(screen.queryByText("Ada")).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Ada")).toBeInTheDocument();
+  });
+
+  it("shows the expert name as a tooltip target and opens the profile", () => {
+    const onOpen = vi.fn();
+    render(
+      <ChatAgentProfileProvider canOpen onOpen={onOpen}>
+        <ExpertMessageAvatar
+          name="数据分析师"
+          color="#6366f1"
+          iconName="sparkles"
+        />
+      </ChatAgentProfileProvider>,
+    );
+
+    const btn = screen.getByRole("button", { name: "数据分析师" });
+    fireEvent.click(btn);
+    expect(onOpen).toHaveBeenCalledTimes(1);
+  });
+});

--- a/dashboard/src/pages/Chat/components/MessageSender.tsx
+++ b/dashboard/src/pages/Chat/components/MessageSender.tsx
@@ -1,0 +1,77 @@
+import type { ReactNode } from "react";
+import { Tooltip } from "antd";
+import { useTranslation } from "react-i18next";
+import ExpertAgentAvatar from "./ExpertAgentAvatar";
+import { useChatAgentProfile } from "../ChatAgentProfileContext";
+import styles from "../index.module.less";
+
+/** Shared message-row avatar size. */
+export const MESSAGE_AVATAR_SIZE = 36;
+
+interface MessageSenderProps {
+  name: string;
+  avatar: ReactNode;
+}
+
+/** Plain message-row avatar. Name is an accessible label only. */
+export default function MessageSender({ name, avatar }: MessageSenderProps) {
+  const label = name.trim();
+  return (
+    <div className={styles.msgSender} aria-label={label || undefined}>
+      <span className={styles.msgAvatarPlain} aria-hidden>
+        {avatar}
+      </span>
+    </div>
+  );
+}
+
+interface ExpertMessageAvatarProps {
+  name?: string | null;
+  color?: string | null;
+  iconName?: string | null;
+  iconUrl?: string | null;
+}
+
+export function ExpertMessageAvatar({
+  name,
+  color,
+  iconName,
+  iconUrl,
+}: ExpertMessageAvatarProps) {
+  const { t } = useTranslation();
+  const profile = useChatAgentProfile();
+  const label = name?.trim() || "";
+  const canOpen = Boolean(profile?.canOpen);
+  const avatar = (
+    <ExpertAgentAvatar
+      iconName={iconName}
+      iconUrl={iconUrl}
+      color={color}
+      size={MESSAGE_AVATAR_SIZE}
+    />
+  );
+
+  const node = canOpen ? (
+    <button
+      type="button"
+      className={styles.msgSenderBtn}
+      onClick={() => profile?.openAgentProfile()}
+      aria-label={label || t("chat.agentProfile.open")}
+    >
+      {avatar}
+    </button>
+  ) : (
+    <div className={styles.msgSender} aria-label={label || undefined}>
+      <span className={styles.msgAvatarPlain} aria-hidden>
+        {avatar}
+      </span>
+    </div>
+  );
+
+  if (!label) return node;
+  return (
+    <Tooltip title={label} mouseEnterDelay={0.35}>
+      {node}
+    </Tooltip>
+  );
+}

--- a/dashboard/src/pages/Chat/components/TurnProcessBlocks.tsx
+++ b/dashboard/src/pages/Chat/components/TurnProcessBlocks.tsx
@@ -6,6 +6,8 @@ import { partitionPinnedTools } from "../../../plugins/toolRenderers/isPinnedToo
 import { useToolRendererVersion } from "../../../plugins/toolRenderers";
 import AssistantProcessSummary from "./AssistantProcessSummary";
 import { ToolDetailsInline } from "./MessageBubble";
+import { ExpertMessageAvatar } from "./MessageSender";
+import { useAgent } from "../../../context/AgentContext";
 import styles from "../index.module.less";
 
 interface TurnProcessBlocksProps {
@@ -14,6 +16,8 @@ interface TurnProcessBlocksProps {
   onAcpPermissionSelect?: (message: string) => void;
   hideToolMedia: boolean;
   agentId: string | null;
+  /** One expert avatar per turn — only the first process row should show it. */
+  showAvatar?: boolean;
 }
 
 function hasFoldContent(split: AssistantTurnSplit): boolean {
@@ -28,7 +32,12 @@ export function TurnProcessBlocks({
   onAcpPermissionSelect,
   hideToolMedia,
   agentId,
+  showAvatar = false,
 }: TurnProcessBlocksProps) {
+  const { agents, activeAgent } = useAgent();
+  const expert =
+    (agentId && agents.find((item) => item.agent_id === agentId)) ||
+    activeAgent;
   const rendererVersion = useToolRendererVersion();
   const { pinned, folded } = useMemo(
     () => partitionPinnedTools(split),
@@ -43,6 +52,16 @@ export function TurnProcessBlocks({
     <>
       {showFold ? (
         <div className={styles.processSummaryRow}>
+          {showAvatar && expert ? (
+            <div className={styles.avatarCol}>
+              <ExpertMessageAvatar
+                name={expert.name}
+                color={expert.color}
+                iconName={expert.icon_name}
+                iconUrl={expert.icon_url}
+              />
+            </div>
+          ) : null}
           <AssistantProcessSummary
             split={folded}
             statsSplit={split}
@@ -54,20 +73,22 @@ export function TurnProcessBlocks({
         </div>
       ) : null}
       {pinned.length > 0 ? (
-        <div className={styles.pinnedToolResults} data-octop-pinned-tools="">
-          {pinned.map((message: ChatMessage) =>
-            message.toolData ? (
-              <div key={message.id} className={styles.pinnedToolResultItem}>
-                <ToolDetailsInline
-                  toolData={message.toolData}
-                  isStreaming={message.status === "streaming" && isStreaming}
-                  onAcpPermissionSelect={onAcpPermissionSelect}
-                  hideMediaPreview={hideToolMedia}
-                  agentId={agentId}
-                />
-              </div>
-            ) : null,
-          )}
+        <div className={styles.turnInset}>
+          <div className={styles.pinnedToolResults} data-octop-pinned-tools="">
+            {pinned.map((message: ChatMessage) =>
+              message.toolData ? (
+                <div key={message.id} className={styles.pinnedToolResultItem}>
+                  <ToolDetailsInline
+                    toolData={message.toolData}
+                    isStreaming={message.status === "streaming" && isStreaming}
+                    onAcpPermissionSelect={onAcpPermissionSelect}
+                    hideMediaPreview={hideToolMedia}
+                    agentId={agentId}
+                  />
+                </div>
+              ) : null,
+            )}
+          </div>
         </div>
       ) : null}
     </>
@@ -77,4 +98,9 @@ export function TurnProcessBlocks({
 export function turnHasVisibleProcess(split: AssistantTurnSplit): boolean {
   const { pinned, folded } = partitionPinnedTools(split);
   return hasFoldContent(folded) || pinned.length > 0;
+}
+
+/** True when the foldable「已调用 N 次工具 / 深度思考」row will render. */
+export function turnHasProcessSummary(split: AssistantTurnSplit): boolean {
+  return hasFoldContent(partitionPinnedTools(split).folded);
 }

--- a/dashboard/src/pages/Chat/index.module.less
+++ b/dashboard/src/pages/Chat/index.module.less
@@ -19,6 +19,8 @@
   --chat-column-max: 960px;
   --chat-column-pad-x: 24px;
   --chat-column-pad-x-narrow: 12px;
+  /* Avatar hangs outside the message column and must not shrink bubbles. */
+  --chat-msg-avatar-slot: 44px;
   /* Chat title, leading icon, and right-dock selected chrome share this ink. */
   --chat-title-color: var(--fn-text-primary);
 

--- a/dashboard/src/pages/Chat/index.tsx
+++ b/dashboard/src/pages/Chat/index.tsx
@@ -72,6 +72,7 @@ import {
 } from "../../utils/sharedExpert";
 import ChatDockPanels from "./components/ChatDockPanels";
 import { ChatFilePreviewProvider } from "./ChatFilePreviewContext";
+import { ChatAgentProfileProvider } from "./ChatAgentProfileContext";
 import {
   ChatToolDockProvider,
   dockTabIdForToolCall,
@@ -1114,38 +1115,44 @@ function ChatPageInner() {
                   hideMascot={isStreaming}
                 />
               ) : (
-                <MessageList
-                  messages={messages}
-                  composerLookups={composerLookups}
-                  loading={awaitingThreadHistory}
-                  historyHasMore={historyHasMore}
-                  historyLoadingMore={historyLoadingMore}
-                  historyRefreshing={historyRefreshing}
-                  onLoadMoreHistory={loadMoreHistory}
-                  onRefreshHistory={refreshHistory}
-                  isStreaming={isStreaming}
-                  thinkingStartedAt={thinkingStartedAt}
-                  sessionKey={activeThreadId ?? undefined}
-                  onCancel={cancelStream}
-                  onRegenerate={handleRegenerate}
-                  onEditUserMessage={handleEditUserMessage}
-                  onForkAssistantMessage={handleForkAssistantMessage}
-                  forkDisabled={forkDisabled}
-                  forkDisabledHint={forkDisabledHint}
-                  onAcpPermissionSelect={handleAcpPermissionSelect}
-                  onHitlDecision={handleHitlDecision}
-                  onTurnRailVisibilityChange={setTurnRailVisible}
-                  onOpenBrowser={
-                    hasBrowserTool && !isMobile ? openBrowserTab : undefined
-                  }
-                  onEditFile={
-                    !sharedExpertViewer &&
-                    panelFilePaths.length > 0 &&
-                    !isMobile
-                      ? openFileList
-                      : undefined
-                  }
-                />
+                <ChatAgentProfileProvider
+                  canOpen={Boolean(resolvedAgentId) && !sharedExpertViewer}
+                  onOpen={() => setAgentProfileOpen(true)}
+                >
+                  <MessageList
+                    messages={messages}
+                    agentId={resolvedAgentId}
+                    composerLookups={composerLookups}
+                    loading={awaitingThreadHistory}
+                    historyHasMore={historyHasMore}
+                    historyLoadingMore={historyLoadingMore}
+                    historyRefreshing={historyRefreshing}
+                    onLoadMoreHistory={loadMoreHistory}
+                    onRefreshHistory={refreshHistory}
+                    isStreaming={isStreaming}
+                    thinkingStartedAt={thinkingStartedAt}
+                    sessionKey={activeThreadId ?? undefined}
+                    onCancel={cancelStream}
+                    onRegenerate={handleRegenerate}
+                    onEditUserMessage={handleEditUserMessage}
+                    onForkAssistantMessage={handleForkAssistantMessage}
+                    forkDisabled={forkDisabled}
+                    forkDisabledHint={forkDisabledHint}
+                    onAcpPermissionSelect={handleAcpPermissionSelect}
+                    onHitlDecision={handleHitlDecision}
+                    onTurnRailVisibilityChange={setTurnRailVisible}
+                    onOpenBrowser={
+                      hasBrowserTool && !isMobile ? openBrowserTab : undefined
+                    }
+                    onEditFile={
+                      !sharedExpertViewer &&
+                      panelFilePaths.length > 0 &&
+                      !isMobile
+                        ? openFileList
+                        : undefined
+                    }
+                  />
+                </ChatAgentProfileProvider>
               )}
             </div>
 

--- a/dashboard/src/pages/Chat/utils/accountDisplayName.test.ts
+++ b/dashboard/src/pages/Chat/utils/accountDisplayName.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { accountDisplayName, accountInitials } from "./accountDisplayName";
+
+describe("accountDisplayName", () => {
+  it("prefers display_name over username, matching the account avatar", () => {
+    expect(accountDisplayName({ display_name: "Ada", username: "ada.l" })).toBe(
+      "Ada",
+    );
+    expect(
+      accountDisplayName({ display_name: "  Ada  ", username: "ada.l" }),
+    ).toBe("Ada");
+  });
+
+  it("falls back to username when display_name is empty", () => {
+    expect(accountDisplayName({ display_name: null, username: "ada.l" })).toBe(
+      "ada.l",
+    );
+    expect(accountDisplayName({ display_name: "  ", username: "ada.l" })).toBe(
+      "ada.l",
+    );
+  });
+
+  it("returns empty when both are missing", () => {
+    expect(accountDisplayName(null)).toBe("");
+    expect(accountDisplayName({ display_name: null, username: null })).toBe("");
+  });
+});
+
+describe("accountInitials", () => {
+  it("uses the first character, matching the account avatar", () => {
+    expect(accountInitials("Ada")).toBe("A");
+    expect(accountInitials("李雷")).toBe("李");
+    expect(accountInitials("")).toBe("?");
+  });
+});

--- a/dashboard/src/pages/Chat/utils/accountDisplayName.ts
+++ b/dashboard/src/pages/Chat/utils/accountDisplayName.ts
@@ -1,0 +1,14 @@
+/** Same label as the sidebar / account avatar: display name, then username. */
+export function accountDisplayName(
+  user:
+    | { display_name?: string | null; username?: string | null }
+    | null
+    | undefined,
+): string {
+  return user?.display_name?.trim() || user?.username?.trim() || "";
+}
+
+export function accountInitials(name: string): string {
+  const source = name.trim() || "?";
+  return source.charAt(0).toUpperCase();
+}


### PR DESCRIPTION
## Summary
- 对话正文保持和输入框同一列（最多 960px），专家/用户头像占两侧额外槽位。
- 一轮回复只显示一个专家头像：有「已调用 N 次工具 / 深度思考」时放在该行，否则放在正文上；点击打开已有专家详情抽屉。
- 过程摘要、工具/引用/todo、HITL、加载更早消息等行都走同一套三列，避免历史记录宽窄不一致。

## Test plan
- [ ] 刷新聊天页：用户气泡右侧、助手过程行或正文左侧出现 36px 头像
- [ ] 正文列与输入框对齐；头像在列外，不挤占气泡宽度
- [ ] 带工具/思考的历史回合：头像只出现在摘要行
- [ ] 纯文本历史回合：头像出现在回复气泡上
- [ ] 悬停专家头像显示名称；点击打开右侧专家详情（只读共享专家不可点）
- [ ] 上滑加载更早消息后，旧记录宽度与新消息一致


Made with [Cursor](https://cursor.com)