### PR TITLE
feat: persist failed chat turns and add expert task examples

### DIFF
--- a/dashboard/src/api/modules/agentChat.ts
+++ b/dashboard/src/api/modules/agentChat.ts
@@ -10,6 +10,7 @@ export interface ChatWelcomeResponse {
     color?: string;
     icon_name?: string | null;
   }>;
+  task_examples?: { zh?: string[]; en?: string[] } | null;
 }
 
 export const agentChatApi = {

--- a/dashboard/src/api/modules/cronjob.ts
+++ b/dashboard/src/api/modules/cronjob.ts
@@ -9,8 +9,20 @@ export interface OctopCronSettings {
   timezone: string;
 }
 
+export interface CronTaskExamples {
+  zh?: string[];
+  en?: string[];
+}
+
+export interface CronExamplesResponse {
+  task_examples: CronTaskExamples | null;
+}
+
 export const octopCronApi = {
   settings: () => request<OctopCronSettings>("/cron/settings"),
+
+  examples: (agentId: string) =>
+    request<CronExamplesResponse>(`/agents/${agentId}/cron/examples`),
 
   list: (agentId: string) => request<OctopCronRow[]>(`/agents/${agentId}/cron`),
 

--- a/dashboard/src/api/modules/expertMarket.ts
+++ b/dashboard/src/api/modules/expertMarket.ts
@@ -28,6 +28,7 @@ export interface MarketExpert {
   source?: string;
   content?: LocalizedText;
   quick_prompts?: ExpertMarketQuickPrompt[];
+  task_examples?: { zh?: string[]; en?: string[] } | null;
 }
 
 export interface ExpertHubListResponse {

--- a/dashboard/src/api/modules/octopThreads.ts
+++ b/dashboard/src/api/modules/octopThreads.ts
@@ -26,6 +26,8 @@ export interface OctopThreadHistory {
     id?: string;
     usage?: unknown;
     timestamp?: number;
+    status?: string;
+    error_code?: string;
   }>;
   pinned?: boolean;
   model_ref?: string | null;

--- a/dashboard/src/locales/en.json
+++ b/dashboard/src/locales/en.json
@@ -767,6 +767,8 @@
     "marketIncludedSkills": "Included Skills",
     "marketQuickPrompts": "Quick-start cards",
     "marketQuickPromptsEmpty": "No quick-start card preview yet",
+    "marketTaskExamples": "Scheduled-task examples",
+    "marketTaskExamplesEmpty": "No scheduled-task examples yet",
     "marketWorkflowPrompt": "Workflow overview",
     "marketWorkflowMeta": "Package info",
     "marketWorkflowVersion": "v{{version}}",

--- a/dashboard/src/locales/zh.json
+++ b/dashboard/src/locales/zh.json
@@ -767,6 +767,8 @@
     "marketIncludedSkills": "包含技能",
     "marketQuickPrompts": "快速启动卡片",
     "marketQuickPromptsEmpty": "暂无快速启动卡片预览",
+    "marketTaskExamples": "计划任务示例",
+    "marketTaskExamplesEmpty": "暂无计划任务示例",
     "marketWorkflowPrompt": "工作流说明",
     "marketWorkflowMeta": "技能包信息",
     "marketWorkflowVersion": "v{{version}}",

--- a/dashboard/src/pages/Chat/hooks/useChat.ts
+++ b/dashboard/src/pages/Chat/hooks/useChat.ts
@@ -453,10 +453,20 @@ function convertCallEntries(entries: CallEntry[]): ChatMessage[] {
               source: "tool_result",
               retryable: toolFeedback?.retryable,
             }
+          : entry.status === "error"
+          ? {
+              code:
+                typeof entry.error_code === "string" && entry.error_code
+                  ? entry.error_code
+                  : "stream_error",
+              source: "history",
+            }
           : undefined,
       _toolKind: tool?.kind,
       status:
         tool?.kind === "result" && (toolFeedback?.isError || toolErrorCode)
+          ? "error"
+          : entry.status === "error"
           ? "error"
           : "done",
       timestamp: resolveEntryTimestamp(entry),
@@ -643,6 +653,8 @@ export function convertHistoryMessages(
     timestamp?: number;
     composer_context?: unknown;
     inbound_attachments?: unknown;
+    status?: string;
+    error_code?: string;
   }>,
   agentId?: string,
 ): ChatMessage[] {
@@ -663,6 +675,8 @@ export function convertHistoryMessages(
       timestamp:
         typeof message.timestamp === "number" ? message.timestamp : undefined,
       metadata: Object.keys(meta).length > 0 ? meta : undefined,
+      status: message.status,
+      error_code: message.error_code,
     };
   });
   const converted = convertCallEntries(entries).filter(

--- a/dashboard/src/pages/Chat/hooks/useChat.usage.test.ts
+++ b/dashboard/src/pages/Chat/hooks/useChat.usage.test.ts
@@ -71,4 +71,27 @@ describe("history token usage", () => {
       "/api/agents/agent_1/",
     );
   });
+
+  it("maps persisted stream errors to assistant error bubbles", () => {
+    const messages = convertHistoryMessages([
+      { role: "user", content: "continue this", id: "u1" },
+      { role: "assistant", content: "partial answer", id: "a1" },
+      {
+        role: "assistant",
+        content: "模型服务返回余额或额度不足。",
+        id: "a2",
+        status: "error",
+        error_code: "TOKEN_QUOTA_EXCEEDED",
+      },
+    ]);
+
+    expect(messages).toHaveLength(3);
+    expect(messages[1]?.content).toBe("partial answer");
+    expect(messages[1]?.status).toBe("done");
+    expect(messages[2]?.status).toBe("error");
+    expect(messages[2]?.errorInfo).toMatchObject({
+      code: "TOKEN_QUOTA_EXCEEDED",
+      source: "history",
+    });
+  });
 });

--- a/dashboard/src/pages/Control/CronJobs/index.module.less
+++ b/dashboard/src/pages/Control/CronJobs/index.module.less
@@ -486,6 +486,18 @@
   margin-bottom: 24px;
 }
 
+.emptyStateSuggestionsCols2 {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  max-width: 760px;
+
+  @media (max-width: 640px) {
+    display: flex;
+    flex-direction: column;
+    max-width: 560px;
+  }
+}
+
 .emptyStateSuggestionItem {
   display: flex;
   align-items: center;
@@ -518,6 +530,11 @@
   color: var(--fn-text-secondary);
   line-height: 1.5;
   flex: 1;
+  min-width: 0;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  overflow: hidden;
 }
 
 .emptyStateSuggestionArrow {

--- a/dashboard/src/pages/Control/CronJobs/index.tsx
+++ b/dashboard/src/pages/Control/CronJobs/index.tsx
@@ -20,6 +20,8 @@ import { OctopEmptyMascot } from "../../../components/EmptyState";
 import { ResizableTable } from "../../../components/ResizableTable";
 import PageShell from "../../../layouts/PageShell";
 import { useAgent } from "../../../context/AgentContext";
+import { taskExampleColumns } from "./taskExamples";
+import { useTaskExamples } from "./useTaskExamples";
 import styles from "./index.module.less";
 
 type CronJob = CronJobSpecOutput;
@@ -27,18 +29,15 @@ type CronJob = CronJobSpecOutput;
 interface CronJobsEmptyStateProps {
   onCreate: () => void;
   onSuggestionClick: (text: string) => void;
+  suggestions: string[];
 }
 
 function CronJobsEmptyState({
   onCreate,
   onSuggestionClick,
+  suggestions,
 }: CronJobsEmptyStateProps) {
   const { t } = useTranslation();
-  const suggestions = [
-    t("cronJobs.noJobsSuggestion1"),
-    t("cronJobs.noJobsSuggestion2"),
-    t("cronJobs.noJobsSuggestion3"),
-  ];
 
   return (
     <div className={styles.emptyState}>
@@ -47,19 +46,28 @@ function CronJobsEmptyState({
       </div>
       <h2 className={styles.emptyStateTitle}>{t("cronJobs.noJobs")}</h2>
       <p className={styles.emptyStateDesc}>{t("cronJobs.noJobsDesc")}</p>
-      <div className={styles.emptyStateSuggestions}>
-        {suggestions.map((text, i) => (
-          <button
-            key={i}
-            type="button"
-            className={styles.emptyStateSuggestionItem}
-            onClick={() => onSuggestionClick(text)}
-          >
-            <span className={styles.emptyStateSuggestionText}>{text}</span>
-            <span className={styles.emptyStateSuggestionArrow}>→</span>
-          </button>
-        ))}
-      </div>
+      {suggestions.length > 0 ? (
+        <div
+          className={`${styles.emptyStateSuggestions} ${
+            taskExampleColumns(suggestions.length) === 2
+              ? styles.emptyStateSuggestionsCols2
+              : ""
+          }`}
+        >
+          {suggestions.map((text, i) => (
+            <button
+              key={i}
+              type="button"
+              className={styles.emptyStateSuggestionItem}
+              title={text}
+              onClick={() => onSuggestionClick(text)}
+            >
+              <span className={styles.emptyStateSuggestionText}>{text}</span>
+              <span className={styles.emptyStateSuggestionArrow}>→</span>
+            </button>
+          ))}
+        </div>
+      ) : null}
       <Button
         type="primary"
         onClick={onCreate}
@@ -78,6 +86,7 @@ function CronJobsPage() {
   const navigate = useNavigate();
   const { activeAgentId, activeAgent } = useAgent();
   const canManageJobs = activeAgent?.is_owner === true;
+  const taskExamples = useTaskExamples(activeAgentId);
   const {
     jobs,
     loading,
@@ -315,6 +324,7 @@ function CronJobsPage() {
         <CronJobsEmptyState
           onCreate={handleCreate}
           onSuggestionClick={handleSuggestionClick}
+          suggestions={taskExamples}
         />
       ) : (
         <div

--- a/dashboard/src/pages/Control/CronJobs/taskExamples.test.ts
+++ b/dashboard/src/pages/Control/CronJobs/taskExamples.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  normalizeTaskExampleCount,
+  resolveTaskExamples,
+  taskExampleColumns,
+} from "./taskExamples";
+
+const defaults = ["default-a", "default-b"];
+
+describe("taskExampleColumns", () => {
+  it("uses one column unless there are six cards", () => {
+    expect(taskExampleColumns(0)).toBe(1);
+    expect(taskExampleColumns(3)).toBe(1);
+    expect(taskExampleColumns(5)).toBe(1);
+  });
+
+  it("uses two columns for a full six-card set", () => {
+    expect(taskExampleColumns(6)).toBe(2);
+  });
+});
+
+describe("normalizeTaskExampleCount", () => {
+  it("keeps three or fewer items", () => {
+    expect(normalizeTaskExampleCount(["a", "b"])).toEqual(["a", "b"]);
+  });
+
+  it("truncates four or five items to three", () => {
+    expect(normalizeTaskExampleCount(["a", "b", "c", "d", "e"])).toEqual([
+      "a",
+      "b",
+      "c",
+    ]);
+  });
+
+  it("caps extras at six", () => {
+    expect(
+      normalizeTaskExampleCount(["a", "b", "c", "d", "e", "f", "g"]),
+    ).toEqual(["a", "b", "c", "d", "e", "f"]);
+  });
+});
+
+describe("resolveTaskExamples", () => {
+  it("uses defaults when the manifest field is missing", () => {
+    expect(resolveTaskExamples(null, "zh", defaults)).toEqual(defaults);
+    expect(resolveTaskExamples(undefined, "en", defaults)).toEqual(defaults);
+  });
+
+  it("uses the active locale list when present", () => {
+    expect(
+      resolveTaskExamples({ zh: ["中文"], en: ["English"] }, "zh", defaults),
+    ).toEqual(["中文"]);
+    expect(
+      resolveTaskExamples({ zh: ["中文"], en: ["English"] }, "en", defaults),
+    ).toEqual(["English"]);
+  });
+
+  it("falls back to the other locale when the active list is empty", () => {
+    expect(
+      resolveTaskExamples({ zh: ["中文"], en: [] }, "en", defaults),
+    ).toEqual(["中文"]);
+  });
+
+  it("shows no cards when the field exists but both lists are empty", () => {
+    expect(resolveTaskExamples({ zh: [], en: [] }, "zh", defaults)).toEqual([]);
+    expect(resolveTaskExamples({}, "en", defaults)).toEqual([]);
+  });
+
+  it("truncates four or five locale items to three", () => {
+    expect(
+      resolveTaskExamples(
+        { zh: ["一", "二", "三", "四", "五"], en: ["a", "b", "c", "d"] },
+        "zh",
+        defaults,
+      ),
+    ).toEqual(["一", "二", "三"]);
+  });
+});

--- a/dashboard/src/pages/Control/CronJobs/taskExamples.ts
+++ b/dashboard/src/pages/Control/CronJobs/taskExamples.ts
@@ -1,0 +1,33 @@
+import type { CronTaskExamples } from "../../../api/modules/cronjob";
+import type { UiLocale } from "../../../utils/locale";
+
+/** Two columns only when there is a full six-card set (desktop). */
+export function taskExampleColumns(count: number): 1 | 2 {
+  return count >= 6 ? 2 : 1;
+}
+
+/** Display contract: 1–3 stay as-is, 4–5 truncate to 3, extras cap at 6. */
+export function normalizeTaskExampleCount(items: string[]): string[] {
+  if (items.length <= 3) return items;
+  if (items.length <= 5) return items.slice(0, 3);
+  return items.slice(0, 6);
+}
+
+/** Pick locale strings from manifest ``task_examples``; ``null`` means use defaults. */
+export function resolveTaskExamples(
+  payload: CronTaskExamples | null | undefined,
+  locale: UiLocale,
+  defaults: string[],
+): string[] {
+  if (payload == null) return defaults;
+  const primary = locale === "zh" ? payload.zh : payload.en;
+  const fallback = locale === "zh" ? payload.en : payload.zh;
+  const picked = _nonEmpty(primary) ?? _nonEmpty(fallback) ?? [];
+  return normalizeTaskExampleCount(picked);
+}
+
+function _nonEmpty(items: string[] | undefined): string[] | null {
+  if (!items) return null;
+  const cleaned = items.map((item) => item.trim()).filter(Boolean);
+  return cleaned.length > 0 ? cleaned : null;
+}

--- a/dashboard/src/pages/Control/CronJobs/useTaskExamples.ts
+++ b/dashboard/src/pages/Control/CronJobs/useTaskExamples.ts
@@ -1,0 +1,60 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import { agentChatApi } from "../../../api/modules/agentChat";
+import type { CronTaskExamples } from "../../../api/modules/cronjob";
+import { normalizeUiLocale } from "../../../utils/locale";
+import { resolveTaskExamples } from "./taskExamples";
+
+export function useTaskExamples(agentId: string | null): string[] {
+  const { t, i18n } = useTranslation();
+  const locale = normalizeUiLocale(i18n.language);
+  const defaults = useMemo(
+    () => [
+      t("cronJobs.noJobsSuggestion1"),
+      t("cronJobs.noJobsSuggestion2"),
+      t("cronJobs.noJobsSuggestion3"),
+    ],
+    [t],
+  );
+  const cacheRef = useRef(new Map<string, CronTaskExamples | null>());
+  const [payload, setPayload] = useState<CronTaskExamples | null | undefined>(
+    undefined,
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!agentId) {
+      setPayload(undefined);
+      return;
+    }
+    if (cacheRef.current.has(agentId)) {
+      setPayload(cacheRef.current.get(agentId));
+    } else {
+      setPayload(undefined);
+    }
+
+    void agentChatApi
+      .welcome(agentId)
+      .then((data) => {
+        if (cancelled) return;
+        const next = data.task_examples ?? null;
+        cacheRef.current.set(agentId, next);
+        setPayload(next);
+      })
+      .catch(() => {
+        if (cancelled || cacheRef.current.has(agentId)) return;
+        cacheRef.current.set(agentId, null);
+        setPayload(null);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [agentId]);
+
+  return useMemo(() => {
+    if (payload === undefined) return [];
+    return resolveTaskExamples(payload, locale, defaults);
+  }, [payload, locale, defaults]);
+}

--- a/dashboard/src/pages/Experts/components/ExpertCard.tsx
+++ b/dashboard/src/pages/Experts/components/ExpertCard.tsx
@@ -14,6 +14,7 @@ export interface ExpertSummary {
   icon_name?: string | null;
   color?: string | null;
   files?: string[];
+  task_examples?: { zh?: string[]; en?: string[] } | null;
 }
 
 interface ExpertCardProps {

--- a/dashboard/src/pages/Experts/components/ExpertMarketTab.tsx
+++ b/dashboard/src/pages/Experts/components/ExpertMarketTab.tsx
@@ -66,6 +66,15 @@ function promptText(
   return pickLocale(prompt[field], lang) || "";
 }
 
+function taskExampleTexts(expert: MarketExpert, lang: "zh" | "en"): string[] {
+  const raw = expert.task_examples;
+  if (!raw) return [];
+  const primary = lang === "zh" ? raw.zh : raw.en;
+  const fallback = lang === "zh" ? raw.en : raw.zh;
+  const picked = primary?.length ? primary : fallback;
+  return (picked ?? []).map((item) => item.trim()).filter(Boolean);
+}
+
 export default function ExpertMarketTab({
   lang,
   installedExpertIds,
@@ -142,6 +151,8 @@ export default function ExpertMarketTab({
     },
     [onRequestCreate],
   );
+
+  const selectedTaskExamples = selected ? taskExampleTexts(selected, lang) : [];
 
   const totalText = useMemo(
     () => t("experts.totalMarket", { count: items.length }),
@@ -393,6 +404,30 @@ export default function ExpertMarketTab({
               ) : (
                 <div className={styles.marketWorkflowPreview}>
                   {t("experts.marketQuickPromptsEmpty")}
+                </div>
+              )}
+            </div>
+            <div>
+              <div className={styles.marketSectionTitle}>
+                {t("experts.marketTaskExamples")}
+              </div>
+              {detailLoading ? (
+                <Spin size="small" />
+              ) : selectedTaskExamples.length > 0 ? (
+                <div className={styles.marketTaskExampleList}>
+                  {selectedTaskExamples.map((text, idx) => (
+                    <div
+                      key={`${text}-${idx}`}
+                      className={styles.marketTaskExampleItem}
+                      title={text}
+                    >
+                      {text}
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <div className={styles.marketWorkflowEmpty}>
+                  {t("experts.marketTaskExamplesEmpty")}
                 </div>
               )}
             </div>

--- a/dashboard/src/pages/Experts/index.module.less
+++ b/dashboard/src/pages/Experts/index.module.less
@@ -882,6 +882,27 @@
   -webkit-box-orient: vertical;
 }
 
+.marketTaskExampleList {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.marketTaskExampleItem {
+  padding: 10px 12px;
+  border-radius: var(--fn-radius-md);
+  background: var(--fn-bg-secondary);
+  border: 1px solid var(--fn-border-secondary, var(--fn-border-primary));
+  font-size: 12px;
+  line-height: 1.45;
+  color: var(--fn-text-secondary);
+  text-align: left;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
 .marketWorkflowPanel {
   display: flex;
   flex-direction: column;

--- a/docs/api.md
+++ b/docs/api.md
@@ -111,6 +111,7 @@ destination synchronized after the request completes.
 | Path | Auth | Notes |
 |------|------|-------|
 | `WS /agents/{id}/chat/ws?token=<jwt>` | owner | Primary dashboard turn endpoint. Send `{"type":"user_turn", ...}` frames; server replies with harness stream chunks ending in `{"type":"done"}` or `{"type":"error","message":"..."}`. `{"type":"ping"}` → `{"type":"pong"}`. `{"type":"subscribe","thread_id"}` → `{"type":"turn_status","thread_id","active"}` (attach to an in-flight turn without cancelling on disconnect). `{"type":"cancel","thread_id"}` stops the active turn (explicit stop; disconnect alone does **not** cancel). |
+| `GET /agents/{id}/chat/welcome` | agent access | `{welcome_message, quick_prompts, task_examples}`; `task_examples` is `null` when the workspace field is absent |
 | `POST /agents/{id}/chat/polish` | owner | body `{text, default_model?}` → `{text}` (one-shot prompt refinement) |
 | `POST /agents/{id}/chat/hitl/resume` | owner | body `{thread_id, decisions: [...]}` → SSE chunk stream; finishes with `{"type":"done"}` |
 
@@ -164,6 +165,7 @@ because each request is a one-shot continuation.
 | `GET`    | `/settings/timezone` | user | process-level `{timezone}` from `default_timezone` |
 | `GET`    | `/settings/upload` | user | `{max_upload_mb, max_upload_bytes}` from `max_upload_mb` |
 | `GET`    | `/cron/settings` | user | compat alias of `/settings/timezone` |
+| `GET`    | `/agents/{aid}/cron/examples` | agent access | `{task_examples}` from workspace `.octop/manifest.json` (`{zh,en}` string arrays, display-normalized to 3 or 6); `null` if the field is absent (dashboard keeps default cards). Prefer `GET /agents/{aid}/chat/welcome` which includes the same field. |
 | `GET`    | `/agents/{aid}/cron` | owner only | list cron rows; non-owners (including admin) get `[]` |
 | `POST`   | `/agents/{aid}/cron` | owner only | body `{name?, trigger, prompt, session_key?, fresh_thread?, enabled?, model?, task_type?}` → `201` |
 | `GET`    | `/agents/{aid}/cron/{cid}` | owner only | cron row |
@@ -243,8 +245,8 @@ see [Personas](./personas.md).
 
 | Method | Path | Auth | Notes |
 |--------|------|------|-------|
-| `GET`    | `/experts` | user | bundled expert catalog (locale-aware) |
-| `GET`    | `/experts/{expert_id}` | user | full expert template (SOUL.md, skills, files) |
+| `GET`    | `/experts` | user | bundled expert catalog (includes `task_examples` `{zh,en}` when present) |
+| `GET`    | `/experts/{expert_id}` | user | full expert template (SOUL.md, skills, files, `task_examples`) |
 | `POST`   | `/agents/from-expert/{expert_id}` | user | body `{name, locale?, ...}` → `201` |
 
 Bundled experts live in `src/octop/infra/agents/experts/library/`

--- a/src/octop/api/routers/chat/routes.py
+++ b/src/octop/api/routers/chat/routes.py
@@ -16,7 +16,11 @@ from octop.api.routers.chat.sse import format_sse
 from octop.i18n.domains.stream import format_stream_error
 from octop.infra.agents.experts.catalog import (
     default_welcome_payload,
-    read_workspace_manifest_welcome,
+    normalize_task_examples_for_display,
+    parse_task_examples,
+    read_workspace_manifest_data,
+    welcome_payload_from_manifest_data,
+    welcome_payload_has_content,
 )
 from octop.infra.agents.profile import welcome_from_row
 from octop.infra.errors import ErrorCode, OctopError
@@ -67,8 +71,14 @@ async def get_chat_welcome(
 
     workspace = registry.workspace_for_agent(agent_id)
     payload: dict[str, Any] | None = None
+    task_examples = None
     if workspace is not None:
-        payload = await read_workspace_manifest_welcome(workspace)
+        manifest = await read_workspace_manifest_data(workspace)
+        if manifest is not None:
+            welcome = welcome_payload_from_manifest_data(manifest)
+            if welcome_payload_has_content(welcome):
+                payload = welcome
+            task_examples = normalize_task_examples_for_display(parse_task_examples(manifest))
 
     row = registry.get_row(agent_id)
     if payload is None:
@@ -77,7 +87,7 @@ async def get_chat_welcome(
     db_welcome = welcome_from_row(row) if row is not None else None
     if db_welcome is not None:
         payload = {**payload, "welcome_message": {"zh": db_welcome, "en": db_welcome}}
-    return payload
+    return {**payload, "task_examples": task_examples}
 
 
 async def iter_dashboard_hitl_resume_sse(

--- a/src/octop/api/routers/chat/serialize.py
+++ b/src/octop/api/routers/chat/serialize.py
@@ -20,6 +20,8 @@ from octop.infra.agents.context_breakdown import usage_dict_from_message
 from octop.infra.gateway.process.message_keys import (
     COMPOSER_CTX_KEY,
     INBOUND_ATTACHMENTS_KEY,
+    STREAM_ERROR_CODE_KEY,
+    STREAM_ERROR_FLAG,
 )
 from octop.infra.utils.llm_text import strip_thinking as _strip_thinking
 from octop.infra.utils.locale import normalize_locale
@@ -981,6 +983,11 @@ def _serialize_history_message(msg: Any, *, user: Any = None) -> dict[str, Any] 
     ts_ms = _extract_message_timestamp_ms(msg)
     if ts_ms is not None:
         entry["timestamp"] = ts_ms
+    if additional_kwargs.get(STREAM_ERROR_FLAG):
+        entry["status"] = "error"
+        code = additional_kwargs.get(STREAM_ERROR_CODE_KEY)
+        if code:
+            entry["error_code"] = str(code)
     return entry
 
 

--- a/src/octop/api/routers/cron.py
+++ b/src/octop/api/routers/cron.py
@@ -7,8 +7,12 @@ from typing import Any, cast
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel, Field
 
-from octop.api.common.agent import require_agent_row, user_owns_agent
+from octop.api.common.agent import assert_agent_access, require_agent_row, user_owns_agent
 from octop.api.deps import current_user, get_server
+from octop.infra.agents.experts.catalog import (
+    normalize_task_examples_for_display,
+    read_workspace_manifest_task_examples,
+)
 from octop.infra.cron.task_type import (
     normalize_cron_task_type,
     require_cron_name,
@@ -45,6 +49,16 @@ class CronPatchBody(BaseModel):
     mcp_servers: list[str] | None = None
 
 
+class CronExamplesResponse(BaseModel):
+    """Empty-state prompts for the tasks page.
+
+    ``task_examples`` is ``null`` when the workspace manifest has no such field,
+    so the dashboard can keep its built-in default cards.
+    """
+
+    task_examples: dict[str, list[str]] | None = None
+
+
 def _get_cron_manager(server: Any) -> Any:
     assert server.app_runtime is not None
     return server.app_runtime.cron_manager
@@ -70,6 +84,31 @@ async def cron_settings(
 ) -> dict[str, str]:
     """Return process-level cron configuration (compat; prefer ``GET /settings/timezone``)."""
     return {"timezone": server.services.config.default_timezone}
+
+
+@router.get(
+    "/agents/{agent_id}/cron/examples",
+    summary="Task page example prompts",
+    response_model=CronExamplesResponse,
+)
+async def cron_examples(
+    agent_id: str,
+    user: Any = Depends(current_user),
+    server: Any = Depends(get_server),
+) -> CronExamplesResponse:
+    """Return ``task_examples`` from the agent workspace ``.octop/manifest.json``.
+
+    Missing field / missing manifest → ``task_examples: null`` (dashboard defaults).
+    """
+    assert_agent_access(server, agent_id, user)
+    assert server.app_runtime is not None
+    workspace = server.app_runtime.agent_registry.workspace_for_agent(agent_id)
+    if workspace is None:
+        return CronExamplesResponse(task_examples=None)
+    examples = normalize_task_examples_for_display(
+        await read_workspace_manifest_task_examples(workspace)
+    )
+    return CronExamplesResponse(task_examples=examples)
 
 
 @router.get("/agents/{agent_id}/cron", summary="List cron jobs")

--- a/src/octop/api/routers/experts.py
+++ b/src/octop/api/routers/experts.py
@@ -182,6 +182,7 @@ class ExpertHubItemResponse(BaseModel):
     source: str = "skillhub"
     content: LocalizedTextResponse | None = None
     quick_prompts: list[QuickPromptResponse] | None = None
+    task_examples: dict[str, list[str]] | None = None
 
 
 class ExpertHubListResponse(BaseModel):
@@ -252,6 +253,7 @@ def _summary_dict(s: Any) -> dict[str, Any]:
         "icon_name": s.icon_name,
         "color": s.color,
         "quick_prompts": [_quick_prompt_dict(p) for p in getattr(s, "quick_prompts", ())],
+        "task_examples": getattr(s, "task_examples", None),
     }
 
 

--- a/src/octop/infra/agents/experts/catalog.py
+++ b/src/octop/infra/agents/experts/catalog.py
@@ -4,7 +4,8 @@ An *expert* is metadata in ``manifest.json`` plus files on disk under
 ``library/<id>/``. At seed time files (including a copy of ``manifest.json``)
 are written into the agent workspace under ``.octop/manifest.json``.
 ``prompt_files`` in the manifest is metadata for the dashboard only — persona
-text is read from the workspace.
+text is read from the workspace. ``task_examples`` is an optional locale-keyed
+string array shown as empty-state cards on the tasks page.
 
 Templates are discovered at server start by :class:`ExpertCatalog`.
 """
@@ -62,6 +63,7 @@ class ExpertSummary:
     icon_name: str | None = None
     color: str | None = None
     quick_prompts: tuple[ExpertQuickPrompt, ...] = ()
+    task_examples: dict[str, list[str]] | None = None
 
 
 @dataclass(frozen=True)
@@ -274,10 +276,10 @@ def default_welcome_payload(catalog: ExpertCatalog | None = None) -> dict[str, A
     }
 
 
-async def read_workspace_manifest_welcome(
+async def read_workspace_manifest_data(
     workspace: BackendWorkspace,
 ) -> dict[str, Any] | None:
-    """Parse workspace welcome manifest (``.octop/manifest.json``), if present and valid."""
+    """Parse workspace ``.octop/manifest.json`` (legacy root fallback) as a dict."""
     text = await read_workspace_manifest_text(workspace)
     if text is None:
         return None
@@ -286,10 +288,28 @@ async def read_workspace_manifest_welcome(
     except json.JSONDecodeError:
         logger.warning("workspace %s is not valid JSON", WORKSPACE_MANIFEST_PATH)
         return None
-    if not isinstance(data, dict):
+    return data if isinstance(data, dict) else None
+
+
+async def read_workspace_manifest_welcome(
+    workspace: BackendWorkspace,
+) -> dict[str, Any] | None:
+    """Parse workspace welcome manifest (``.octop/manifest.json``), if present and valid."""
+    data = await read_workspace_manifest_data(workspace)
+    if data is None:
         return None
     payload = welcome_payload_from_manifest_data(data)
     return payload if welcome_payload_has_content(payload) else None
+
+
+async def read_workspace_manifest_task_examples(
+    workspace: BackendWorkspace,
+) -> dict[str, list[str]] | None:
+    """Return ``task_examples`` from the workspace manifest, or ``None`` if absent."""
+    data = await read_workspace_manifest_data(workspace)
+    if data is None:
+        return None
+    return parse_task_examples(data)
 
 
 def read_text_file_contents(expert_dir: Path, paths: list[str]) -> list[dict[str, str]]:
@@ -344,6 +364,131 @@ def _parse_quick_prompts(data: dict[str, Any]) -> tuple[ExpertQuickPrompt, ...]:
             ),
         )
     return tuple(out)
+
+
+def _coerce_string_list(raw: Any) -> list[str]:
+    if not isinstance(raw, list):
+        return []
+    out: list[str] = []
+    for item in raw:
+        if isinstance(item, str):
+            text = item.strip()
+            if text:
+                out.append(text)
+    return out
+
+
+def parse_task_examples(data: dict[str, Any]) -> dict[str, list[str]] | None:
+    """Parse ``task_examples`` from a manifest dict.
+
+    Canonical form is locale-keyed string arrays::
+
+        {"zh": ["…"], "en": ["…"]}
+
+    A plain ``["…"]`` list is treated as the same strings for both locales.
+    Missing or invalid values return ``None`` so callers can keep default cards.
+    """
+    if "task_examples" not in data:
+        return None
+    raw = data["task_examples"]
+    if isinstance(raw, list):
+        items = _coerce_string_list(raw)
+        return {"zh": list(items), "en": list(items)}
+    if isinstance(raw, dict):
+        zh_raw = raw.get("zh")
+        en_raw = raw.get("en")
+        if isinstance(zh_raw, list) or isinstance(en_raw, list):
+            return {
+                "zh": _coerce_string_list(zh_raw),
+                "en": _coerce_string_list(en_raw),
+            }
+    return None
+
+
+_TASK_EXAMPLE_COUNT_THREE = 3
+_TASK_EXAMPLE_COUNT_SIX = 6
+
+
+def default_task_examples(label_zh: str, label_en: str) -> dict[str, list[str]]:
+    """Shared bilingual fallbacks for generated / padded ``task_examples``."""
+    return {
+        "zh": [
+            f"每天「09:00」按「{label_zh}」工作流巡检一次，有结果再发给我，任务创建后立即启用",
+            f"每周一「10:00」汇总上周与「{label_zh}」相关的进展和下周计划",
+            "每个工作日「18:00」复盘当天工作，列出待跟进项",
+            f"每周五「17:00」汇总本周与「{label_zh}」相关的交付物和下周安排",
+            f"每天「08:00」按「{label_zh}」工作流推送一条可执行简报",
+            f"每月 1 日「09:30」复盘上月「{label_zh}」进展，列出本月优先项",
+        ],
+        "en": [
+            (
+                f"Every day at 09:00, run the {label_en} workflow once and notify me "
+                "when there is a result — enable immediately"
+            ),
+            f"Every Monday at 10:00, summarize last week's {label_en} progress and next week's plan",
+            "Every weekday at 18:00, recap the day's work and list follow-ups",
+            f"Every Friday at 17:00, recap this week's {label_en} deliverables and next week's plan",
+            f"Every day at 08:00, push one actionable {label_en} briefing",
+            (
+                f"On the 1st of each month at 09:30, recap last month's {label_en} "
+                "progress and list this month's priorities"
+            ),
+        ],
+    }
+
+
+def normalize_task_examples_for_display(
+    parsed: dict[str, list[str]] | None,
+) -> dict[str, list[str]] | None:
+    """Keep display lists at 3 or 6 entries; 4–5 truncate to 3, extras cap at 6."""
+    if parsed is None:
+        return None
+    zh = list(parsed.get("zh") or [])
+    en = list(parsed.get("en") or [])
+    if not zh and not en:
+        return {"zh": [], "en": []}
+    cap = (
+        _TASK_EXAMPLE_COUNT_SIX
+        if max(len(zh), len(en)) >= _TASK_EXAMPLE_COUNT_SIX
+        else _TASK_EXAMPLE_COUNT_THREE
+    )
+    return {"zh": zh[:cap], "en": en[:cap]}
+
+
+def snap_task_examples(
+    zh: list[str],
+    en: list[str],
+    *,
+    fillers_zh: list[str],
+    fillers_en: list[str],
+    count: int | None = None,
+) -> dict[str, list[str]]:
+    """Keep exactly 3 or 6 bilingual examples (4–5 pad to 6; fewer pad to 3)."""
+    out_zh = [item for item in zh if item][:_TASK_EXAMPLE_COUNT_SIX]
+    out_en = [item for item in en if item][:_TASK_EXAMPLE_COUNT_SIX]
+    if count in (_TASK_EXAMPLE_COUNT_THREE, _TASK_EXAMPLE_COUNT_SIX):
+        target = count
+    else:
+        target = (
+            _TASK_EXAMPLE_COUNT_SIX
+            if max(len(out_zh), len(out_en)) > _TASK_EXAMPLE_COUNT_THREE
+            else _TASK_EXAMPLE_COUNT_THREE
+        )
+
+    def _pad(side: list[str], extras: list[str]) -> None:
+        for item in extras:
+            if len(side) >= target:
+                return
+            if item and item not in side:
+                side.append(item)
+        idx = 0
+        while len(side) < target and extras:
+            side.append(extras[idx % len(extras)])
+            idx += 1
+
+    _pad(out_zh, fillers_zh)
+    _pad(out_en, fillers_en)
+    return {"zh": out_zh[:target], "en": out_en[:target]}
 
 
 class ExpertCatalog:
@@ -414,6 +559,7 @@ class ExpertCatalog:
                     icon_name=data.get("icon_name"),
                     color=data.get("color"),
                     quick_prompts=_parse_quick_prompts(data),
+                    task_examples=normalize_task_examples_for_display(parse_task_examples(data)),
                 )
                 out[ex_id] = Expert(
                     summary=summary,

--- a/src/octop/infra/agents/experts/library/ai-coding-coach/manifest.json
+++ b/src/octop/infra/agents/experts/library/ai-coding-coach/manifest.json
@@ -66,5 +66,17 @@
       "color": "#fef3c7",
       "icon_name": "git-compare"
     }
-  ]
+  ],
+  "task_examples": {
+    "zh": [
+      "每个工作日「09:30」推送一条可立即练习的 AI 编程技巧（结合我常用的 Cursor / Claude Code），任务创建后立即启用",
+      "每周五「17:30」复盘本周我在 AI 编程上卡住的问题，给出下周练习计划",
+      "每月最后一天「20:00」整理一份本月工具与提示词最佳实践清单"
+    ],
+    "en": [
+      "Every weekday at 09:30, send one AI coding technique I can practice immediately (Cursor / Claude Code) — enable immediately",
+      "Every Friday at 17:30, recap where I got stuck with AI coding this week and outline next week's drills",
+      "On the last day of each month at 20:00, compile this month's tool and prompting best-practices list"
+    ]
+  }
 }

--- a/src/octop/infra/agents/experts/library/ai-safety-guardian/manifest.json
+++ b/src/octop/infra/agents/experts/library/ai-safety-guardian/manifest.json
@@ -66,5 +66,17 @@
       "color": "#dbeafe",
       "icon_name": "globe"
     }
-  ]
+  ],
+  "task_examples": {
+    "zh": [
+      "每天「09:00」做一次轻量安全体检：危险命令、敏感文件和环境变量泄露风险，任务创建后立即启用",
+      "每周一「10:00」扫描工作区是否有密钥或个人信息落地，列出待处理项",
+      "每月 1 日「09:30」做一次合规检查摘要（PIPL / 数据出境 / 生成式 AI 标识）"
+    ],
+    "en": [
+      "Every day at 09:00, run a light safety check for dangerous commands, sensitive files, and leaked env vars — enable immediately",
+      "Every Monday at 10:00, scan the workspace for secrets or personal data on disk and list follow-ups",
+      "On the 1st of each month at 09:30, send a compliance summary (PIPL / data export / generative-AI labeling)"
+    ]
+  }
 }

--- a/src/octop/infra/agents/experts/library/clinical-learning-subscription/manifest.json
+++ b/src/octop/infra/agents/experts/library/clinical-learning-subscription/manifest.json
@@ -324,5 +324,23 @@
       "color": "#f3e8ff",
       "icon_name": "sparkles"
     }
-  ]
+  ],
+  "task_examples": {
+    "zh": [
+      "每个工作日「07:30」按我的学习轨道推送当天指南学习单元，任务创建后立即启用",
+      "每周日「20:00」复盘本周学习进度，给出下周章节建议",
+      "每月 1 日「08:00」检查当前指南是否有新版；若有则预览迁移影响，先不改轨道",
+      "每个工作日「21:00」根据今日学习单元出 3 道自测题，不给诊疗建议",
+      "每周三「07:30」推送一条医保政策学习摘要（仅政策层面）",
+      "每周五「21:00」整理本周学习笔记索引，不改原文、不给诊疗建议"
+    ],
+    "en": [
+      "Every weekday at 07:30, push today's guideline learning unit from my track — enable immediately",
+      "Every Sunday at 20:00, recap this week's learning progress and suggest next week's sections",
+      "On the 1st of each month at 08:00, check whether the current guideline has a new edition; if so, preview migration impact without changing the track yet",
+      "Every weekday at 21:00, write 3 self-check questions from today's unit — no clinical advice",
+      "Every Wednesday at 07:30, push one insurance-policy learning brief (policy level only)",
+      "Every Friday at 21:00, index this week's study notes — no rewrites and no clinical advice"
+    ]
+  }
 }

--- a/src/octop/infra/agents/experts/library/cvm-ai-doctor/manifest.json
+++ b/src/octop/infra/agents/experts/library/cvm-ai-doctor/manifest.json
@@ -116,5 +116,23 @@
       "color": "#fff1f2",
       "icon_name": "wrench"
     }
-  ]
+  ],
+  "task_examples": {
+    "zh": [
+      "每天「09:00」做系统健康检查（CPU / 内存 / 磁盘 / 关键服务），有异常再通知我，任务创建后立即启用",
+      "每「2 小时」检查磁盘使用率和系统负载，超过阈值立即告警，从今天开始持续生效",
+      "每周一「09:30」汇总上周系统错误日志和修复建议",
+      "每个工作日「18:00」复盘当天告警，区分已恢复和仍异常的项",
+      "每月 1 日「09:30」输出容量趋势：磁盘、内存和近期增长",
+      "每周五「16:00」检查关键服务重启记录，列出反复异常的项"
+    ],
+    "en": [
+      "Every day at 09:00, run a system health check (CPU / memory / disk / key services) and notify me only on anomalies — enable immediately",
+      "Every 2 hours, check disk usage and load; alert immediately if thresholds are exceeded, starting today",
+      "Every Monday at 09:30, summarize last week's system error logs and suggested fixes",
+      "Every weekday at 18:00, recap today's alerts and separate recovered items from still-open ones",
+      "On the 1st of each month at 09:30, send a capacity trend: disk, memory, and recent growth",
+      "Every Friday at 16:00, review key-service restarts and list recurring faults"
+    ]
+  }
 }

--- a/src/octop/infra/agents/experts/library/cvm-cluster-doctor/manifest.json
+++ b/src/octop/infra/agents/experts/library/cvm-cluster-doctor/manifest.json
@@ -120,5 +120,23 @@
       "color": "#eef2ff",
       "icon_name": "refresh-cw"
     }
-  ]
+  ],
+  "task_examples": {
+    "zh": [
+      "每天「09:00」对腾讯云 CVM 集群做健康巡检，按木桶原理打分并指出最弱节点，任务创建后立即启用",
+      "每个工作日「18:00」汇总当天跨节点异常关联，列出需人工确认的修复项",
+      "每周一「10:00」输出集群风险周报：容量、故障与待修复项",
+      "每「4 小时」检查节点 CPU / 磁盘 / 网络异常，超过阈值再通知我",
+      "每月 1 日「10:00」对照木桶短板给出扩容或下线建议，先不执行",
+      "每周五「16:00」核对集群变更与告警是否对齐，标出未关闭项"
+    ],
+    "en": [
+      "Every day at 09:00, patrol the Tencent Cloud CVM cluster, score it by the weakest-link rule, and name the weakest node — enable immediately",
+      "Every weekday at 18:00, summarize cross-node correlations from today and list remediations that need confirmation",
+      "Every Monday at 10:00, send a cluster risk weekly: capacity, incidents, and open fixes",
+      "Every 4 hours, check node CPU / disk / network anomalies and notify me only above threshold",
+      "On the 1st of each month at 10:00, suggest scale-up or retirement from the weakest-link gaps — do not execute",
+      "Every Friday at 16:00, check cluster changes against alerts and flag still-open items"
+    ]
+  }
 }

--- a/src/octop/infra/agents/experts/library/default/manifest.json
+++ b/src/octop/infra/agents/experts/library/default/manifest.json
@@ -17,5 +17,17 @@
   "prompt_files": [
     "SOUL.md",
     "IDENTITY.md"
-  ]
+  ],
+  "task_examples": {
+    "zh": [
+      "每个工作日「09:00」列出今日待办并按优先级排序，任务创建后立即启用",
+      "每周日「20:00」复盘本周完成事项，并给出下周计划",
+      "每天「22:00」提醒我整理明天要处理的三件事，从今天开始持续生效"
+    ],
+    "en": [
+      "Every weekday at 09:00, list today's todos ranked by priority — enable immediately",
+      "Every Sunday at 20:00, recap what got done this week and outline next week's plan",
+      "Every day at 22:00, remind me to pick the three things to handle tomorrow — start today and keep running"
+    ]
+  }
 }

--- a/src/octop/infra/agents/experts/library/general-assistant/manifest.json
+++ b/src/octop/infra/agents/experts/library/general-assistant/manifest.json
@@ -210,5 +210,17 @@
       "color": "#fdf2f8",
       "icon_name": "user"
     }
-  ]
+  ],
+  "task_examples": {
+    "zh": [
+      "每个工作日「09:00」列出今日待办并按优先级排序，任务创建后立即启用",
+      "每周日「20:00」复盘本周完成事项，并给出下周计划",
+      "每天「22:00」提醒我整理明天要处理的三件事，从今天开始持续生效"
+    ],
+    "en": [
+      "Every weekday at 09:00, list today's todos ranked by priority — enable immediately",
+      "Every Sunday at 20:00, recap what got done this week and outline next week's plan",
+      "Every day at 22:00, remind me to pick the three things to handle tomorrow — start today and keep running"
+    ]
+  }
 }

--- a/src/octop/infra/agents/experts/library/karpathy-knowledge-base/manifest.json
+++ b/src/octop/infra/agents/experts/library/karpathy-knowledge-base/manifest.json
@@ -21,8 +21,14 @@
   ],
   "quick_prompts": [
     {
-      "title": {"zh": "初始化知识主题", "en": "Initialize a topic"},
-      "description": {"zh": "确定知识库范围、目标和首批来源", "en": "Define scope, goals, and initial sources"},
+      "title": {
+        "zh": "初始化知识主题",
+        "en": "Initialize a topic"
+      },
+      "description": {
+        "zh": "确定知识库范围、目标和首批来源",
+        "en": "Define scope, goals, and initial sources"
+      },
       "prompt": {
         "zh": "请和我一起初始化这个知识库。主题是：；我希望长期回答的问题是：；首批资料是：。先检查现有 MEMORY.md 和 Wiki，再给出初始化方案。",
         "en": "Help me initialize this knowledge base. Topic:; long-term questions:; initial sources:. Check MEMORY.md and the existing wiki first, then propose the setup."
@@ -31,8 +37,14 @@
       "icon_name": "book-open"
     },
     {
-      "title": {"zh": "摄取新资料", "en": "Ingest a source"},
-      "description": {"zh": "读取一个来源并更新相关 Wiki 页面", "en": "Read one source and update related wiki pages"},
+      "title": {
+        "zh": "摄取新资料",
+        "en": "Ingest a source"
+      },
+      "description": {
+        "zh": "读取一个来源并更新相关 Wiki 页面",
+        "en": "Read one source and update related wiki pages"
+      },
       "prompt": {
         "zh": "请把以下资料摄取到知识库：。先确认来源身份和范围，再摘要、交叉链接并更新索引与日志。",
         "en": "Ingest this source into the knowledge base:. Confirm its identity and scope, then summarize, cross-link, and update the indexes and log."
@@ -41,8 +53,14 @@
       "icon_name": "file-text"
     },
     {
-      "title": {"zh": "查询知识库", "en": "Query the wiki"},
-      "description": {"zh": "基于已编译知识与原始来源回答", "en": "Answer from compiled knowledge and raw sources"},
+      "title": {
+        "zh": "查询知识库",
+        "en": "Query the wiki"
+      },
+      "description": {
+        "zh": "基于已编译知识与原始来源回答",
+        "en": "Answer from compiled knowledge and raw sources"
+      },
       "prompt": {
         "zh": "请基于当前知识库回答这个问题：。先从 MEMORY.md 和 index.md 定位，再引用具体 Wiki 页面与原始来源。",
         "en": "Answer this question from the current knowledge base:. Start with MEMORY.md and index.md, then cite the relevant wiki pages and raw sources."
@@ -51,8 +69,14 @@
       "icon_name": "search"
     },
     {
-      "title": {"zh": "运行知识库体检", "en": "Lint the knowledge base"},
-      "description": {"zh": "检查冲突、陈旧内容、断链和索引漂移", "en": "Find conflicts, stale claims, broken links, and index drift"},
+      "title": {
+        "zh": "运行知识库体检",
+        "en": "Lint the knowledge base"
+      },
+      "description": {
+        "zh": "检查冲突、陈旧内容、断链和索引漂移",
+        "en": "Find conflicts, stale claims, broken links, and index drift"
+      },
       "prompt": {
         "zh": "请对整个知识库做一次 lint：检查冲突、过期主张、孤立页面、断链、缺失来源和 MEMORY.md/index.md 漂移；先报告，再执行安全修复。",
         "en": "Lint the knowledge base for contradictions, stale claims, orphan pages, broken links, missing sources, and MEMORY.md/index.md drift. Report first, then apply safe fixes."
@@ -61,8 +85,14 @@
       "icon_name": "list-checks"
     },
     {
-      "title": {"zh": "整理主题地图", "en": "Build a topic map"},
-      "description": {"zh": "把分散页面组织成概念关系和研究缺口", "en": "Organize pages into concepts, relationships, and gaps"},
+      "title": {
+        "zh": "整理主题地图",
+        "en": "Build a topic map"
+      },
+      "description": {
+        "zh": "把分散页面组织成概念关系和研究缺口",
+        "en": "Organize pages into concepts, relationships, and gaps"
+      },
       "prompt": {
         "zh": "请为这个主题整理一张知识地图：。标出核心概念、实体、关键来源、相互关系、冲突和待研究问题，并把有长期价值的结果归档到 Wiki。",
         "en": "Build a knowledge map for this topic:. Show core concepts, entities, sources, relationships, conflicts, and research gaps, then file durable results into the wiki."
@@ -70,5 +100,23 @@
       "color": "#e0f2fe",
       "icon_name": "network"
     }
-  ]
+  ],
+  "task_examples": {
+    "zh": [
+      "每天「21:00」对知识库做一次 lint：断链、孤立页、无来源主张，只报告不自动大改，任务创建后立即启用",
+      "每周日「20:00」根据 MEMORY.md 活跃主题生成一周研究摘要",
+      "每个工作日「09:30」提醒我今日待摄取的来源，并更新 MEMORY 索引",
+      "每周三「21:00」把本周新增笔记按主题归入索引，不改原文",
+      "每月 1 日「20:00」盘点孤立页与重复主题，给出合并建议但不自动改",
+      "每周五「21:00」根据本周摄取来源更新 MEMORY 待办，不改正文"
+    ],
+    "en": [
+      "Every day at 21:00, lint the knowledge base for broken links, orphan pages, and unsourced claims — report only, no large auto-edits; enable immediately",
+      "Every Sunday at 20:00, write a weekly research digest from the active topics in MEMORY.md",
+      "Every weekday at 09:30, remind me of sources waiting to ingest and refresh the MEMORY index",
+      "Every Wednesday at 21:00, file this week's new notes into the index by topic without rewriting them",
+      "On the 1st of each month at 20:00, inventory orphan pages and duplicate topics and suggest merges — no auto-edits",
+      "Every Friday at 21:00, refresh MEMORY todos from this week's sources — do not rewrite notes"
+    ]
+  }
 }

--- a/src/octop/infra/agents/experts/library/meituan-living-assistant/manifest.json
+++ b/src/octop/infra/agents/experts/library/meituan-living-assistant/manifest.json
@@ -114,5 +114,23 @@
       "color": "#ffe8f0",
       "icon_name": "shopping-bag"
     }
-  ]
+  ],
+  "task_examples": {
+    "zh": [
+      "每天「09:00」自动领取美团各品类优惠券和红包，领完后把结果发给我，任务创建后立即启用",
+      "每个工作日「11:30」根据我附近推荐今日午餐团购，列出 3 个高性价比选项",
+      "每周五「18:00」汇总本周省了多少、哪些券快过期",
+      "每天「17:30」根据天气和位置推荐晚餐外卖，列出 3 个选项",
+      "每周日「10:00」扫描本周可订的周末休闲/出行团购",
+      "每月 1 日「09:00」汇总上月优惠使用和过期券，给出本月领取提醒"
+    ],
+    "en": [
+      "Every day at 09:00, collect Meituan coupons and red packets across categories and send me the result — enable immediately",
+      "Every weekday at 11:30, recommend 3 high-value nearby lunch group-buys",
+      "Every Friday at 18:00, summarize how much I saved this week and which coupons expire soon",
+      "Every day at 17:30, recommend 3 dinner takeout options from weather and location",
+      "Every Sunday at 10:00, scan weekend leisure or travel group-buys still bookable this week",
+      "On the 1st of each month at 09:00, recap last month's coupon use and expiries, and remind me what to claim"
+    ]
+  }
 }

--- a/src/octop/infra/agents/experts/library/multi-agent-orchestrator/manifest.json
+++ b/src/octop/infra/agents/experts/library/multi-agent-orchestrator/manifest.json
@@ -51,5 +51,17 @@
       "color": "#fef3c7",
       "icon_name": "users"
     }
-  ]
+  ],
+  "task_examples": {
+    "zh": [
+      "每个工作日「09:30」检查进行中的多专家协作计划，汇报卡在哪一步，任务创建后立即启用",
+      "每周五「17:00」汇总本周已完成的协作任务与遗留依赖",
+      "每天「18:00」若有未关闭的 DAG 步骤，提醒我确认是否继续或换角"
+    ],
+    "en": [
+      "Every weekday at 09:30, inspect in-flight multi-expert plans and report which step is blocked — enable immediately",
+      "Every Friday at 17:00, summarize completed collaboration tasks and leftover dependencies",
+      "Every day at 18:00, if any DAG step is still open, ask me whether to continue or reassign the role"
+    ]
+  }
 }

--- a/src/octop/infra/agents/experts/library/news-trend/manifest.json
+++ b/src/octop/infra/agents/experts/library/news-trend/manifest.json
@@ -116,5 +116,23 @@
       "color": "#f3e8ff",
       "icon_name": "search"
     }
-  ]
+  ],
+  "task_examples": {
+    "zh": [
+      "每天「08:00」推送今日多平台热点早报，精选 10 条并附简评，任务创建后立即启用",
+      "每个工作日「18:00」复盘白天热点变化，标出持续升温的话题",
+      "每周日「21:00」做一周热点趋势盘点，列出值得深读的 5 个话题",
+      "每个交易日「09:30」扫描财经与科技交叉热点，标出可能影响市场的突发",
+      "每天「12:00」推送午间快讯，只保留当天新增的 5 条",
+      "每周五「19:00」整理本周被多次验证的热点，写成一份周末阅读清单"
+    ],
+    "en": [
+      "Every day at 08:00, push a 10-item multi-platform hotspot briefing with short comments — enable immediately",
+      "Every weekday at 18:00, recap how daytime hotspots shifted and flag topics that are still heating up",
+      "Every Sunday at 21:00, review the week's trend and list 5 topics worth a deeper read",
+      "Every trading day at 09:30, scan finance/tech crossover hotspots and flag market-moving surprises",
+      "Every day at 12:00, push a midday bulletin with only the 5 new items from today",
+      "Every Friday at 19:00, compile this week's multiply-verified hotspots into a weekend reading list"
+    ]
+  }
 }

--- a/src/octop/infra/agents/experts/library/office-automation/manifest.json
+++ b/src/octop/infra/agents/experts/library/office-automation/manifest.json
@@ -115,5 +115,23 @@
       "color": "#f3e8ff",
       "icon_name": "calendar"
     }
-  ]
+  ],
+  "task_examples": {
+    "zh": [
+      "每个工作日「18:00」根据当天会议记录起草日报，发给我确认，任务创建后立即启用",
+      "每周五「17:00」汇总本周待办与文档进展，生成周报大纲",
+      "每个月最后一个工作日「16:00」整理本月合同和表格待办清单发给我",
+      "每个工作日「09:00」把收件箱里待处理的邮件按优先级列成待办",
+      "每周一「10:00」根据日历起草本周会议纪要模板，先放草稿不发送",
+      "每天「12:30」把上午会议待办并入清单，标出今天下午要跟的项"
+    ],
+    "en": [
+      "Every weekday at 18:00, draft a daily report from today's meeting notes and send it for my review — enable immediately",
+      "Every Friday at 17:00, summarize this week's todos and document progress into a weekly-report outline",
+      "On the last weekday of each month at 16:00, compile this month's contract and spreadsheet follow-ups",
+      "Every weekday at 09:00, turn inbox items still needing action into a prioritized todo list",
+      "Every Monday at 10:00, draft this week's meeting-notes templates from the calendar — keep as drafts, do not send",
+      "Every day at 12:30, merge morning meeting follow-ups into the list and flag this afternoon's items"
+    ]
+  }
 }

--- a/src/octop/infra/agents/experts/library/ops-engineer/manifest.json
+++ b/src/octop/infra/agents/experts/library/ops-engineer/manifest.json
@@ -115,5 +115,23 @@
       "color": "#fdf4e7",
       "icon_name": "terminal"
     }
-  ]
+  ],
+  "task_examples": {
+    "zh": [
+      "每天「09:00」巡检 Kubernetes 集群：异常 Pod、节点 NotReady、最近事件，有问题再通知我，任务创建后立即启用",
+      "每「4 小时」检查磁盘使用率和 inode，超过 80% 时立即告警，从今天开始持续生效",
+      "每周一「10:00」汇总上周故障与变更，列出待处理项发给我",
+      "每个工作日「18:00」复盘当天告警与变更窗口，标出未关闭工单",
+      "每周五「16:00」检查证书与密钥到期日，30 天内到期的列出来",
+      "每月 1 日「10:00」输出容量与成本摘要：节点、存储和本月费用"
+    ],
+    "en": [
+      "Every day at 09:00, inspect the Kubernetes cluster (bad pods, NotReady nodes, recent events) and notify me only if something is wrong — enable immediately",
+      "Every 4 hours, check disk usage and inodes; alert immediately if either exceeds 80%, starting today",
+      "Every Monday at 10:00, summarize last week's incidents and changes and send me the open items",
+      "Every weekday at 18:00, recap today's alerts and change windows and flag unclosed tickets",
+      "Every Friday at 16:00, check certificate and key expiry and list anything due within 30 days",
+      "On the 1st of each month at 10:00, send a capacity and cost brief: nodes, storage, and this month's bill"
+    ]
+  }
 }

--- a/src/octop/infra/agents/experts/library/parenting-companion/manifest.json
+++ b/src/octop/infra/agents/experts/library/parenting-companion/manifest.json
@@ -117,5 +117,23 @@
       "color": "#fff1f2",
       "icon_name": "pen-line"
     }
-  ]
+  ],
+  "task_examples": {
+    "zh": [
+      "每天「21:00」提醒我记录宝宝今日饮食、睡眠和异常，持续生效并立即启用",
+      "每周日「20:00」汇总本周发育与健康记录，对照档案给出注意事项",
+      "距离下次疫苗接种 7 天内，每天「09:00」提醒我预约和注意事项",
+      "每月孩子月龄日「20:00」汇总当月发育并对照 WHO 曲线，仅在偏好窗口内发送",
+      "每天「07:30」根据档案提醒今日辅食或过敏观察要点",
+      "每周五「21:00」整理本周日记条目索引，不改原文"
+    ],
+    "en": [
+      "Every day at 21:00, remind me to log today's feeding, sleep, and anything unusual — enable immediately and keep it running",
+      "Every Sunday at 20:00, summarize this week's growth and health notes against the profile",
+      "When the next vaccine is within 7 days, remind me daily at 09:00 to book it and review precautions",
+      "On the child's monthly age-day at 20:00, summarize growth vs WHO curves — send only in the preferred window",
+      "Every day at 07:30, remind me of today's feeding or allergy-watch notes from the profile",
+      "Every Friday at 21:00, index this week's diary entries without rewriting them"
+    ]
+  }
 }

--- a/src/octop/infra/agents/experts/library/stock-assistant/manifest.json
+++ b/src/octop/infra/agents/experts/library/stock-assistant/manifest.json
@@ -116,5 +116,23 @@
       "color": "#fff1f2",
       "icon_name": "bar-chart-3"
     }
-  ]
+  ],
+  "task_examples": {
+    "zh": [
+      "设置「每个交易日 09:15」推送今日 A 股开盘综述（大盘、热点板块、北向资金），任务创建后立即启用",
+      "每个交易日「15:10」复盘收盘：指数涨跌、涨停跌停池和我关注的自选股，从今天开始持续生效",
+      "每周一「08:30」汇总上周板块资金流向和我自选股的技术面变化，发送给我",
+      "每个交易日「11:35」盘中快报：指数、成交额和我自选股异动",
+      "每个交易日「21:00」复盘美股与隔夜期货对 A 股的可能影响",
+      "每月最后一个交易日「16:00」汇总本月自选股涨跌和估值变化"
+    ],
+    "en": [
+      "Push today's A-share open briefing (index, hot sectors, northbound flow) every trading day at 09:15, and enable the job immediately",
+      "Every trading day at 15:10, recap the close: index moves, limit-up/down pool, and my watchlist — start today and keep it running",
+      "Every Monday at 08:30, summarize last week's sector fund flows and technical changes on my watchlist",
+      "Every trading day at 11:35, send a midday flash: index, turnover, and watchlist movers",
+      "Every trading day at 21:00, recap how US stocks and overnight futures may affect A-shares",
+      "On the last trading day of each month at 16:00, summarize this month's watchlist moves and valuation changes"
+    ]
+  }
 }

--- a/src/octop/infra/agents/experts/library/superpowers-methodology/manifest.json
+++ b/src/octop/infra/agents/experts/library/superpowers-methodology/manifest.json
@@ -66,5 +66,17 @@
       "color": "#dbeafe",
       "icon_name": "list"
     }
-  ]
+  ],
+  "task_examples": {
+    "zh": [
+      "每个工作日「09:30」提醒我今天的开发任务先写失败测试再动手，任务创建后立即启用",
+      "每周五「16:30」按 explore → plan → TDD → review 复盘本周一个功能",
+      "每天「18:00」检查是否有未完成的审查或验证步骤，列成明日待办"
+    ],
+    "en": [
+      "Every weekday at 09:30, remind me to write a failing test before coding today's task — enable immediately",
+      "Every Friday at 16:30, recap one feature using explore → plan → TDD → review",
+      "Every day at 18:00, check for unfinished review or verify steps and turn them into tomorrow's todos"
+    ]
+  }
 }

--- a/src/octop/infra/agents/experts/library/tencentcloud-api/manifest.json
+++ b/src/octop/infra/agents/experts/library/tencentcloud-api/manifest.json
@@ -114,5 +114,23 @@
       "color": "#ffe8f0",
       "icon_name": "stethoscope"
     }
-  ]
+  ],
+  "task_examples": {
+    "zh": [
+      "每天「09:30」巡检腾讯云 CVM：运行中实例、异常状态和即将到期资源，发给我，任务创建后立即启用",
+      "每周一「10:00」汇总上周费用与高危操作记录，标出异常账单",
+      "每月 1 日「09:00」检查即将到期的包年包月资源并提醒续费",
+      "每个工作日「18:00」核对安全组与密钥变更，只报告差异不自动改",
+      "每周五「11:00」汇总本周 API 调用失败率最高的接口",
+      "每「6 小时」检查核心实例状态，有异常再通知我，从今天开始持续生效"
+    ],
+    "en": [
+      "Every day at 09:30, inspect Tencent Cloud CVM — running instances, unhealthy states, and resources nearing expiry — enable immediately",
+      "Every Monday at 10:00, summarize last week's billing and high-risk operations, and flag unusual charges",
+      "On the 1st of each month at 09:00, check prepaid resources that will expire soon and remind me to renew",
+      "Every weekday at 18:00, diff security-group and key changes — report only, no auto-edits",
+      "Every Friday at 11:00, list this week's APIs with the highest failure rates",
+      "Every 6 hours, check core instance health and notify me only on anomalies, starting today"
+    ]
+  }
 }

--- a/src/octop/infra/agents/experts/library/wechat-ops/manifest.json
+++ b/src/octop/infra/agents/experts/library/wechat-ops/manifest.json
@@ -115,5 +115,23 @@
       "color": "#fff7ed",
       "icon_name": "image"
     }
-  ]
+  ],
+  "task_examples": {
+    "zh": [
+      "每个工作日「09:00」检查公众号草稿箱，列出待发布文章并提醒我确认，任务创建后立即启用",
+      "每周一「10:00」根据本周选题日历起草一篇短内容，放到待发布",
+      "每月 1 日「09:30」汇总上月各平台发布数据，给出下月选题建议",
+      "每个工作日「18:00」复盘当天阅读、点赞和留言，标出需回复的评论",
+      "每周五「16:00」对照选题日历检查下周空档，补一条备稿",
+      "每天「12:00」检查待发布队列，有到点稿件提醒我确认"
+    ],
+    "en": [
+      "Every weekday at 09:00, check the WeChat draft box, list posts waiting to publish, and ask me to confirm — enable immediately",
+      "Every Monday at 10:00, draft a short piece from this week's topic calendar and leave it in the publish queue",
+      "On the 1st of each month at 09:30, summarize last month's publish stats and suggest next month's topics",
+      "Every weekday at 18:00, recap today's reads, likes, and comments, and flag replies still due",
+      "Every Friday at 16:00, check next week's topic calendar for gaps and add one backup draft",
+      "Every day at 12:00, check the publish queue and remind me to confirm anything due"
+    ]
+  }
 }

--- a/src/octop/infra/agents/experts/manifest_generator.py
+++ b/src/octop/infra/agents/experts/manifest_generator.py
@@ -11,6 +11,11 @@ from typing import Any
 
 from langchain_core.messages import HumanMessage, SystemMessage
 
+from octop.infra.agents.experts.catalog import (
+    default_task_examples,
+    parse_task_examples,
+    snap_task_examples,
+)
 from octop.infra.utils.llm_text import ainvoke_text
 
 logger = logging.getLogger(__name__)
@@ -28,6 +33,9 @@ _MAX_WELCOME_CHARS_ZH = 40
 _MAX_WELCOME_CHARS_EN = 90
 _MAX_QUICK_PROMPTS = 6
 _MIN_QUICK_PROMPTS = 6
+_MIN_TASK_EXAMPLES = 3
+_MAX_TASK_EXAMPLES = 6
+_MAX_TASK_EXAMPLE_CHARS = 140
 
 _ALLOWED_ICONS = {
     "zap",
@@ -150,7 +158,12 @@ async def generate_skillhub_manifest_assets(
             "welcome_max_chars_en": _MAX_WELCOME_CHARS_EN,
             "quick_prompt_min": _MIN_QUICK_PROMPTS,
             "quick_prompt_max": _MAX_QUICK_PROMPTS,
-            "output": "label + description + one-line welcome_message + quick_prompts for Octop expert manifest",
+            "task_example_min": _MIN_TASK_EXAMPLES,
+            "task_example_max": _MAX_TASK_EXAMPLES,
+            "output": (
+                "label + description + one-line welcome_message + quick_prompts "
+                "+ task_examples for Octop expert manifest"
+            ),
         },
     }
     messages = [
@@ -192,6 +205,7 @@ def merge_manifest_assets(
     out["description"] = assets["description"]
     out["welcome_message"] = assets["welcome_message"]
     out["quick_prompts"] = assets["quick_prompts"]
+    out["task_examples"] = assets["task_examples"]
     raw_skillhub = out.get("skillhub")
     skillhub = dict(raw_skillhub) if isinstance(raw_skillhub, dict) else {}
     generated = {
@@ -402,6 +416,12 @@ def normalize_manifest_assets(
         if len(prompts) >= _MAX_QUICK_PROMPTS:
             break
 
+    task_examples = _normalize_task_examples(
+        payload.get("task_examples"),
+        label_zh=label_zh,
+        label_en=label_en,
+    )
+
     if len(prompts) < 2:
         raise ExpertManifestGenerationError("model returned too few usable quick prompts")
     while len(prompts) < _MIN_QUICK_PROMPTS:
@@ -432,7 +452,27 @@ def normalize_manifest_assets(
         "description": {"zh": expert_description_zh, "en": expert_description_en},
         "welcome_message": {"zh": welcome_zh, "en": welcome_en},
         "quick_prompts": prompts[:_MAX_QUICK_PROMPTS],
+        "task_examples": task_examples,
     }
+
+
+def _normalize_task_examples(
+    raw: Any,
+    *,
+    label_zh: str,
+    label_en: str,
+) -> dict[str, list[str]]:
+    """Keep exactly 3 or 6 bilingual scheduled-task prompts."""
+    fallback = default_task_examples(label_zh, label_en)
+    parsed = parse_task_examples({"task_examples": raw} if raw is not None else {})
+    zh = [_clip(item, _MAX_TASK_EXAMPLE_CHARS) for item in (parsed or {}).get("zh", [])]
+    en = [_clip(item, _MAX_TASK_EXAMPLE_CHARS) for item in (parsed or {}).get("en", [])]
+    return snap_task_examples(
+        zh,
+        en,
+        fillers_zh=fallback["zh"],
+        fillers_en=fallback["en"],
+    )
 
 
 def _manifest_skill_slugs(manifest: dict[str, Any]) -> list[str]:

--- a/src/octop/infra/agents/experts/manifest_generator_skill.md
+++ b/src/octop/infra/agents/experts/manifest_generator_skill.md
@@ -7,7 +7,7 @@ description: Generate bilingual Octop expert manifest metadata from a SkillHub s
 
 You turn a SkillHub skillset package into the small manifest metadata Octop needs
 for an expert agent. You do not create a soul/persona file. You only generate
-display metadata, a welcome message, and quick-start cards.
+display metadata, a welcome message, quick-start cards, and scheduled-task examples.
 
 Return JSON only. Do not include Markdown fences, commentary, XML tags, or
 reasoning.
@@ -51,7 +51,11 @@ Return exactly this shape:
       "color": "#RRGGBB",
       "icon_name": "string"
     }
-  ]
+  ],
+  "task_examples": {
+    "zh": ["string"],
+    "en": ["string"]
+  }
 }
 ```
 
@@ -115,6 +119,18 @@ Return exactly this shape:
 - Prefer professional, task-oriented wording.
 - Do not mention SkillHub, packages, JSON, schema, or internal implementation.
 - Do not invent unsupported abilities beyond the workflow prompt and skills.
+- Produce exactly 3 or exactly 6 `task_examples` (prefer 6 when the workflow
+  has recurring work). Do not return 4 or 5.
+  These are empty-state cards on the **tasks / cron** page: each string is a
+  natural-language request that asks the expert to **create a scheduled job**.
+- Every task example must include a concrete schedule in quotes, for example
+  `每天「09:00」` / `every weekday at 18:00`, and should say to enable the job
+  after creation when that is the first card.
+- Domain-specific only — do not reuse generic drink-water / zodiac / tech-news
+  examples. Cover daily patrol, weekly recap, and at least one deliverable push
+  when the workflow supports it.
+- `task_examples.zh` and `task_examples.en` must be the same length and express
+  the same jobs. Keep each string under ~120 characters.
 
 Allowed `icon_name` values:
 

--- a/src/octop/infra/agents/experts/publish.py
+++ b/src/octop/infra/agents/experts/publish.py
@@ -72,6 +72,7 @@ class PublishedExpertSnapshotMeta:
     welcome_message_zh: str
     welcome_message_en: str
     quick_prompts: tuple[dict[str, Any], ...] = ()
+    task_examples: dict[str, list[str]] | None = None
 
 
 def assert_can_mutate_published(row: PublishedExpertRow, user: User) -> None:
@@ -222,6 +223,8 @@ def _manifest_from_metadata(
         data["color"] = metadata.color
     if metadata.quick_prompts:
         data["quick_prompts"] = list(metadata.quick_prompts)
+    if metadata.task_examples is not None:
+        data["task_examples"] = metadata.task_examples
     return json.dumps(data, ensure_ascii=False).encode("utf-8")
 
 

--- a/src/octop/infra/agents/experts/published_creation.py
+++ b/src/octop/infra/agents/experts/published_creation.py
@@ -15,6 +15,8 @@ from psycopg import IntegrityError as PsycopgIntegrityError
 from octop.infra.agents.avatar import bind_workspace_avatar_icon_url
 from octop.infra.agents.experts.catalog import (
     MANIFEST_FILENAME,
+    parse_task_examples,
+    read_workspace_manifest_task_examples,
     read_workspace_manifest_welcome,
     seed_expert_directory,
 )
@@ -95,6 +97,15 @@ async def _workspace_quick_prompts(workspace: Any) -> tuple[dict[str, Any], ...]
     return _manifest_quick_prompts(payload) if payload is not None else ()
 
 
+def _manifest_task_examples(manifest: dict[str, Any]) -> dict[str, list[str]] | None:
+    return parse_task_examples(manifest)
+
+
+async def _workspace_task_examples(workspace: Any) -> dict[str, list[str]] | None:
+    """Tasks-page examples from the source workspace, so publishing never drops them."""
+    return await read_workspace_manifest_task_examples(workspace)
+
+
 def _agent_color(registry: Any, agent_id: str) -> str | None:
     row = registry.get_row(agent_id)
     if row is not None:
@@ -115,6 +126,7 @@ def _snapshot_meta(
     welcome_message_zh: str = "",
     welcome_message_en: str = "",
     quick_prompts: tuple[dict[str, Any], ...] = (),
+    task_examples: dict[str, list[str]] | None = None,
 ) -> PublishedExpertSnapshotMeta:
     return PublishedExpertSnapshotMeta(
         name=name,
@@ -126,6 +138,7 @@ def _snapshot_meta(
         welcome_message_zh=welcome_message_zh,
         welcome_message_en=welcome_message_en,
         quick_prompts=quick_prompts,
+        task_examples=task_examples,
     )
 
 
@@ -153,6 +166,7 @@ async def publish_agent_expert(
     welcome_message_zh: str = "",
     welcome_message_en: str = "",
     quick_prompts: tuple[dict[str, Any], ...] = (),
+    task_examples: dict[str, list[str]] | None = None,
 ) -> PublishedExpertRow:
     """Snapshot an owned agent workspace into a globally installable expert template."""
     repo = services.published_expert_repo
@@ -169,6 +183,9 @@ async def publish_agent_expert(
     snapshot_dir = _snapshot_dir(services, expert_id)
     resolved_description = description or source.description or ""
     resolved_quick_prompts = quick_prompts or await _workspace_quick_prompts(workspace)
+    resolved_task_examples = (
+        task_examples if task_examples is not None else await _workspace_task_examples(workspace)
+    )
     color = _agent_color(registry, source.agent_id) or ""
     icon_name = getattr(source, "icon_name", None) or source.icon or ""
     try:
@@ -183,6 +200,7 @@ async def publish_agent_expert(
                 welcome_message_zh=welcome_message_zh,
                 welcome_message_en=welcome_message_en,
                 quick_prompts=resolved_quick_prompts,
+                task_examples=resolved_task_examples,
             ),
             manifest_id=resolved_slug,
         )
@@ -224,6 +242,7 @@ async def refresh_published_expert(
     welcome_message_zh: str | None = None,
     welcome_message_en: str | None = None,
     quick_prompts: tuple[dict[str, Any], ...] | None = None,
+    task_examples: dict[str, list[str]] | None = None,
 ) -> PublishedExpertRow:
     """Replace a published snapshot using its still-owned source agent workspace."""
     row = require_published_expert(services, expert_id)
@@ -237,6 +256,7 @@ async def refresh_published_expert(
     existing_manifest = await asyncio.to_thread(_read_snapshot_manifest, snapshot_dir)
     existing_welcome_zh, existing_welcome_en = _manifest_welcome(existing_manifest)
     existing_quick_prompts = _manifest_quick_prompts(existing_manifest)
+    existing_task_examples = _manifest_task_examples(existing_manifest)
     resolved_name = name if name is not None else row.name
     resolved_description = description if description is not None else row.description
     resolved_welcome_zh = (
@@ -248,6 +268,12 @@ async def refresh_published_expert(
     resolved_quick_prompts = quick_prompts
     if resolved_quick_prompts is None:
         resolved_quick_prompts = await _workspace_quick_prompts(workspace) or existing_quick_prompts
+    resolved_task_examples = task_examples
+    if resolved_task_examples is None:
+        workspace_examples = await _workspace_task_examples(workspace)
+        resolved_task_examples = (
+            workspace_examples if workspace_examples is not None else existing_task_examples
+        )
     await export_agent_workspace_to_dir(
         workspace=workspace,
         dest=snapshot_dir,
@@ -259,6 +285,7 @@ async def refresh_published_expert(
             welcome_message_zh=resolved_welcome_zh,
             welcome_message_en=resolved_welcome_en,
             quick_prompts=resolved_quick_prompts,
+            task_examples=resolved_task_examples,
         ),
         manifest_id=row.slug,
     )

--- a/src/octop/infra/agents/experts/skillhub_market.py
+++ b/src/octop/infra/agents/experts/skillhub_market.py
@@ -25,6 +25,7 @@ from urllib.error import HTTPError, URLError
 from urllib.parse import quote, urlencode
 from urllib.request import Request, urlopen
 
+from octop.infra.agents.experts.catalog import default_task_examples, snap_task_examples
 from octop.infra.utils.ssl_errors import looks_like_ssl_error
 
 logger = logging.getLogger(__name__)
@@ -35,6 +36,7 @@ _HTTP_TIMEOUT = 30
 _SKILLSET_PAGE_SIZE = 100
 _MAX_SKILLSET_PAGES = 20
 _MAX_WORKFLOW_QUICK_PROMPTS = 6
+_MAX_TASK_EXAMPLES = 6
 _SKILLSET_LIST_CACHE_TTL_SECONDS = 300.0
 _MAX_HTTP_BYTES = 32 * 1024 * 1024
 _MAX_ZIP_ENTRIES = 2_000
@@ -139,6 +141,7 @@ class SkillHubSkillset:
             "skill_slugs": list(self.skill_slugs),
             "skill_count": self.skill_count or len(self.skill_slugs),
             "source": "skillhub",
+            "task_examples": task_examples_for_skillset(self),
         }
         if include_content:
             out["content"] = {"zh": self.content, "en": self.content_en}
@@ -867,6 +870,7 @@ def _expert_manifest(
         "color": _scene_color(item.scene),
         "prompt_files": ["SOUL.md"],
         "quick_prompts": quick_prompts_for_skillset(item, skillset_prompt),
+        "task_examples": task_examples_for_skillset(item, skillset_prompt),
         "source": {
             "type": "skillhub",
             "kind": "skillset",
@@ -993,6 +997,53 @@ def quick_prompts_for_skillset(
 ) -> list[dict[str, Any]]:
     prompts = _workflow_quick_prompts(item, workflow_prompt or item.content)
     return _ensure_min_quick_prompts(item, prompts)
+
+
+def task_examples_for_skillset(
+    item: SkillHubSkillset,
+    workflow_prompt: str | None = None,
+) -> dict[str, list[str]]:
+    """Scheduled-task starter prompts for the tasks-page empty state."""
+    generated = _workflow_task_examples(item, workflow_prompt or item.content)
+    defaults = default_task_examples(_expert_label_zh(item), _expert_label_en(item))
+    return snap_task_examples(
+        list(generated["zh"]),
+        list(generated["en"]),
+        fillers_zh=defaults["zh"],
+        fillers_en=defaults["en"],
+    )
+
+
+_TASK_EXAMPLE_SCHEDULES = (
+    ("每天「09:00」", "Every day at 09:00"),
+    ("每个工作日「18:00」", "Every weekday at 18:00"),
+    ("每周一「10:00」", "Every Monday at 10:00"),
+    ("每周五「17:00」", "Every Friday at 17:00"),
+    ("每天「08:00」", "Every day at 08:00"),
+    ("每月 1 日「09:30」", "On the 1st of each month at 09:30"),
+)
+
+
+def _workflow_task_examples(
+    item: SkillHubSkillset,
+    workflow_prompt: str,
+) -> dict[str, list[str]]:
+    steps = _workflow_steps(workflow_prompt)
+    zh: list[str] = []
+    en: list[str] = []
+    for idx, step in enumerate(steps[:_MAX_TASK_EXAMPLES]):
+        title = _clip_text(step["title"], 16)
+        if not title:
+            continue
+        zh_sched, en_sched = _TASK_EXAMPLE_SCHEDULES[idx % len(_TASK_EXAMPLE_SCHEDULES)]
+        enable_zh = "，任务创建后立即启用" if not zh else ""
+        enable_en = " — enable immediately" if not en else ""
+        zh.append(f"{zh_sched}帮我完成「{title}」并把结果发给我{enable_zh}")
+        en.append(
+            f"{en_sched}, help me complete “{_english_step_title(title, idx)}” "
+            f"and send the result{enable_en}"
+        )
+    return {"zh": zh, "en": en}
 
 
 def _ensure_min_quick_prompts(

--- a/src/octop/infra/agents/workspace_dir.py
+++ b/src/octop/infra/agents/workspace_dir.py
@@ -86,18 +86,27 @@ def default_agent_workspace_dir(
     agent_id: str,
     *,
     cfg: dict[str, Any] | None = None,
+    ensure: bool = True,
 ) -> Path:
-    """Create-time on-disk workspace (mkdir -p). Not what harness receives."""
+    """Create-time on-disk workspace (mkdir -p unless ``ensure=False``).
+
+    Not what harness receives.
+    """
     root_raw = local_backend_root_dir(cfg)
     if root_raw is not None and not _is_host_root_sentinel(root_raw):
         try:
             root = Path(root_raw).expanduser().resolve()
         except OSError:
-            return paths.ensure_agent_workspace(agent_id)
+            if ensure:
+                return paths.ensure_agent_workspace(agent_id)
+            return paths.agent_workspace(agent_id)
         out = root / DEFAULT_SYSTEM_FILES_PATH / SCOPED_WORKSPACE_DIRNAME / agent_id
-        out.mkdir(parents=True, exist_ok=True)
+        if ensure:
+            out.mkdir(parents=True, exist_ok=True)
         return out
-    return paths.ensure_agent_workspace(agent_id)
+    if ensure:
+        return paths.ensure_agent_workspace(agent_id)
+    return paths.agent_workspace(agent_id)
 
 
 def seed_workspace_dir_on_create(
@@ -285,14 +294,20 @@ def workspace_dir_from_config(
     *,
     paths: PathLayout,
     agent_id: str,
+    ensure: bool = True,
 ) -> Path:
-    """On-disk workspace for Octop host ops (may map ``/.octop/…`` under root_dir)."""
+    """On-disk workspace for Octop host ops (may map ``/.octop/…`` under root_dir).
+
+    Read-only callers (backup) pass ``ensure=False`` so a stale or unwritable
+    ``workspace_dir`` is not created.
+    """
     raw = (cfg or {}).get("workspace_dir")
     if isinstance(raw, str) and raw.strip():
         out = resolve_workspace_host_path(raw, cfg)
-        out.mkdir(parents=True, exist_ok=True)
+        if ensure:
+            out.mkdir(parents=True, exist_ok=True)
         return out
-    return default_agent_workspace_dir(paths, agent_id, cfg=cfg)
+    return default_agent_workspace_dir(paths, agent_id, cfg=cfg, ensure=ensure)
 
 
 def system_files_path_from_config(cfg: dict[str, Any] | None) -> str:
@@ -338,13 +353,14 @@ def workspace_dir_from_config_json(
     *,
     paths: PathLayout,
     agent_id: str,
+    ensure: bool = True,
 ) -> Path:
     try:
         parsed = json.loads(config_json or "{}")
     except (json.JSONDecodeError, TypeError):
         parsed = {}
     cfg = parsed if isinstance(parsed, dict) else {}
-    return workspace_dir_from_config(cfg, paths=paths, agent_id=agent_id)
+    return workspace_dir_from_config(cfg, paths=paths, agent_id=agent_id, ensure=ensure)
 
 
 __all__ = [

--- a/src/octop/infra/backup/system_archive.py
+++ b/src/octop/infra/backup/system_archive.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import io
 import json
+import logging
 import os
 import shutil
 import tarfile
@@ -45,6 +46,8 @@ from octop.infra.db.repos.secrets import SecretRepo
 from octop.infra.errors import ErrorCode, OctopError
 from octop.infra.utils.env_file import env_file_path
 from octop.infra.utils.paths import PathLayout
+
+logger = logging.getLogger(__name__)
 
 _CONFIG_DIR = "config"
 _DB_DIR = "db"
@@ -293,18 +296,28 @@ def create_system_backup(
                     tf.add(root / _CONFIG_DIR / "env", arcname=f"{_CONFIG_DIR}/env")
                 if include_workspaces:
                     for row in agent_rows:
-                        ws = workspace_dir_from_config_json(
-                            getattr(row, "config_json", None),
-                            paths=paths,
-                            agent_id=str(row.agent_id),
-                        )
-                        if ws.is_dir():
+                        agent_id = str(row.agent_id)
+                        try:
+                            ws = workspace_dir_from_config_json(
+                                getattr(row, "config_json", None),
+                                paths=paths,
+                                agent_id=agent_id,
+                                ensure=False,
+                            )
+                            if not ws.is_dir():
+                                continue
                             _add_dir(
                                 tf,
                                 ws,
-                                f"{_WORKSPACES_DIR}/{row.agent_id}",
+                                f"{_WORKSPACES_DIR}/{agent_id}",
                                 skip_chats=not include_chats,
                                 system_files_path=_system_files_path_from_row(row),
+                            )
+                        except OSError:
+                            logger.warning(
+                                "skipping workspace for agent %s",
+                                agent_id,
+                                exc_info=True,
                             )
                 if include_skill_packages and paths.skill_packages_dir.is_dir():
                     _add_dir(

--- a/src/octop/infra/gateway/process/history_projection.py
+++ b/src/octop/infra/gateway/process/history_projection.py
@@ -7,12 +7,14 @@ import json
 from dataclasses import dataclass, field
 from typing import Any
 
-from langchain_core.messages import convert_to_messages, message_to_dict
+from langchain_core.messages import AIMessage, convert_to_messages, message_to_dict
 
 from octop.infra.db.repos._base import now_ts
 from octop.infra.db.repos.thread_messages import ThreadMessageInput
+from octop.infra.gateway.process.message_keys import STREAM_ERROR_CODE_KEY, STREAM_ERROR_FLAG
 
 _USER_ROLES = frozenset({"human", "user"})
+_ASSISTANT_ROLES = frozenset({"ai", "assistant"})
 
 
 def _role(message: Any) -> str:
@@ -73,12 +75,38 @@ def message_inputs(
     return out
 
 
+def _wire_text(item: ThreadMessageInput) -> str:
+    try:
+        wire = json.loads(item.message_json)
+    except json.JSONDecodeError:
+        return ""
+    data = wire.get("data") if isinstance(wire, dict) else None
+    content = data.get("content") if isinstance(data, dict) else None
+    if content is None and isinstance(wire, dict):
+        content = wire.get("content")
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for block in content:
+            if isinstance(block, str):
+                parts.append(block)
+            elif isinstance(block, dict):
+                parts.append(str(block.get("text") or ""))
+        return "".join(parts)
+    return ""
+
+
 @dataclass
 class TurnHistoryTracker:
     """Keep only the current user turn from replay-prone state chunks."""
 
     seed_messages: list[Any] = field(default_factory=list)
     _state_messages: list[Any] = field(default_factory=list, init=False)
+    _stream_text: str = field(default="", init=False)
+    _reasoning_text: str = field(default="", init=False)
+    _error_message: str = field(default="", init=False)
+    _error_code: str | None = field(default=None, init=False)
 
     @classmethod
     def from_request(cls, request: dict[str, Any]) -> TurnHistoryTracker:
@@ -86,19 +114,57 @@ class TurnHistoryTracker:
         return cls(seed_messages=list(raw) if isinstance(raw, list) else [])
 
     def observe(self, chunk: dict[str, Any]) -> None:
-        if chunk.get("type") not in ("state_snapshot", "state_update"):
+        kind = chunk.get("type")
+        if kind in ("state_snapshot", "state_update"):
+            messages = _chunk_messages(chunk)
+            if not messages:
+                return
+            last_user = max(
+                (index for index, msg in enumerate(messages) if _role(msg) in _USER_ROLES),
+                default=-1,
+            )
+            if last_user >= 0:
+                self._state_messages = messages[last_user:]
+            else:
+                self._state_messages.extend(messages)
             return
-        messages = _chunk_messages(chunk)
-        if not messages:
+        if kind == "token":
+            self._stream_text += str(chunk.get("content") or "")
             return
-        last_user = max(
-            (index for index, msg in enumerate(messages) if _role(msg) in _USER_ROLES),
-            default=-1,
+        if kind == "reasoning":
+            self._reasoning_text += str(chunk.get("content") or "")
+            return
+        if kind == "error":
+            text = str(chunk.get("message") or chunk.get("content") or "")
+            if text:
+                self._error_message = text
+            code = chunk.get("error_code")
+            if code:
+                self._error_code = str(code)
+
+    def _stream_message(self) -> ThreadMessageInput | None:
+        if not self._stream_text and not self._reasoning_text:
+            return None
+        extra: dict[str, Any] = {}
+        if self._reasoning_text:
+            extra["reasoning_content"] = self._reasoning_text
+        return message_input(AIMessage(content=self._stream_text, additional_kwargs=extra))
+
+    def _error_input(self) -> ThreadMessageInput | None:
+        if not self._error_message:
+            return None
+        extra: dict[str, Any] = {STREAM_ERROR_FLAG: True}
+        if self._error_code:
+            extra[STREAM_ERROR_CODE_KEY] = self._error_code
+        return message_input(AIMessage(content=self._error_message, additional_kwargs=extra))
+
+    def _inputs_cover_stream(self, items: list[ThreadMessageInput]) -> bool:
+        if not self._stream_text:
+            return False
+        return any(
+            item.role in _ASSISTANT_ROLES and self._stream_text in _wire_text(item)
+            for item in items
         )
-        if last_user >= 0:
-            self._state_messages = messages[last_user:]
-        else:
-            self._state_messages.extend(messages)
 
     @property
     def inputs(self) -> list[ThreadMessageInput]:
@@ -106,7 +172,15 @@ class TurnHistoryTracker:
         source = (
             self._state_messages if state_has_user else [*self.seed_messages, *self._state_messages]
         )
-        return message_inputs(
+        items = message_inputs(
             source,
             dedupe_missing_ids=True,
         )
+        if not self._inputs_cover_stream(items):
+            streamed = self._stream_message()
+            if streamed is not None:
+                items.append(streamed)
+        error = self._error_input()
+        if error is not None:
+            items.append(error)
+        return items

--- a/src/octop/infra/gateway/process/message_keys.py
+++ b/src/octop/infra/gateway/process/message_keys.py
@@ -11,6 +11,9 @@ from octop.infra.gateway.threads import ThreadRegistry
 # Persisted on HumanMessage.additional_kwargs for dashboard history UI.
 COMPOSER_CTX_KEY = "octop_composer_context"
 INBOUND_ATTACHMENTS_KEY = "octop_inbound_attachments"
+# Persisted on AIMessage.additional_kwargs when a stream fails mid-turn.
+STREAM_ERROR_FLAG = "octop_stream_error"
+STREAM_ERROR_CODE_KEY = "error_code"
 
 
 def build_composer_context(

--- a/src/octop/infra/gateway/process/processor.py
+++ b/src/octop/infra/gateway/process/processor.py
@@ -857,6 +857,7 @@ class GlobalProcessor:
         yield MessageEvent.typing()
         stream_ok = False
         hitl_paused = False
+        persist_failed_turn = False
         usage_tracker = UsageTracker()
         history_tracker = await self._begin_history(agent_id, thread_id, request)
         projection_state = StreamProjectionState()
@@ -887,6 +888,14 @@ class GlobalProcessor:
             message, error_code = _stream_error(exc, locale)
             if error_code:
                 message = f"[{error_code}] {message}"
+            persist_failed_turn = True
+            history_tracker.observe(
+                {
+                    "type": "error",
+                    "message": message,
+                    **({"error_code": error_code} if error_code else {}),
+                }
+            )
             yield MessageEvent.error_event(message)
         else:
             if stream_ok and not hitl_paused:
@@ -899,7 +908,12 @@ class GlobalProcessor:
                 )
                 await self._record_turn_history(thread_id, history_tracker)
         finally:
-            await self._finish_history(history_tracker, completed=stream_ok and not hitl_paused)
+            if persist_failed_turn or (not stream_ok and not hitl_paused):
+                await self._persist_incomplete_turn(
+                    thread_id, history_tracker, title_source=msg.text
+                )
+            else:
+                await self._finish_history(history_tracker, completed=stream_ok and not hitl_paused)
         yield MessageEvent.completed()
 
     # -- Raw harness-chunk stream (Dashboard WS, etc.) -------------------------
@@ -1022,6 +1036,7 @@ class GlobalProcessor:
         )
 
         stream_ok = False
+        persist_failed_turn = False
         harness_workspace = harness_workspace_for_agent(self._agent_manager, agent_id)
         usage_tracker = UsageTracker()
 
@@ -1086,10 +1101,17 @@ class GlobalProcessor:
             payload = {"type": "error", "message": message}
             if error_code:
                 payload["error_code"] = error_code
+            history_tracker.observe(payload)
+            persist_failed_turn = True
             yield payload
         finally:
             self._finish_trajectory(thread_id=thread_id, usage=usage_tracker.usage, enabled=traj_on)
-            await self._finish_history(history_tracker, completed=stream_ok)
+            if persist_failed_turn or not stream_ok:
+                await self._persist_incomplete_turn(
+                    thread_id, history_tracker, title_source=msg.text
+                )
+            else:
+                await self._finish_history(history_tracker, completed=stream_ok)
         if stream_ok:
             self._touch_thread_after_turn(thread_id, msg.text)
             self._record_turn_usage(
@@ -1113,6 +1135,7 @@ class GlobalProcessor:
         usage_tracker = UsageTracker()
         history_tracker = await self._begin_history(agent_id, thread_id, {}, resume=True)
         completed = False
+        persist_failed_turn = False
         traj_on = self._agent_trajectory_enabled(agent_id)
         try:
             async for chunk in self._agent_manager.resume_hitl(
@@ -1133,9 +1156,26 @@ class GlobalProcessor:
                 )
                 yield chunk
             completed = True
+        except Exception as exc:
+            await self._record_stream_error(user_id=user_id, agent_id=agent_id, exc=exc)
+            locale = resolve_user_locale(
+                user_repo=self._user_repo,
+                user_id=user_id,
+                channel_type="dashboard",
+            )
+            message, error_code = _stream_error(exc, locale)
+            payload = {"type": "error", "message": message}
+            if error_code:
+                payload["error_code"] = error_code
+            history_tracker.observe(payload)
+            persist_failed_turn = True
+            yield payload
         finally:
             self._finish_trajectory(thread_id=thread_id, usage=usage_tracker.usage, enabled=traj_on)
-            await self._finish_history(history_tracker, completed=completed)
+            if persist_failed_turn or not completed:
+                await self._persist_incomplete_turn(thread_id, history_tracker, title_source=None)
+            else:
+                await self._finish_history(history_tracker, completed=completed)
             if completed:
                 self._touch_thread_after_turn(thread_id, None)
                 self._record_turn_usage(
@@ -1370,10 +1410,23 @@ class GlobalProcessor:
             usage=usage,
         )
 
+    async def _persist_incomplete_turn(
+        self,
+        thread_id: str,
+        tracker: TurnHistoryTracker,
+        *,
+        title_source: str | None,
+    ) -> None:
+        """Keep partial tokens (and any error) when a turn is stopped or fails."""
+        self._touch_thread_after_turn(thread_id, title_source)
+        await self._record_turn_history(thread_id, tracker, completed=False)
+
     async def _record_turn_history(
         self,
         thread_id: str,
         tracker: TurnHistoryTracker,
+        *,
+        completed: bool = True,
     ) -> None:
         from octop.infra.history.recorder import RecordingTracker  # noqa: PLC0415
 
@@ -1382,7 +1435,9 @@ class GlobalProcessor:
                 await asyncio.to_thread(
                     tracker.archive.messages.append_legacy_interval, thread_id, tracker.inputs
                 )
-                await tracker.finish(completed=True)
+                await tracker.finish(completed=completed)
+            elif not completed:
+                await tracker.finish(completed=False)
             return
         if self._thread_message_repo is None:
             return

--- a/src/octop/infra/history/recorder.py
+++ b/src/octop/infra/history/recorder.py
@@ -11,6 +11,7 @@ from typing import Any
 from langchain_core.messages import AIMessage, ToolMessage, message_to_dict
 
 from octop.infra.gateway.process.history_projection import TurnHistoryTracker, _role, message_input
+from octop.infra.gateway.process.message_keys import STREAM_ERROR_CODE_KEY, STREAM_ERROR_FLAG
 from octop.infra.history.service import HistoryArchive
 from octop.infra.history.store import dumps
 from octop.infra.trajectory.projector import _tool_result_fields
@@ -190,6 +191,24 @@ class RecordingTracker(TurnHistoryTracker):
                 elif existing != wire:
                     existing.update(wire)
                     self._mark_changed(existing)
+            self._assistant = None
+        elif kind == "error":
+            text = str(chunk.get("message") or chunk.get("content") or "")
+            if not text:
+                return
+            error_extra: dict[str, Any] = {STREAM_ERROR_FLAG: True}
+            code = chunk.get("error_code")
+            if code:
+                error_extra[STREAM_ERROR_CODE_KEY] = str(code)
+            self._append_part(
+                message_to_dict(
+                    AIMessage(
+                        content=text,
+                        id=f"{self.turn['id']}:error",
+                        additional_kwargs=error_extra,
+                    )
+                )
+            )
             self._assistant = None
 
     def _merge_state(self) -> None:

--- a/tests/integration/test_cron_api.py
+++ b/tests/integration/test_cron_api.py
@@ -7,6 +7,7 @@ run-now invoking the cron manager and updating last_status.
 
 from __future__ import annotations
 
+import json
 from typing import Any
 
 import pytest
@@ -172,6 +173,65 @@ async def test_cron_settings_returns_timezone(env: Any) -> None:
     r = await c.get("/api/cron/settings", headers=alice_auth)
     assert r.status_code == 200
     assert r.json() == {"timezone": "Asia/Shanghai"}
+
+
+async def test_cron_examples_missing_field_is_null(env: Any) -> None:
+    c, _srv, alice_auth, _bob_auth, aid = env
+    r = await c.get(f"/api/agents/{aid}/cron/examples", headers=alice_auth)
+    assert r.status_code == 200, r.text
+    assert r.json() == {"task_examples": None}
+
+
+async def test_cron_examples_reads_workspace_manifest(env: Any) -> None:
+    c, srv, alice_auth, bob_auth, aid = env
+    workspace = srv.app_runtime.agent_registry.workspace_for_agent(aid)
+    assert workspace is not None
+    await workspace.awrite_text(
+        ".octop/manifest.json",
+        json.dumps(
+            {
+                "id": "demo",
+                "task_examples": {
+                    "zh": ["每天 09:00 巡检"],
+                    "en": ["Patrol daily at 09:00"],
+                },
+            }
+        ),
+        force=True,
+    )
+    r = await c.get(f"/api/agents/{aid}/cron/examples", headers=alice_auth)
+    assert r.status_code == 200, r.text
+    assert r.json()["task_examples"] == {
+        "zh": ["每天 09:00 巡检"],
+        "en": ["Patrol daily at 09:00"],
+    }
+    denied = await c.get(f"/api/agents/{aid}/cron/examples", headers=bob_auth)
+    assert denied.status_code == 403
+
+
+async def test_cron_examples_display_normalizes_four_or_five_to_three(env: Any) -> None:
+    c, srv, alice_auth, _bob_auth, aid = env
+    workspace = srv.app_runtime.agent_registry.workspace_for_agent(aid)
+    assert workspace is not None
+    await workspace.awrite_text(
+        ".octop/manifest.json",
+        json.dumps(
+            {
+                "id": "demo",
+                "task_examples": {
+                    "zh": ["一", "二", "三", "四", "五"],
+                    "en": ["a", "b", "c", "d", "e"],
+                },
+            }
+        ),
+        force=True,
+    )
+    r = await c.get(f"/api/agents/{aid}/cron/examples", headers=alice_auth)
+    assert r.status_code == 200, r.text
+    assert r.json()["task_examples"] == {"zh": ["一", "二", "三"], "en": ["a", "b", "c"]}
+    welcome = await c.get(f"/api/agents/{aid}/chat/welcome", headers=alice_auth)
+    assert welcome.status_code == 200, welcome.text
+    assert welcome.json()["task_examples"] == {"zh": ["一", "二", "三"], "en": ["a", "b", "c"]}
 
 
 async def test_settings_timezone_returns_default(env: Any) -> None:

--- a/tests/integration/test_experts_api.py
+++ b/tests/integration/test_experts_api.py
@@ -24,6 +24,8 @@ async def test_list_experts_returns_bundled_library(env: Any) -> None:
     assert len(rows) >= 1
     sample = next(r for r in rows if r["id"] == "general-assistant")
     assert "label" in sample and "zh" in sample["label"] and "en" in sample["label"]
+    assert sample["task_examples"]["zh"]
+    assert len(sample["task_examples"]["zh"]) == 3
 
 
 async def test_get_expert_includes_prompt_files(env: Any) -> None:

--- a/tests/integration/test_published_experts.py
+++ b/tests/integration/test_published_experts.py
@@ -258,6 +258,57 @@ async def test_install_keeps_source_quick_prompts_when_publish_body_omits_them(
     assert fork_welcome.json()["quick_prompts"] == source_prompts
 
 
+@posix_only
+async def test_install_keeps_source_task_examples_when_publish_body_omits_them(
+    env: tuple[Any, Any, dict[str, str]],
+) -> None:
+    client, _server, admin_auth = env
+    owner_auth = await create_user(client, admin_auth, username="taskex_owner")
+    peer_auth = await create_user(client, admin_auth, username="taskex_peer")
+    created = await client.post(
+        "/api/agents/from-expert/ai-coding-coach",
+        headers=owner_auth,
+        json={"name": "taskex-source"},
+    )
+    assert created.status_code == 201, created.text
+    source_agent_id = created.json()["agent_id"]
+
+    source_examples = await client.get(
+        f"/api/agents/{source_agent_id}/cron/examples",
+        headers=owner_auth,
+    )
+    assert source_examples.status_code == 200, source_examples.text
+    source_payload = source_examples.json()["task_examples"]
+    assert source_payload and source_payload["zh"] and source_payload["en"]
+
+    published = await client.post(
+        f"/api/agents/{source_agent_id}/publish-expert",
+        headers=owner_auth,
+        json={"name": "Task example expert"},
+    )
+    assert published.status_code == 201, published.text
+
+    installed = await client.post(
+        f"/api/experts/published/{published.json()['id']}/install",
+        headers=peer_auth,
+        json={"name": "Task example fork"},
+    )
+    assert installed.status_code == 201, installed.text
+
+    unpublished = await client.delete(
+        f"/api/experts/published/{published.json()['id']}",
+        headers=owner_auth,
+    )
+    assert unpublished.status_code == 204, unpublished.text
+
+    fork_examples = await client.get(
+        f"/api/agents/{installed.json()['agent_id']}/cron/examples",
+        headers=peer_auth,
+    )
+    assert fork_examples.status_code == 200, fork_examples.text
+    assert fork_examples.json()["task_examples"] == source_payload
+
+
 PNG = b"\x89PNG\r\n\x1a\n" + b"\x00" * 16
 
 

--- a/tests/unit/agents/test_expert_catalog.py
+++ b/tests/unit/agents/test_expert_catalog.py
@@ -204,3 +204,28 @@ def test_expert_quick_prompts_from_manifest(tmp_path: Path) -> None:
     assert len(expert.quick_prompts) == 1
     assert expert.quick_prompts[0].title_zh == "标题"
     assert expert.quick_prompts[0].prompt_en == "Hello"
+
+
+def test_expert_task_examples_from_manifest(tmp_path: Path) -> None:
+    from octop.infra.agents.experts.catalog import ExpertCatalog
+
+    expert_dir = tmp_path / "my-expert"
+    expert_dir.mkdir()
+    _write_manifest(
+        expert_dir,
+        extra={
+            "task_examples": {
+                "zh": ["一", "二", "三", "四", "五"],
+                "en": ["a", "b", "c", "d", "e"],
+            }
+        },
+    )
+
+    catalog = ExpertCatalog(tmp_path)
+    catalog.refresh()
+    expert = catalog.get("my-expert")
+    assert expert is not None
+    assert expert.summary.task_examples == {
+        "zh": ["一", "二", "三"],
+        "en": ["a", "b", "c"],
+    }

--- a/tests/unit/agents/test_expert_manifest_generator.py
+++ b/tests/unit/agents/test_expert_manifest_generator.py
@@ -119,6 +119,10 @@ async def test_generate_and_apply_skillhub_manifest_assets(tmp_path) -> None:
     assert data["quick_prompts"][0]["title"]["en"] == "Card 1"
     assert data["skillhub"]["manifest_generated"]["model"] == "p/model"
     assert data["skillhub"]["welcome_generated"]["model"] == "p/model"
+    assert len(data["task_examples"]["zh"]) == 3
+    assert len(data["task_examples"]["en"]) == 3
+    assert "测试工作流专家" in data["task_examples"]["zh"][0]
+    assert "09:00" in data["task_examples"]["zh"][0]
 
     catalog = ExpertCatalog(tmp_path)
     catalog.refresh()
@@ -292,3 +296,66 @@ def test_normalize_manifest_assets_pads_to_six_quick_prompts() -> None:
     assert len(assets["quick_prompts"]) == 6
     assert assets["quick_prompts"][0]["title"]["zh"] == "启动任务"
     assert assets["quick_prompts"][3]["title"]["zh"] == "继续推进 4"
+
+
+def test_normalize_manifest_assets_pads_task_examples() -> None:
+    from octop.infra.agents.experts.manifest_generator import normalize_manifest_assets
+
+    payload = _generated_payload()
+    payload["task_examples"] = {
+        "zh": ["每天「08:00」推送测试早报"],
+        "en": ["Every day at 08:00, push a test briefing"],
+    }
+
+    assets = normalize_manifest_assets(
+        payload,
+        fallback_name_zh="测试工作流专家",
+        fallback_name_en="Test Workflow Expert",
+    )
+
+    assert len(assets["task_examples"]["zh"]) == 3
+    assert len(assets["task_examples"]["en"]) == 3
+    assert assets["task_examples"]["zh"][0] == "每天「08:00」推送测试早报"
+    assert "测试工作流专家" in assets["task_examples"]["zh"][1]
+
+
+def test_normalize_manifest_assets_pads_four_task_examples_to_six() -> None:
+    from octop.infra.agents.experts.manifest_generator import normalize_manifest_assets
+
+    payload = _generated_payload()
+    payload["task_examples"] = {
+        "zh": [f"每天「0{idx}:00」跑第 {idx} 项巡检" for idx in range(1, 5)],
+        "en": [f"Every day at 0{idx}:00, run patrol {idx}" for idx in range(1, 5)],
+    }
+
+    assets = normalize_manifest_assets(
+        payload,
+        fallback_name_zh="测试工作流专家",
+        fallback_name_en="Test Workflow Expert",
+    )
+
+    assert len(assets["task_examples"]["zh"]) == 6
+    assert len(assets["task_examples"]["en"]) == 6
+    assert assets["task_examples"]["zh"][0] == "每天「01:00」跑第 1 项巡检"
+    assert "测试工作流专家" in assets["task_examples"]["zh"][4]
+
+
+def test_normalize_manifest_assets_keeps_at_most_six_task_examples() -> None:
+    from octop.infra.agents.experts.manifest_generator import normalize_manifest_assets
+
+    payload = _generated_payload()
+    payload["task_examples"] = {
+        "zh": [f"每天「0{idx}:00」跑第 {idx} 项巡检" for idx in range(1, 9)],
+        "en": [f"Every day at 0{idx}:00, run patrol {idx}" for idx in range(1, 9)],
+    }
+
+    assets = normalize_manifest_assets(
+        payload,
+        fallback_name_zh="专家",
+        fallback_name_en="Expert",
+    )
+
+    assert assets["task_examples"]["zh"] == [
+        f"每天「0{idx}:00」跑第 {idx} 项巡检" for idx in range(1, 7)
+    ]
+    assert len(assets["task_examples"]["en"]) == 6

--- a/tests/unit/agents/test_expert_publish_snapshot.py
+++ b/tests/unit/agents/test_expert_publish_snapshot.py
@@ -275,6 +275,7 @@ async def test_export_snapshot_builds_manifest_from_publish_metadata_only(
         "description": {"zh": "旧说明", "en": "Old description"},
         "welcome_message": {"zh": "欢迎回来", "en": "Welcome back"},
         "quick_prompts": [{"title": {"zh": "开始", "en": "Start"}}],
+        "task_examples": {"zh": ["工作区示例"], "en": ["Workspace example"]},
         "icon_name": "zap",
         "color": "#111111",
         "skillhub": {"manifest_generated": {"by": "test"}},
@@ -315,10 +316,45 @@ async def test_export_snapshot_builds_manifest_from_publish_metadata_only(
         "en": "Start researching",
     }
     assert "quick_prompts" not in merged
+    assert "task_examples" not in merged
     assert "skillhub" not in merged
     assert merged["icon_name"] == "search"
     assert merged["color"] == "#123456"
     assert merged["prompt_files"] == ["SOUL.md"]
+
+
+@pytest.mark.asyncio
+async def test_export_snapshot_writes_task_examples_from_metadata(tmp_path: Path) -> None:
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    source = _workspace(source_dir)
+    await source.aupload_many(
+        [
+            (MANIFEST_FILENAME, json.dumps({"id": "source"}).encode()),
+            ("SOUL.md", b"# Source soul"),
+        ]
+    )
+
+    destination = tmp_path / "published-expert"
+    await export_agent_workspace_to_dir(
+        workspace=source,
+        dest=destination,
+        metadata=PublishedExpertSnapshotMeta(
+            name="Research Expert",
+            description="Helps with research",
+            icon_name=None,
+            color=None,
+            label_zh="研究专家",
+            label_en="Research Expert",
+            welcome_message_zh="",
+            welcome_message_en="",
+            task_examples={"zh": ["每天巡检"], "en": ["Daily patrol"]},
+        ),
+        manifest_id="research-expert",
+    )
+
+    merged = json.loads((destination / MANIFEST_FILENAME).read_text(encoding="utf-8"))
+    assert merged["task_examples"] == {"zh": ["每天巡检"], "en": ["Daily patrol"]}
 
 
 @pytest.mark.asyncio

--- a/tests/unit/agents/test_library_task_examples.py
+++ b/tests/unit/agents/test_library_task_examples.py
@@ -1,0 +1,53 @@
+"""Bundled expert templates expose tasks-page ``task_examples``."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from octop.infra.agents.experts.catalog import default_library_root, parse_task_examples
+
+_LIBRARY = default_library_root()
+
+
+def _iter_manifests() -> list[Path]:
+    return sorted(path for path in _LIBRARY.glob("*/manifest.json") if path.is_file())
+
+
+def test_every_bundled_expert_declares_task_examples() -> None:
+    manifests = _iter_manifests()
+    assert manifests, "expected bundled expert templates"
+    for path in manifests:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        parsed = parse_task_examples(data)
+        assert parsed is not None, f"{path.parent.name} missing task_examples"
+        assert parsed["zh"], f"{path.parent.name} has empty zh task_examples"
+        assert parsed["en"], f"{path.parent.name} has empty en task_examples"
+        assert len(parsed["zh"]) == len(parsed["en"]), path.parent.name
+        assert len(parsed["zh"]) in (3, 6), path.parent.name
+        assert all(item.strip() for item in parsed["zh"] + parsed["en"])
+
+
+def test_domain_experts_offer_six_task_examples() -> None:
+    """Recurring-work templates keep a full two-column empty state."""
+    richer = (
+        "news-trend",
+        "stock-assistant",
+        "ops-engineer",
+        "parenting-companion",
+    )
+    for expert_id in richer:
+        data = json.loads((_LIBRARY / expert_id / "manifest.json").read_text(encoding="utf-8"))
+        parsed = parse_task_examples(data)
+        assert parsed is not None
+        assert len(parsed["zh"]) == 6, expert_id
+
+
+def test_general_templates_do_not_copy_dashboard_default_cards() -> None:
+    """i18n defaults stay the no-field fallback; bundled templates keep their own copy."""
+    dashboard_zh = "根据我的星座"
+    for expert_id in ("general-assistant", "default"):
+        data = json.loads((_LIBRARY / expert_id / "manifest.json").read_text(encoding="utf-8"))
+        parsed = parse_task_examples(data)
+        assert parsed is not None
+        assert all(dashboard_zh not in item for item in parsed["zh"])

--- a/tests/unit/agents/test_skillhub_market.py
+++ b/tests/unit/agents/test_skillhub_market.py
@@ -183,6 +183,112 @@ def test_skillhub_manifest_keeps_up_to_six_workflow_quick_prompts() -> None:
     assert manifest["quick_prompts"][-1]["title"]["zh"] == "步骤标题 6"
 
 
+def test_skillhub_manifest_defaults_task_examples_without_workflow() -> None:
+    from octop.infra.agents.experts.skillhub_market import (
+        SkillHubSkillset,
+        _expert_manifest,
+    )
+
+    item = SkillHubSkillset(
+        slug="tech-test-automation",
+        display_name="技术测试自动化",
+        display_name_en="Tech Test Automation",
+        scene="tech",
+    )
+
+    manifest = _expert_manifest(item, ["playwright"])
+    examples = manifest["task_examples"]
+
+    assert len(examples["zh"]) == 3
+    assert len(examples["en"]) == 3
+    assert "技术测试自动化专家" in examples["zh"][0]
+    assert "09:00" in examples["zh"][0]
+    assert "任务创建后立即启用" in examples["zh"][0]
+    assert "Tech Test Automation Expert" in examples["en"][0]
+    assert "09:00" in examples["en"][0]
+
+
+def test_skillhub_manifest_generates_workflow_task_examples() -> None:
+    from octop.infra.agents.experts.skillhub_market import (
+        SkillHubSkillset,
+        _expert_manifest,
+    )
+
+    item = SkillHubSkillset(
+        slug="media-storyboard-design",
+        display_name="分镜设计",
+        scene="media",
+        content="""# 分镜设计工作流
+
+## 步骤 1：剧本到分镜表格转换（获取层）
+- 将剧本文本解析为结构化分镜表格
+
+输出标准分镜表格和拍摄计划。
+
+## 步骤 2：电影感镜头运动设计（获取层）
+- 为每个分镜设计镜头运动方案
+
+输出镜头运动设计方案和机位规划。
+""",
+    )
+
+    manifest = _expert_manifest(item, ["script-to-storyboard"])
+    examples = manifest["task_examples"]
+
+    assert len(examples["zh"]) == 3
+    assert len(examples["zh"]) == len(examples["en"])
+    assert examples["zh"][0].startswith("每天「09:00」")
+    assert "剧本到分镜表格转换" in examples["zh"][0]
+    assert "任务创建后立即启用" in examples["zh"][0]
+    assert "电影感镜头运动设计" in examples["zh"][1]
+    assert "18:00" in examples["zh"][1]
+    assert "enable immediately" in examples["en"][0]
+    assert not _has_cjk(examples["en"][0])
+
+
+def test_skillhub_manifest_keeps_up_to_six_task_examples() -> None:
+    from octop.infra.agents.experts.skillhub_market import (
+        SkillHubSkillset,
+        _expert_manifest,
+    )
+
+    workflow = "# 工作流\n\n" + "\n\n".join(
+        f"## 步骤 {idx}：步骤标题 {idx}（处理层）\n- 执行动作 {idx}\n\n输出交付物 {idx}。"
+        for idx in range(1, 11)
+    )
+    item = SkillHubSkillset(
+        slug="demo",
+        display_name="演示专家",
+        scene="tech",
+        content=workflow,
+    )
+
+    examples = _expert_manifest(item, ["demo"])["task_examples"]
+
+    assert len(examples["zh"]) == 6
+    assert "步骤标题 1" in examples["zh"][0]
+    assert "步骤标题 6" in examples["zh"][-1]
+
+
+def test_skillhub_api_dict_includes_task_examples_with_content() -> None:
+    from octop.infra.agents.experts.skillhub_market import SkillHubSkillset
+
+    item = SkillHubSkillset(
+        slug="demo",
+        display_name="演示",
+        display_name_en="Demo",
+        scene="tech",
+        content="## 步骤 1：巡检集群\n输出健康报告。",
+    )
+
+    preview = item.api_dict(include_content=True)
+    listing = item.api_dict()
+
+    assert len(listing["task_examples"]["zh"]) == 3
+    assert preview["task_examples"]["zh"][0].startswith("每天「09:00」")
+    assert "巡检集群" in preview["task_examples"]["zh"][0]
+
+
 def test_browse_skillsets_filters_by_scene(monkeypatch) -> None:
     from octop.infra.agents.experts import skillhub_market
 

--- a/tests/unit/agents/test_workspace_dir.py
+++ b/tests/unit/agents/test_workspace_dir.py
@@ -107,3 +107,19 @@ def test_workspace_dir_from_config_roundtrip(tmp_path: Path) -> None:
     host = default_agent_workspace_dir(paths, "RT001", cfg=cfg)
     cfg["workspace_dir"] = scoped_workspace_dir_str("RT001")
     assert workspace_dir_from_config(cfg, paths=paths, agent_id="RT001") == host.resolve()
+
+
+def test_workspace_dir_from_config_ensure_false_does_not_mkdir(tmp_path: Path) -> None:
+    paths = PathLayout(tmp_path / "octop-home")
+    missing = tmp_path / "gone" / "YZQ7X4"
+    cfg = {"workspace_dir": str(missing)}
+    out = workspace_dir_from_config(cfg, paths=paths, agent_id="YZQ7X4", ensure=False)
+    assert out == missing.resolve()
+    assert not missing.exists()
+
+
+def test_default_workspace_ensure_false_does_not_mkdir(tmp_path: Path) -> None:
+    paths = PathLayout(tmp_path / "octop-home")
+    out = default_agent_workspace_dir(paths, "A1", ensure=False)
+    assert out == paths.agent_workspace("A1")
+    assert not out.exists()

--- a/tests/unit/api/test_chat_polish.py
+++ b/tests/unit/api/test_chat_polish.py
@@ -86,6 +86,19 @@ def test_serialize_history_message_includes_thinking_and_tools() -> None:
     assert failed_tool_result is not None
     assert failed_tool_result["content"][0]["error_code"] == "tool_error"
 
+    stream_error = _serialize_history_message(
+        AIMessage(
+            content="模型服务返回余额或额度不足。",
+            additional_kwargs={
+                "octop_stream_error": True,
+                "error_code": "TOKEN_QUOTA_EXCEEDED",
+            },
+        )
+    )
+    assert stream_error is not None
+    assert stream_error["status"] == "error"
+    assert stream_error["error_code"] == "TOKEN_QUOTA_EXCEEDED"
+
 
 def test_split_string_thinking_parses_redacted_block() -> None:
     from octop.api.routers.chat.serialize import _split_string_thinking

--- a/tests/unit/api/test_chat_welcome.py
+++ b/tests/unit/api/test_chat_welcome.py
@@ -12,9 +12,14 @@ from harness_agent.backends.workspace import BackendWorkspace
 
 from octop.infra.agents.experts.catalog import (
     ExpertCatalog,
+    default_task_examples,
     default_welcome_payload,
+    normalize_task_examples_for_display,
+    parse_task_examples,
+    read_workspace_manifest_task_examples,
     read_workspace_manifest_welcome,
     seed_expert_directory,
+    snap_task_examples,
     welcome_payload_has_content,
 )
 
@@ -123,3 +128,107 @@ def test_default_welcome_builtin_without_catalog() -> None:
     payload = default_welcome_payload(None)
     assert welcome_payload_has_content(payload)
     assert len(payload["quick_prompts"]) >= 1
+
+
+def test_parse_task_examples_missing_field_is_none() -> None:
+    assert parse_task_examples({"id": "demo"}) is None
+    assert parse_task_examples({"task_examples": "nope"}) is None
+
+
+def test_parse_task_examples_plain_string_list() -> None:
+    assert parse_task_examples({"task_examples": ["  早报  ", "", "复盘"]}) == {
+        "zh": ["早报", "复盘"],
+        "en": ["早报", "复盘"],
+    }
+
+
+def test_parse_task_examples_locale_keyed_lists() -> None:
+    assert parse_task_examples({"task_examples": {"zh": ["中文", " "], "en": ["English"]}}) == {
+        "zh": ["中文"],
+        "en": ["English"],
+    }
+
+
+def test_default_task_examples_are_six_and_named() -> None:
+    examples = default_task_examples("巡检专家", "Patrol Expert")
+    assert len(examples["zh"]) == 6
+    assert len(examples["en"]) == 6
+    assert "巡检专家" in examples["zh"][0]
+    assert "Patrol Expert" in examples["en"][0]
+
+
+def test_normalize_task_examples_for_display_keeps_three_or_six() -> None:
+    assert normalize_task_examples_for_display(None) is None
+    assert normalize_task_examples_for_display({"zh": ["a", "b"], "en": ["A"]}) == {
+        "zh": ["a", "b"],
+        "en": ["A"],
+    }
+    assert normalize_task_examples_for_display(
+        {"zh": ["1", "2", "3", "4", "5"], "en": ["a", "b", "c", "d", "e"]}
+    ) == {"zh": ["1", "2", "3"], "en": ["a", "b", "c"]}
+    assert (
+        len(
+            normalize_task_examples_for_display(
+                {"zh": [str(i) for i in range(8)], "en": [str(i) for i in range(8)]}
+            )["zh"]
+        )
+        == 6
+    )
+
+
+def test_snap_task_examples_keeps_three_or_six() -> None:
+    fillers_zh = [f"补位中文 {idx}" for idx in range(1, 7)]
+    fillers_en = [f"filler {idx}" for idx in range(1, 7)]
+    three = snap_task_examples(
+        ["每天巡检"],
+        ["Daily patrol"],
+        fillers_zh=fillers_zh,
+        fillers_en=fillers_en,
+    )
+    assert three == {
+        "zh": ["每天巡检", "补位中文 1", "补位中文 2"],
+        "en": ["Daily patrol", "filler 1", "filler 2"],
+    }
+    six = snap_task_examples(
+        ["a", "b", "c", "d"],
+        ["A", "B", "C", "D"],
+        fillers_zh=fillers_zh,
+        fillers_en=fillers_en,
+    )
+    assert len(six["zh"]) == 6
+    assert six["zh"][:4] == ["a", "b", "c", "d"]
+
+
+def test_parse_task_examples_empty_lists_stay_present() -> None:
+    assert parse_task_examples({"task_examples": []}) == {"zh": [], "en": []}
+    assert parse_task_examples({"task_examples": {"zh": [], "en": []}}) == {
+        "zh": [],
+        "en": [],
+    }
+
+
+@pytest.mark.asyncio
+async def test_read_workspace_manifest_task_examples() -> None:
+    with tempfile.TemporaryDirectory() as ws_dir:
+        workspace = _workspace(ws_dir)
+        await workspace.awrite_text(
+            ".octop/manifest.json",
+            json.dumps({"id": "demo", "task_examples": {"zh": ["巡检"], "en": ["Patrol"]}}),
+            force=True,
+        )
+        assert await read_workspace_manifest_task_examples(workspace) == {
+            "zh": ["巡检"],
+            "en": ["Patrol"],
+        }
+
+
+@pytest.mark.asyncio
+async def test_read_workspace_manifest_task_examples_missing() -> None:
+    with tempfile.TemporaryDirectory() as ws_dir:
+        workspace = _workspace(ws_dir)
+        await workspace.awrite_text(
+            ".octop/manifest.json",
+            json.dumps({"id": "demo"}),
+            force=True,
+        )
+        assert await read_workspace_manifest_task_examples(workspace) is None

--- a/tests/unit/backup/test_system_archive.py
+++ b/tests/unit/backup/test_system_archive.py
@@ -166,6 +166,43 @@ def test_backup_packs_config_workspace_dir(layout: PathLayout, tmp_path: Path) -
     assert not (layout.agent_workspace("agent01") / "SOUL.md").exists()
 
 
+def test_backup_skips_unwritable_workspace_dir(layout: PathLayout, tmp_path: Path) -> None:
+    """Stale host paths (e.g. former /root/.octop/agents/…) must not abort backup."""
+    pool = SqlitePool(layout.db)
+    run_migrations(pool)
+    reachable = layout.ensure_agent_workspace("ok01")
+    (reachable / "keep.txt").write_text("ok", encoding="utf-8")
+    blocker = tmp_path / "not-a-dir"
+    blocker.write_text("x", encoding="utf-8")
+    stale = blocker / "YZQ7X4"
+
+    class OkRow:
+        agent_id = "ok01"
+        name = "Ok"
+
+    class StaleRow:
+        agent_id = "YZQ7X4"
+        name = "Stale"
+        config_json = json.dumps({"workspace_dir": str(stale)})
+
+    archive = tmp_path / "skip-stale-ws.tar.gz"
+    create_system_backup(
+        paths=layout,
+        agent_rows=[StaleRow(), OkRow()],
+        pool=pool,
+        db_config=DatabaseConfig(),
+        dest=archive,
+    )
+    pool.close()
+
+    assert archive.is_file()
+    assert not stale.exists()
+    with tarfile.open(archive, mode="r:gz") as tf:
+        names = tf.getnames()
+    assert "workspaces/ok01/keep.txt" in names
+    assert not any(name.startswith("workspaces/YZQ7X4/") for name in names)
+
+
 def test_backup_skips_junk_directories(layout: PathLayout, tmp_path: Path) -> None:
     pool = SqlitePool(layout.db)
     run_migrations(pool)

--- a/tests/unit/gateway/test_history_projection.py
+++ b/tests/unit/gateway/test_history_projection.py
@@ -5,7 +5,11 @@ import asyncio
 import pytest
 
 from octop.infra.gateway.history_backfill import HistoryBackfillQueue
-from octop.infra.gateway.process.history_projection import TurnHistoryTracker
+from octop.infra.gateway.process.history_projection import (
+    TurnHistoryTracker,
+    _wire_text,
+)
+from octop.infra.gateway.process.message_keys import STREAM_ERROR_FLAG
 
 
 def test_turn_tracker_keeps_only_latest_user_turn_and_dedupes_replay() -> None:
@@ -22,6 +26,50 @@ def test_turn_tracker_keeps_only_latest_user_turn_and_dedupes_replay() -> None:
     tracker.observe({"type": "state_update", "data": {"messages": state}})
 
     assert [item.message_id for item in tracker.inputs] == ["u2", "a2"]
+
+
+def test_turn_tracker_keeps_streamed_tokens_and_error() -> None:
+    tracker = TurnHistoryTracker.from_request(
+        {"messages": [{"role": "user", "content": "continue this", "id": "u1"}]}
+    )
+    tracker.observe({"type": "token", "content": "partial "})
+    tracker.observe({"type": "token", "content": "answer"})
+    tracker.observe(
+        {
+            "type": "error",
+            "message": "模型服务返回余额或额度不足。",
+            "error_code": "TOKEN_QUOTA_EXCEEDED",
+        }
+    )
+
+    texts = [_wire_text(item) for item in tracker.inputs]
+    assert any("continue this" in text for text in texts)
+    assert "partial answer" in texts
+    assert any("余额或额度不足" in text for text in texts)
+    error = next(item for item in tracker.inputs if "余额或额度不足" in _wire_text(item))
+    assert STREAM_ERROR_FLAG in error.message_json
+
+
+def test_turn_tracker_does_not_duplicate_state_assistant() -> None:
+    tracker = TurnHistoryTracker.from_request(
+        {"messages": [{"role": "user", "content": "hi", "id": "u1"}]}
+    )
+    tracker.observe({"type": "token", "content": "hello"})
+    tracker.observe(
+        {
+            "type": "state_snapshot",
+            "data": {
+                "messages": [
+                    {"role": "user", "content": "hi", "id": "u1"},
+                    {"role": "assistant", "content": "hello world", "id": "a1"},
+                ]
+            },
+        }
+    )
+
+    texts = [_wire_text(item) for item in tracker.inputs]
+    assert texts.count("hello") == 0
+    assert any(text == "hello world" for text in texts)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/gateway/test_processor_resource_errors.py
+++ b/tests/unit/gateway/test_processor_resource_errors.py
@@ -1,7 +1,21 @@
 """Resource-policy stream error projection tests."""
 
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import AsyncIterator, Callable
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from harness_gateway.models import ChannelSubject, InboundMessage, TextContent
+
 from octop.infra.errors import ErrorCode, OctopError
-from octop.infra.gateway.process.processor import _stream_error
+from octop.infra.gateway.process.history_projection import _wire_text
+from octop.infra.gateway.process.processor import GlobalProcessor, _stream_error
+from octop.infra.gateway.slash.dispatcher import SlashDispatcher
+from octop.infra.gateway.ws import WS_CHANNEL_ID
 
 
 def test_stream_error_preserves_resource_error_code() -> None:
@@ -15,3 +29,104 @@ def test_stream_error_preserves_resource_error_code() -> None:
 
     assert code == "TOKEN_QUOTA_EXCEEDED"
     assert "12/10" in message
+
+
+def _processor_with_stream(
+    stream: Callable[..., AsyncIterator[dict[str, Any]]],
+) -> tuple[GlobalProcessor, InboundMessage, list[list[Any]]]:
+    appended: list[list[Any]] = []
+
+    agent_manager = MagicMock()
+    agent_manager.stream = stream
+    agent_manager.merge_turn_mcp_servers = MagicMock(return_value=None)
+    agent_manager.prepare_chat_mcp = AsyncMock(return_value=[])
+
+    agent_row = MagicMock()
+    agent_row.user_id = 1
+    agent_row.config_json = "{}"
+    agent_row.system_prompt = None
+    agent_row.default_model = None
+    agent_repo = MagicMock()
+    agent_repo.get = MagicMock(return_value=agent_row)
+
+    thread_message_repo = MagicMock()
+    thread_message_repo.append_if_ready.side_effect = lambda _thread_id, inputs: (
+        appended.append(list(inputs)) or len(inputs)
+    )
+
+    processor = GlobalProcessor(
+        agent_manager=agent_manager,
+        thread_registry=MagicMock(),
+        audit_repo=MagicMock(),
+        agent_repo=agent_repo,
+        user_repo=MagicMock(),
+        connector_repo=MagicMock(),
+        dispatcher=SlashDispatcher(),
+        usage_repo=None,
+        gateway=None,
+        thread_message_repo=thread_message_repo,
+    )
+    processor._record_stream_error = AsyncMock()
+    msg = InboundMessage(
+        channel_id=WS_CHANNEL_ID,
+        channel_type="dashboard",
+        tenant_id="agent-1",
+        channel_subject=ChannelSubject(subject_id="1"),
+        content=[TextContent(text="continue this")],
+        metadata={"session_key": "sk", "thread_id": "thread-1"},
+    )
+    return processor, msg, appended
+
+
+@pytest.mark.asyncio
+async def test_iter_turn_chunks_persists_partial_output_and_error() -> None:
+    async def stream(*_args: object, **_kwargs: object) -> AsyncIterator[dict[str, Any]]:
+        yield {"type": "token", "content": "partial answer"}
+        raise RuntimeError("Error code: 402 insufficient balance")
+
+    processor, msg, appended = _processor_with_stream(stream)
+    chunks = [chunk async for chunk in processor.iter_turn_chunks(msg)]
+
+    assert any(chunk.get("type") == "error" for chunk in chunks)
+    assert chunks[-1]["type"] == "done"
+    assert appended
+    texts = [_wire_text(item) for item in appended[0]]
+    assert any("continue this" in text for text in texts)
+    assert "partial answer" in texts
+    assert any("余额" in text or "insufficient" in text.lower() for text in texts)
+    assert any(
+        json.loads(item.message_json)["data"]["additional_kwargs"].get("octop_stream_error")
+        for item in appended[0]
+        if "余额" in _wire_text(item) or "insufficient" in _wire_text(item).lower()
+    )
+    processor._thread_registry.touch_last_active.assert_called_with("thread-1")
+
+
+@pytest.mark.asyncio
+async def test_iter_turn_chunks_persists_streamed_tokens_without_state() -> None:
+    async def stream(*_args: object, **_kwargs: object) -> AsyncIterator[dict[str, Any]]:
+        yield {"type": "token", "content": "partial answer"}
+
+    processor, msg, appended = _processor_with_stream(stream)
+    chunks = [chunk async for chunk in processor.iter_turn_chunks(msg)]
+
+    assert not any(chunk.get("type") == "error" for chunk in chunks)
+    assert chunks[-1]["type"] == "done"
+    texts = [_wire_text(item) for item in appended[0]]
+    assert any("continue this" in text for text in texts)
+    assert "partial answer" in texts
+
+
+@pytest.mark.asyncio
+async def test_iter_turn_chunks_persists_partial_when_cancelled() -> None:
+    async def stream(*_args: object, **_kwargs: object) -> AsyncIterator[dict[str, Any]]:
+        yield {"type": "token", "content": "partial answer"}
+        raise asyncio.CancelledError
+
+    processor, msg, appended = _processor_with_stream(stream)
+    with pytest.raises(asyncio.CancelledError):
+        _ = [chunk async for chunk in processor.iter_turn_chunks(msg)]
+
+    texts = [_wire_text(item) for item in appended[0]]
+    assert any("continue this" in text for text in texts)
+    assert "partial answer" in texts

--- a/tests/unit/gateway/test_versioned_history.py
+++ b/tests/unit/gateway/test_versioned_history.py
@@ -672,6 +672,58 @@ async def test_write_failure_does_not_deliver_or_retry_uncommitted_content(archi
 
 
 @pytest.mark.asyncio
+async def test_dashboard_error_keeps_partial_tokens_and_error(archive):
+    from unittest.mock import AsyncMock, MagicMock
+
+    from harness_gateway.models import ChannelSubject, InboundMessage, TextContent
+
+    from octop.infra.gateway.process.processor import GlobalProcessor
+    from octop.infra.gateway.slash.dispatcher import SlashDispatcher
+    from octop.infra.gateway.ws import WS_CHANNEL_ID
+
+    async def stream(*_args, **_kwargs):
+        yield {"type": "token", "message_id": "m", "content": "partial answer"}
+        raise RuntimeError("Error code: 402 insufficient balance")
+
+    manager = MagicMock()
+    manager.stream = stream
+    manager.merge_turn_mcp_servers.return_value = None
+    manager.prepare_chat_mcp = AsyncMock(return_value=[])
+    processor = GlobalProcessor(
+        agent_manager=manager,
+        thread_registry=MagicMock(),
+        audit_repo=MagicMock(),
+        agent_repo=MagicMock(),
+        user_repo=MagicMock(),
+        connector_repo=MagicMock(),
+        dispatcher=SlashDispatcher(),
+        thread_message_repo=archive.messages,
+        history_archive=archive,
+    )
+    processor._record_stream_error = AsyncMock()
+    msg = InboundMessage(
+        channel_id=WS_CHANNEL_ID,
+        channel_type="dashboard",
+        tenant_id="a",
+        channel_subject=ChannelSubject(subject_id="1"),
+        content=[TextContent(text="question")],
+        metadata={"session_key": "s", "thread_id": "t"},
+    )
+    delivered = [chunk async for chunk in processor.iter_turn_chunks(msg)]
+    assert any(chunk.get("type") == "error" for chunk in delivered)
+    history = (await archive.page("t", limit=20, cursor=None, legacy_reader=no_anchor))["messages"]
+    recovered = messages_from_dict(history)
+    texts = [str(message.content) for message in recovered]
+    assert any("question" in text for text in texts)
+    assert "partial answer" in texts
+    error = next(
+        message for message in recovered if message.additional_kwargs.get("octop_stream_error")
+    )
+    assert "余额" in str(error.content) or "insufficient" in str(error.content).lower()
+    assert archive.store.turn("t")["status"] == "failed"
+
+
+@pytest.mark.asyncio
 async def test_im_projection_commits_back_to_back_fragments_before_delivery(archive):
     from types import SimpleNamespace
 

--- a/uv.lock
+++ b/uv.lock
@@ -2503,7 +2503,7 @@ wheels = [
 
 [[package]]
 name = "octop"
-version = "0.9.32"
+version = "0.9.33"
 source = { editable = "." }
 dependencies = [
     { name = "acme" },


### PR DESCRIPTION
## Summary
- 中断或模型失败时，把已流出的 token / reasoning 和错误气泡写入会话历史，刷新后仍能看到半成品回复。
- 专家 `manifest.json` 增加 `task_examples`（欢迎页、任务空态、专家市场共用）；无字段时沿用仪表盘默认卡片。
- 系统备份遇到过期/不可写的 `workspace_dir` 时跳过该工作区，不再 `mkdir` 污染宿主机。

头像列改动已在 #653，本 PR 刻意不包含，避免重复冲突。

## Test plan
- [ ] 对话中途点停止：刷新后仍能看到已生成的部分回复
- [ ] 触发额度/余额类流错误：历史里出现带 `status=error` 的助手气泡
- [ ] 打开带 `task_examples` 的专家「任务」空态：卡片文案来自 manifest（3 或 6 张）
- [ ] 无 `task_examples` 字段的工作区：仍显示默认 3 张建议
- [ ] 专家市场详情抽屉能看到「计划任务示例」
- [ ] 备份含失效 workspace 路径的 agent 时，归档成功且不创建该路径


Made with [Cursor](https://cursor.com)