### PR TITLE
fix(chat): restore history timestamps and align user bubbles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@
 
 ## [Unreleased]
 
+### 修复
+
+- 刷新会话后消息时间戳不再丢失：当前轮投影补写 `checkpoint_ts`，历史接口缺戳时回退 `created_at`
+- 用户头像与输入气泡对齐，不再跟上方面板 chip 齐平；复制/编辑改到时间左侧同一行
+
+### 变更
+
+- README / README_CN 补齐知识库、插件、PostgreSQL、WebSocket 与 `octop update` 说明
+
 ## [0.9.33] - 2026-09-11
 
 ### 新增

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 <p align="center">
   <a href="https://www.python.org/downloads/"><img alt="Python 3.12+" src="https://img.shields.io/badge/python-3.12%2B-blue?logo=python&logoColor=white" /></a>
   <a href="https://github.com/TencentCloud/Octop/blob/main/LICENSE"><img alt="License: MIT" src="https://img.shields.io/badge/license-MIT-green" /></a>
-  <a href="https://github.com/TencentCloud/Octop/releases"><img alt="Version" src="https://img.shields.io/badge/version-0.9.32-orange" /></a>
+  <a href="https://github.com/TencentCloud/Octop/releases"><img alt="Version" src="https://img.shields.io/badge/version-0.9.33-orange" /></a>
   <a href="https://pypi.org/project/octop/"><img src="https://img.shields.io/pypi/v/octop" alt="PyPI" /></a>
   <a href="https://github.com/astral-sh/ruff"><img alt="Code Style: Ruff" src="https://img.shields.io/badge/code%20style-ruff-000000?logo=ruff&logoColor=white" /></a>
   <a href="https://github.com/TencentCloud/Octop"><img alt="GitHub stars" src="https://img.shields.io/github/stars/TencentCloud/Octop?style=social" /></a>
@@ -35,7 +35,7 @@
 
 **Octop** is an open-source, self-hosted AI assistant. It's not just a tool — it's a digital life form that can operate in parallel. Through its multi-agent architecture, it builds an intelligent environment that is both independent and collaborative for teams, families, and individuals. Best of all, it runs entirely on your machine — the fully self-hosted design means privacy is never a compromise, while single-process startup makes the powerful web console, CLI, and IM integrations readily accessible.
 
-Chat through the Web Dashboard, Feishu, DingTalk, QQ, Discord, WeCom, or programmatic HTTP/SSE. Extend capabilities with the **expert library**, **Connectors** (OAuth + MCP), and **ACP** integration for IDE workflows.
+Chat through the Web Dashboard, Feishu, DingTalk, QQ, Discord, WeCom, or programmatic HTTP/SSE/WebSocket. Extend capabilities with the **expert library**, **Connectors** (OAuth + MCP), and **ACP** integration for IDE workflows.
 
 ## ✨ Highlights
 
@@ -47,6 +47,8 @@ Chat through the Web Dashboard, Feishu, DingTalk, QQ, Discord, WeCom, or program
 | 🔌 | **Connector ecosystem** | Tencent suite (Docs, Weibo trends, News, …); OAuth and MCP gateway extend resource boundaries |
 | 💾 | **Pluggable backends** | Local disk, Docker containers, PostgreSQL, or COS/S3 — AI operates inside isolated boundaries |
 | 🧠 | **Portable memory** | Powered by harness-memory; memory migrates with the workspace |
+| 📚 | **Knowledge base** | RAG over your documents; semantic retrieval grounds agent answers in your private corpus |
+| 🧩 | **Plugins** | Extend Octop with third-party plugins; bundled plugins are seeded and toggled on demand |
 | ↔️ | **ACP bidirectional** | `octop acp` for IDE/terminal AI; delegate to OpenCode / Claude Code with permission gates |
 | 💻 | **Terminal AI+** | Interactive shell in the browser — AI-assisted command execution and troubleshooting |
 | 🌐 | **Browser AI+** | Headless Chromium sessions for web automation, screenshots, and remote browsing |
@@ -55,9 +57,21 @@ Chat through the Web Dashboard, Feishu, DingTalk, QQ, Discord, WeCom, or program
 
 ## 📌 Overview
 
-Octop is a self-hosted AI assistant platform for households and small teams. It runs a single process that serves a web dashboard, a CLI, IM channels (Feishu, DingTalk, QQ, Discord, WeCom, and more), and cron automation — all sharing one SQLite database under `~/.octop/`.
+Octop is a self-hosted AI assistant platform for households and small teams. It runs a single process that serves a web dashboard, a CLI, IM channels (Feishu, DingTalk, QQ, Discord, WeCom, and more), and cron automation — all sharing one control-plane database under `~/.octop/` (SQLite by default; PostgreSQL optional).
 
 > Octop's design goal: keep every conversation, workspace, and credential on your own machine, while giving each user a personal team of specialized agents they can switch between per task.
+
+<details>
+<summary>🐾 What can you do with Octop</summary>
+
+- **Personal assistant** — let a dedicated agent write weekly reports, organize notes, and manage your schedule; memory persists with the workspace.
+- **Family sharing** — one admin account, the whole household; assign different agents and experts per member.
+- **Team helper** — multiple agents collaborate in parallel, bridging Feishu / DingTalk / WeCom to route tasks into group chats.
+- **Developer boost** — delegate coding tasks to OpenCode / Claude Code via ACP, or troubleshoot from the terminal with AI assistance.
+- **Web automation** — use Browser AI+ to fill forms, capture screenshots, and gather public info.
+- **Scheduled tasks** — configure cron in natural language so the agent pushes or runs jobs on time every day.
+
+</details>
 
 ## 🧠 Core Technology
 
@@ -67,7 +81,7 @@ Octop is a self-hosted AI assistant platform for households and small teams. It 
 | **Web framework** | FastAPI + uvicorn |
 | **Agent runtime** | harness-agent |
 | **Gateway** | harness-gateway |
-| **Control plane DB** | SQLite (WAL) via aiosqlite |
+| **Control plane DB** | SQLite (WAL, default) or PostgreSQL (optional) |
 | **Frontend** | React 18 + TypeScript + Vite + Ant Design |
 | **Scheduling** | APScheduler |
 | **ACP** | agent-client-protocol |
@@ -80,7 +94,7 @@ Octop is built on the Harness stack — a set of focused runtimes that Octop com
 - **harness-memory** — hierarchical recall with full-text search, so an agent's memory travels with its workspace.
 - **harness-browser** — CDP-based browser automation with persistent profiles for web tasks.
 
-Instead of an external queue or message broker, Octop routes every surface — Web UI, IM, and cron — through one in-process `HarnessProcessor`. The result is a single, restart-safe process whose entire state is rebuilt from `~/.octop/octop.db` on boot.
+Instead of an external queue or message broker, Octop routes every surface — Web UI, IM, and cron — through one in-process `HarnessProcessor`. The result is a single, restart-safe process whose entire state is rebuilt from the control-plane database on boot (local SQLite by default; PostgreSQL optional).
 
 ## 🤔 Features
 
@@ -103,7 +117,11 @@ Instead of an external queue or message broker, Octop routes every surface — W
 ### Surfaces
 - **Web dashboard** — chat, agents, connectors, channels, cron, settings
 - **CLI** — `octop run`, `octop chat`, `octop acp`, admin commands
-- **HTTP/SSE API** — full programmatic access
+- **HTTP/SSE/WebSocket API** — full programmatic access
+
+### Knowledge & plugins
+- **Knowledge base** — RAG over your documents; upload files and let semantic retrieval ground agent answers in your private corpus
+- **Plugins** — install and manage third-party plugins (`octop plugin`); bundled plugins are seeded and toggled on demand from the dashboard
 
 ### ACP (Agent Client Protocol)
 
@@ -141,6 +159,7 @@ This roadmap may shift as the community grows; treat it as indicative only.
 
 - **macOS / Linux / Windows**
 - No pre-installed Python required — the installer uses [uv](https://docs.astral.sh/uv/) to provision Python 3.12 in an isolated venv under `~/.octop/`
+- A modern multi-core CPU with a few GB of RAM for the process plus model/embedding caches; enough disk for the database, agent workspaces, and document corpora
 
 ### 1. Install
 
@@ -267,6 +286,7 @@ See [`.env.example`](.env.example) for the full list.
 - [Overview](#-overview)
 - [Core Technology](#-core-technology)
 - [Features](#-features)
+- [Roadmap](#-roadmap)
 - [Quick Start](#-quick-start)
 - **Deploy & Use**
   - [Install options](#-install-options)
@@ -279,7 +299,6 @@ See [`.env.example`](.env.example) for the full list.
   - [Project layout](#-project-layout)
   - [Development](#-development)
 - **Project Info**
-  - [Roadmap](#-roadmap)
   - [Security & privacy](#-security--privacy)
   - [Contributing](#-contributing)
   - [Changelog](#-changelog)
@@ -299,6 +318,16 @@ See [`.env.example`](.env.example) for the full list.
 | Docker | Any | `docker/docker-compose.yml` |
 
 All install scripts provision an isolated environment at `~/.octop/venv` and a `~/.octop/bin/octop` wrapper — they do not touch system Python.
+
+### Upgrade
+
+`octop update` replaces only the wheel/binary — your `~/.octop/` database, workspaces, secrets, and `config.json` are preserved:
+
+```bash
+octop update          # fetch and install the latest octop, then restart the service if one is registered
+```
+
+The schema migrates automatically on next boot; run `octop init` only if the setup wizard prompts for a migration. Always back up first (`octop backup`) before a cross-version upgrade.
 
 ## ⚙️ Configuration
 
@@ -354,6 +383,7 @@ OpenAI-compatible APIs, DashScope (Qwen), Ollama, and other presets — configur
 | `octop cron` | Manage scheduled tasks |
 | `octop models` | Provider presets and model resolution |
 | `octop skills` | Enable/disable per-agent skills |
+| `octop plugin` | Install and manage third-party plugins |
 | `octop backup` | Export / restore backups |
 | `octop clean` | Remove CLI state or wipe `~/.octop/` |
 | `octop update` | Check for and install updates |
@@ -373,6 +403,8 @@ After `octop run`, open **http://127.0.0.1:8088**.
 - **Connectors** — OAuth apps and MCP gateways
 - **Channels** — IM platform setup
 - **Cron** — visual cron job management
+- **Knowledge base** — manage document corpora and semantic retrieval
+- **Plugins** — install, enable, and configure plugins
 - **ACP** — configure outbound coding-agent runners
 - **Settings** — users, security, TLS, system
 
@@ -382,6 +414,7 @@ Interactive API docs: **http://127.0.0.1:8088/api/docs** (disabled by default �
 
 ```
 ~/.octop/                          ← install & data root
+├── config.json                    # process config (optional database section)
 ├── octop.db                       # SQLite — users, agents, channels, cron, …
 ├── secrets/                       # JWT secret, channel tokens
 ├── agents/<agent_id>/             # per-agent workspace (SOUL.md, skills, …)
@@ -391,13 +424,15 @@ Interactive API docs: **http://127.0.0.1:8088/api/docs** (disabled by default �
 └── bin/octop                      # PATH wrapper → venv/bin/octop
 ```
 
+The control plane can also use PostgreSQL — set `database` in `config.json`, or `OCTOP_DATABASE_*` / the first-run wizard. With PostgreSQL, agent memory reuses the same DSN by default (per-agent schema); to keep file-based memory, set `"memory": { "backend": { "type": "sqlite" } }` in the agent config. See [docs/configuration.md](docs/configuration.md) and [docs/adr/002-database-backends.md](docs/adr/002-database-backends.md).
+
 See [docs/configuration.md](docs/configuration.md) for env vars and `config.json`.
 
 ## 🏗️ Architecture
 
 ```
 OctopServer
- ├─ SqlitePool               SQLite (WAL mode)
+ ├─ DatabasePool            SQLite (WAL) or PostgreSQL
  ├─ SharedServices       DI root — every repo + config
  ├─ ExpertCatalog        scans agents/experts/library/ at boot
  ├─ UserManager
@@ -410,9 +445,9 @@ OctopServer
  └─ FastAPI app (uvicorn)
 ```
 
-Single process. Restart rebuilds state from `~/.octop/octop.db`.
+Single process. Restart rebuilds state from the control-plane database (local SQLite by default; PostgreSQL optional).
 
-See [docs/architecture.md](docs/architecture.md) and [docs/adr/001-single-process-model.md](docs/adr/001-single-process-model.md).
+See [docs/architecture.md](docs/architecture.md), [docs/adr/001-single-process-model.md](docs/adr/001-single-process-model.md), and [docs/adr/002-database-backends.md](docs/adr/002-database-backends.md).
 
 ## 📁 Project layout
 
@@ -452,6 +487,7 @@ Individual targets: `make test`, `make lint`, `make typecheck`, `make format`.
 
 - **Local-first**: Config, chats, workspaces, and credentials live under `~/.octop/` on your machine.
 - **Multi-user isolation**: JWT auth with per-user agents and workspaces.
+- **PII redaction & tool approval**: sensitive data is redacted before it leaves the workspace, and risky tools or shell commands require explicit approval under the guardrail rules.
 - **Tool guardrails**: User-editable shell command rules under `~/.octop/security/tool_guard/`.
 - **No vendor lock-in**: Swap LLM providers, storage backends, and channels without rewriting agents.
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -9,6 +9,7 @@
 <p align="center">
   <a href="https://www.python.org/downloads/"><img alt="Python 3.12+" src="https://img.shields.io/badge/python-3.12%2B-blue?logo=python&logoColor=white" /></a>
   <a href="https://github.com/TencentCloud/Octop/blob/main/LICENSE"><img alt="License: MIT" src="https://img.shields.io/badge/license-MIT-green" /></a>
+  <a href="https://github.com/TencentCloud/Octop/releases"><img alt="Version" src="https://img.shields.io/badge/version-0.9.33-orange" /></a>
   <a href="https://pypi.org/project/octop/"><img src="https://img.shields.io/pypi/v/octop" alt="PyPI" /></a>
   <a href="https://github.com/astral-sh/ruff"><img alt="Code Style: Ruff" src="https://img.shields.io/badge/code%20style-ruff-000000?logo=ruff&logoColor=white" /></a>
   <a href="https://github.com/TencentCloud/Octop"><img alt="GitHub stars" src="https://img.shields.io/github/stars/TencentCloud/Octop?style=social" /></a>
@@ -36,7 +37,7 @@
 
 **Octop** 是一个开源、自托管的 AI 助手。它不仅是工具，更是可并行运作的数字生命体。通过多 Agent 架构，它为团队、家庭和个人构建了既独立又协作的智能环境。并且这一切都运行在你的机器上——完全自托管的设计让隐私不再是妥协，而单进程启动的便捷性，则让强大的 Web 控制台、CLI 与 IM 集成触手可及。
 
-借助飞书、钉钉、QQ、Discord、企业微信或 HTTP/SSE API 与任意 Agent 对话；通过**专家库**一键创建专业角色，通过 **Connector**（OAuth + MCP）接入外部服务，通过 **ACP** 与 IDE / 终端 AI 工具双向协作。
+借助飞书、钉钉、QQ、Discord、企业微信或 HTTP/SSE/WebSocket API 与任意 Agent 对话；通过**专家库**一键创建专业角色，通过 **Connector**（OAuth + MCP）接入外部服务，通过 **ACP** 与 IDE / 终端 AI 工具双向协作。
 
 > Octop 的设计目标：让每一次对话、工作区与凭据都留在你自己的机器上，同时为每个用户配备一组可按场景切换的专业 Agent。
 
@@ -50,6 +51,8 @@
 | 🔌 | **Connector 拓展体系** | 一键接入腾讯全家桶（文档 / 微博 / 新闻等），OAuth 与 MCP 网关轻松扩展 |
 | 💾 | **可插拔后端存储** | 本地目录、Docker 容器、PostgreSQL 或 COS/S3，AI 在隔离边界内操作 |
 | 🧠 | **可迁移记忆系统** | 基于 harness-memory，记忆随工作区迁移 |
+| 📚 | **知识库** | 基于文档的 RAG 检索，让 Agent 的回答锚定你的私有知识库 |
+| 🧩 | **插件** | 支持第三方插件扩展；内置插件随安装注入，按需一键启用 |
 | ↔️ | **ACP 双向集成** | `octop acp` 增强 IDE 与终端 AI；对话中委派 OpenCode / Claude Code 等 |
 | 💻 | **终端 AI+** | 浏览器内交互式 Shell，AI 辅助命令执行与排障 |
 | 🌐 | **浏览器 AI+** | 基于 Chromium 的无头浏览器会话，支持网页自动化、截图与远程操控 |
@@ -116,6 +119,10 @@ Octop 不依赖外部消息队列或中间件，而是通过进程内的 `Harnes
 - **CLI** — `octop run`、`octop chat`、`octop acp`、管理命令
 - **HTTP/SSE/WebSocket API** — 完整的程序化访问能力
 
+### 知识库与插件
+- **知识库** — 基于文档的 RAG 检索；上传文件后，语义检索让 Agent 的回答锚定你的私有知识库
+- **插件** — 安装并管理第三方插件（`octop plugin`）；内置插件随安装注入，按需在控制台一键启用
+
 ### ACP（Agent Client Protocol）
 
 Octop 支持两个方向的 ACP 集成：
@@ -152,6 +159,7 @@ Octop 支持两个方向的 ACP 集成：
 
 - **macOS / Linux / Windows**
 - 无需预先安装 Python — 安装脚本通过 [uv](https://docs.astral.sh/uv/) 在 `~/.octop/` 下创建隔离的 Python 3.12 虚拟环境
+- 现代多核 CPU，并预留数 GB 内存供进程与模型/Embedding 缓存使用；磁盘需容纳数据库、Agent 工作区与文档语料
 
 ### 1. 安装
 
@@ -271,6 +279,7 @@ docker run -d \
 - [概述](#-概述)
 - [核心技术](#-核心技术)
 - [功能特性](#-功能特性)
+- [规划](#-规划)
 - [快速开始](#-快速开始)
 - **部署与使用**
   - [安装方式](#-安装方式)
@@ -283,7 +292,6 @@ docker run -d \
   - [项目结构](#-项目结构)
   - [开发](#-开发)
 - **项目信息**
-  - [规划](#-规划)
   - [安全与隐私](#-安全与隐私)
   - [参与贡献](#-参与贡献)
   - [更新日志](#-更新日志)
@@ -303,6 +311,16 @@ docker run -d \
 | Docker | 全平台 | `docker/docker-compose.yml` |
 
 所有安装脚本均在 `~/.octop/venv` 创建隔离环境，并通过 `~/.octop/bin/octop` 包装 CLI，不会影响系统 Python。
+
+### 升级
+
+`octop update` 只替换 wheel / 二进制，你的 `~/.octop/` 数据库、工作区、密钥与 `config.json` 均会保留：
+
+```bash
+octop update          # 获取并安装最新版 Octop，若已注册系统服务则自动重启
+```
+
+数据库结构会在下次启动时自动迁移；仅当设置向导提示需要迁移时才运行 `octop init`。跨版本升级前请务必先备份（`octop backup`）。
 
 ### ⚙️ 配置
 
@@ -358,6 +376,7 @@ OpenAI 兼容 API、DashScope（千问）、Ollama 等预设 — 在控制台或
 | `octop cron` | 管理定时任务 |
 | `octop models` | 供应商预设与模型解析 |
 | `octop skills` | 按 Agent 启用/禁用 Skill |
+| `octop plugin` | 安装并管理第三方插件 |
 | `octop backup` | 导出 / 恢复备份 |
 | `octop clean` | 清理 CLI 状态或清空 `~/.octop/` |
 | `octop update` | 检查并安装更新 |
@@ -377,6 +396,8 @@ OpenAI 兼容 API、DashScope（千问）、Ollama 等预设 — 在控制台或
 - **Connector** — OAuth 应用与 MCP 网关
 - **通道** — IM 平台配置
 - **定时任务** — 可视化 Cron 管理
+- **知识库** — 管理文档语料与语义检索
+- **插件** — 安装、启用与配置插件
 - **ACP** — 配置出站编程 Agent Runner
 - **设置** — 用户、安全、TLS、系统
 
@@ -460,6 +481,7 @@ cd dashboard && npx tsc --noEmit
 
 - **本地优先**：配置、对话、工作区与凭证均存储在 `~/.octop/`。
 - **多用户隔离**：JWT 认证，按用户隔离 Agent 与工作区。
+- **敏感信息脱敏与工具审批**：离开工作区前自动脱敏敏感数据；高风险工具或 Shell 命令需依据护栏规则显式审批。
 - **工具护栏**：可在 `~/.octop/security/tool_guard/` 编辑 Shell 命令规则。
 - **无厂商锁定**：可自由切换 LLM 供应商、存储后端与 IM 通道。
 

--- a/dashboard/src/pages/Chat/chatMessages.partial.less
+++ b/dashboard/src/pages/Chat/chatMessages.partial.less
@@ -278,6 +278,22 @@
   }
 }
 
+.userBubbleWithTags {
+  row-gap: 0;
+
+  .userComposerTags {
+    grid-column: 2;
+    grid-row: 1;
+    justify-self: end;
+    max-width: min(75%, 600px);
+  }
+
+  .bubbleContent,
+  .avatarCol {
+    grid-row: 2;
+  }
+}
+
 .assistantBubble {
   .bubbleContent {
     grid-column: 2;
@@ -1177,8 +1193,8 @@
 .msgTime {
   font-size: 10px;
   color: var(--fn-text-quaternary);
-  margin-top: 4px;
-  padding: 0 4px;
+  margin-top: 0;
+  padding: 0;
   user-select: none;
   display: flex;
   align-items: center;
@@ -1208,6 +1224,7 @@
 
 .msgMetaRowRight {
   justify-content: flex-end;
+  flex-wrap: nowrap;
 }
 
 .msgUsage {
@@ -1261,15 +1278,13 @@
   align-items: center;
   justify-content: flex-end;
   gap: 2px;
-  margin-top: 2px;
-  /* Stable 32px hit row so copy/edit stay easy to aim at. */
-  min-height: 32px;
+  margin: 0;
   padding: 0;
 
   .msgCopyBtn,
   .msgActionBtn {
-    width: 32px;
-    height: 32px;
+    width: 22px;
+    height: 22px;
     margin-left: 0;
     /* Invisible until hover/focus, but still receive clicks if aimed. */
     opacity: 0;
@@ -1297,11 +1312,11 @@
   }
 }
 
-/* Reveal when the user bubble is hovered/focused, not only the tiny buttons. */
-.userMsgColumn:hover .userMsgActions .msgCopyBtn,
-.userMsgColumn:hover .userMsgActions .msgActionBtn,
-.userMsgColumn:focus-within .userMsgActions .msgCopyBtn,
-.userMsgColumn:focus-within .userMsgActions .msgActionBtn,
+/* Reveal when the user bubble (or meta row) is hovered/focused. */
+.bubbleContent:hover .userMsgActions .msgCopyBtn,
+.bubbleContent:hover .userMsgActions .msgActionBtn,
+.bubbleContent:focus-within .userMsgActions .msgCopyBtn,
+.bubbleContent:focus-within .userMsgActions .msgActionBtn,
 .messageBubble:hover .userMsgActions .msgCopyBtn,
 .messageBubble:hover .userMsgActions .msgActionBtn {
   opacity: 1;

--- a/dashboard/src/pages/Chat/components/MessageBubble.tsx
+++ b/dashboard/src/pages/Chat/components/MessageBubble.tsx
@@ -16,8 +16,10 @@ import {
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 import type { ChatAttachment, ChatMessage } from "../hooks/useChat";
-import type { ComposerTagLookups } from "./UserMessageComposerTags";
-import UserMessageComposerTags from "./UserMessageComposerTags";
+import UserMessageComposerTags, {
+  hasUserComposerTags,
+  type ComposerTagLookups,
+} from "./UserMessageComposerTags";
 import { deriveMessageContent } from "../utils/messageContent";
 import { inferKindFromNameAndMime } from "../utils/chatAttachments";
 import { ChatMediaPlayer } from "./ChatMediaPlayer";
@@ -653,6 +655,8 @@ function MessageBubble({
   }
 
   const isUser = message.role === "user";
+  const showUserComposerTags =
+    isUser && !isEditing && hasUserComposerTags(message.composerContext);
   const isStreaming = message.status === "streaming";
   const hasToolData = !!message.toolData;
   const looksLikeStreamError =
@@ -746,12 +750,18 @@ function MessageBubble({
     <div
       className={`${styles.messageBubble} ${
         isUser ? styles.userBubble : styles.assistantBubble
-      } ${isError ? styles.errorBubble : ""} ${
-        compact ? styles.compactBubble : ""
-      }`}
+      } ${showUserComposerTags ? styles.userBubbleWithTags : ""} ${
+        isError ? styles.errorBubble : ""
+      } ${compact ? styles.compactBubble : ""}`}
     >
       {!isUser && senderAvatar ? (
         <div className={styles.avatarCol}>{senderAvatar}</div>
+      ) : null}
+      {showUserComposerTags ? (
+        <UserMessageComposerTags
+          context={message.composerContext}
+          lookups={composerLookups}
+        />
       ) : null}
       <div className={styles.bubbleContent}>
         {isUser ? (
@@ -792,78 +802,48 @@ function MessageBubble({
                   </div>
                 </div>
               ) : (
-                <>
-                  <UserMessageComposerTags
-                    context={message.composerContext}
-                    lookups={composerLookups}
-                  />
-                  <div className={styles.userText}>
-                    {imageAttachments.length > 0 && (
-                      <ImageGallery
-                        images={imageAttachments}
-                        agentId={agentId}
-                      />
-                    )}
-                    {videoAttachments.length > 0 && (
-                      <div className={styles.messageMediaList}>
-                        {videoAttachments.map((attachment, idx) => (
-                          <ChatMediaPlayer
-                            key={`${attachment.url}-${idx}`}
-                            url={attachment.url}
-                            filename={attachment.filename}
-                            workspacePath={attachment.workspacePath}
-                            mediaType={attachment.mediaType}
-                            kind="video"
-                            agentId={agentId}
-                          />
-                        ))}
-                      </div>
-                    )}
-                    {audioAttachments.length > 0 && (
-                      <div className={styles.messageMediaList}>
-                        {audioAttachments.map((attachment, idx) => (
-                          <ChatMediaPlayer
-                            key={`${attachment.url}-${idx}`}
-                            url={attachment.url}
-                            filename={attachment.filename}
-                            workspacePath={attachment.workspacePath}
-                            mediaType={attachment.mediaType}
-                            kind="audio"
-                            agentId={agentId}
-                          />
-                        ))}
-                      </div>
-                    )}
-                    {fileAttachments.length > 0 && (
-                      <FileAttachmentList
-                        files={fileAttachments}
-                        agentId={agentId}
-                      />
-                    )}
-                    {message.content && <div>{message.content}</div>}
-                  </div>
-                  {(message.content || onEditUserMessage) && (
-                    <div className={styles.userMsgActions} role="group">
-                      {message.content ? (
-                        <CopyButton text={message.content} />
-                      ) : null}
-                      {onEditUserMessage ? (
-                        <button
-                          className={styles.msgActionBtn}
-                          onClick={() => {
-                            setEditText(message.content);
-                            setIsEditing(true);
-                          }}
-                          title={t("common.edit")}
-                          type="button"
-                          aria-label={t("common.edit")}
-                        >
-                          <Pencil size={14} />
-                        </button>
-                      ) : null}
+                <div className={styles.userText}>
+                  {imageAttachments.length > 0 && (
+                    <ImageGallery images={imageAttachments} agentId={agentId} />
+                  )}
+                  {videoAttachments.length > 0 && (
+                    <div className={styles.messageMediaList}>
+                      {videoAttachments.map((attachment, idx) => (
+                        <ChatMediaPlayer
+                          key={`${attachment.url}-${idx}`}
+                          url={attachment.url}
+                          filename={attachment.filename}
+                          workspacePath={attachment.workspacePath}
+                          mediaType={attachment.mediaType}
+                          kind="video"
+                          agentId={agentId}
+                        />
+                      ))}
                     </div>
                   )}
-                </>
+                  {audioAttachments.length > 0 && (
+                    <div className={styles.messageMediaList}>
+                      {audioAttachments.map((attachment, idx) => (
+                        <ChatMediaPlayer
+                          key={`${attachment.url}-${idx}`}
+                          url={attachment.url}
+                          filename={attachment.filename}
+                          workspacePath={attachment.workspacePath}
+                          mediaType={attachment.mediaType}
+                          kind="audio"
+                          agentId={agentId}
+                        />
+                      ))}
+                    </div>
+                  )}
+                  {fileAttachments.length > 0 && (
+                    <FileAttachmentList
+                      files={fileAttachments}
+                      agentId={agentId}
+                    />
+                  )}
+                  {message.content && <div>{message.content}</div>}
+                </div>
               )}
             </div>
           </div>
@@ -968,15 +948,42 @@ function MessageBubble({
             )}
           </>
         )}
-        {/* Meta row: only show on the last message in a group (or standalone messages) */}
+        {/* Meta row: last-in-group only. User copy/edit sit left of the timestamp. */}
         {isLastInGroup &&
           !hasToolData &&
-          (message.timestamp > 0 || usageParts.length > 0) && (
+          (message.timestamp > 0 ||
+            usageParts.length > 0 ||
+            (isUser &&
+              !isEditing &&
+              Boolean(message.content || onEditUserMessage))) && (
             <div
               className={`${styles.msgMetaRow} ${
                 isUser ? styles.msgMetaRowRight : ""
               }`}
             >
+              {isUser &&
+                !isEditing &&
+                (message.content || onEditUserMessage) && (
+                  <div className={styles.userMsgActions} role="group">
+                    {message.content ? (
+                      <CopyButton text={message.content} />
+                    ) : null}
+                    {onEditUserMessage ? (
+                      <button
+                        className={styles.msgActionBtn}
+                        onClick={() => {
+                          setEditText(message.content);
+                          setIsEditing(true);
+                        }}
+                        title={t("common.edit")}
+                        type="button"
+                        aria-label={t("common.edit")}
+                      >
+                        <Pencil size={14} />
+                      </button>
+                    ) : null}
+                  </div>
+                )}
               {message.timestamp > 0 && (
                 <div
                   className={`${styles.msgTime} ${

--- a/dashboard/src/pages/Chat/components/UserMessageComposerTags.tsx
+++ b/dashboard/src/pages/Chat/components/UserMessageComposerTags.tsx
@@ -25,6 +25,17 @@ interface UserMessageComposerTagsProps {
   lookups?: ComposerTagLookups;
 }
 
+export function hasUserComposerTags(context?: UserComposerContext): boolean {
+  if (!context) return false;
+  return Boolean(
+    context.skills?.length ||
+      context.connectors?.length ||
+      context.knowledgeBaseIds?.length ||
+      context.targetAgents?.length ||
+      context.model,
+  );
+}
+
 export default function UserMessageComposerTags({
   context,
   lookups,

--- a/src/octop/api/routers/chat/serialize.py
+++ b/src/octop/api/routers/chat/serialize.py
@@ -18,10 +18,12 @@ from octop.api.common.agent_workspace import resolve_agent_workspace_dir
 from octop.i18n.domains.attachment import attachment_empty_image
 from octop.infra.agents.context_breakdown import usage_dict_from_message
 from octop.infra.gateway.process.message_keys import (
+    CHECKPOINT_TS_KEY,
     COMPOSER_CTX_KEY,
     INBOUND_ATTACHMENTS_KEY,
     STREAM_ERROR_CODE_KEY,
     STREAM_ERROR_FLAG,
+    parse_checkpoint_ts_ms,
 )
 from octop.infra.utils.llm_text import strip_thinking as _strip_thinking
 from octop.infra.utils.locale import normalize_locale
@@ -47,9 +49,6 @@ _OFFLOAD_PLACEHOLDER_RE = re.compile(
     r"^\s*\[\s*(?:image|audio)\s+offloaded\s*:",
     re.IGNORECASE,
 )
-
-# Must match harness_agent.agent.CHECKPOINT_TS_KEY (epoch-ms in additional_kwargs).
-CHECKPOINT_TS_KEY = "checkpoint_ts"
 
 HISTORY_DEFAULT_LIMIT = 25
 HISTORY_MAX_LIMIT = 200
@@ -316,10 +315,6 @@ def _slice_message_page(
     return page, has_more
 
 
-def _epoch_to_ms(raw: int | float) -> int:
-    return int(raw) if raw > 1_000_000_000_000 else int(raw * 1000)
-
-
 async def _load_checkpoint_messages(
     harness: Any,
     thread_id: str,
@@ -474,7 +469,11 @@ def _load_projected_thread_messages(
                 exc_info=True,
             )
             continue
-        entry = _serialize_history_message(message, user=user)
+        entry = _serialize_history_message(
+            message,
+            user=user,
+            fallback_created_at=row.created_at,
+        )
         if entry is not None:
             out.append(entry)
     return _enrich_history_tool_media(out, agent_id=agent_id), has_more
@@ -588,11 +587,30 @@ def _extract_message_timestamp_ms(msg: Any) -> int | None:
     if not isinstance(additional_kwargs, dict):
         return None
     raw = additional_kwargs.get(CHECKPOINT_TS_KEY)
-    if isinstance(raw, int | float) and raw > 0:
-        return _epoch_to_ms(raw)
+    parsed = parse_checkpoint_ts_ms(raw)
+    if parsed is not None:
+        return parsed
     if isinstance(raw, str) and raw.strip():
         return _ts_to_ms(_parse_jsonl_ts(raw))
     return None
+
+
+def _history_timestamp_ms(msg: Any, fallback_created_at: int | None = None) -> int | None:
+    ts_ms = _extract_message_timestamp_ms(msg)
+    if ts_ms is not None:
+        return ts_ms
+    return parse_checkpoint_ts_ms(fallback_created_at)
+
+
+def _apply_history_timestamp(
+    entry: dict[str, Any],
+    msg: Any,
+    fallback_created_at: int | None = None,
+) -> dict[str, Any]:
+    ts_ms = _history_timestamp_ms(msg, fallback_created_at)
+    if ts_ms is not None:
+        entry["timestamp"] = ts_ms
+    return entry
 
 
 def _parse_jsonl_ts(ts: str | None) -> float | None:
@@ -894,7 +912,12 @@ def _split_string_thinking(text: str) -> list[dict[str, Any]]:
     return blocks
 
 
-def _serialize_history_message(msg: Any, *, user: Any = None) -> dict[str, Any] | None:
+def _serialize_history_message(
+    msg: Any,
+    *,
+    user: Any = None,
+    fallback_created_at: int | None = None,
+) -> dict[str, Any] | None:
     """Project a LangGraph checkpoint message into dashboard history shape."""
     role = _message_role(msg)
     if role in ("system", ""):
@@ -923,10 +946,7 @@ def _serialize_history_message(msg: Any, *, user: Any = None) -> dict[str, Any] 
         entry: dict[str, Any] = {"role": "tool", "content": blocks}
         if mid:
             entry["id"] = mid
-        ts_ms = _extract_message_timestamp_ms(msg)
-        if ts_ms is not None:
-            entry["timestamp"] = ts_ms
-        return entry
+        return _apply_history_timestamp(entry, msg, fallback_created_at)
 
     content = _msg_attr(msg, "content", "")
     blocks = _content_blocks_from_raw(content, additional_kwargs)
@@ -980,15 +1000,12 @@ def _serialize_history_message(msg: Any, *, user: Any = None) -> dict[str, Any] 
             entry["composer_context"] = raw_ctx
         if has_user_attachments:
             entry["inbound_attachments"] = raw_att
-    ts_ms = _extract_message_timestamp_ms(msg)
-    if ts_ms is not None:
-        entry["timestamp"] = ts_ms
     if additional_kwargs.get(STREAM_ERROR_FLAG):
         entry["status"] = "error"
         code = additional_kwargs.get(STREAM_ERROR_CODE_KEY)
         if code:
             entry["error_code"] = str(code)
-    return entry
+    return _apply_history_timestamp(entry, msg, fallback_created_at)
 
 
 def _message_content(msg: Any) -> str:

--- a/src/octop/infra/gateway/process/history_projection.py
+++ b/src/octop/infra/gateway/process/history_projection.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import time
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -11,7 +12,12 @@ from langchain_core.messages import AIMessage, convert_to_messages, message_to_d
 
 from octop.infra.db.repos._base import now_ts
 from octop.infra.db.repos.thread_messages import ThreadMessageInput
-from octop.infra.gateway.process.message_keys import STREAM_ERROR_CODE_KEY, STREAM_ERROR_FLAG
+from octop.infra.gateway.process.message_keys import (
+    CHECKPOINT_TS_KEY,
+    STREAM_ERROR_CODE_KEY,
+    STREAM_ERROR_FLAG,
+    parse_checkpoint_ts_ms,
+)
 
 _USER_ROLES = frozenset({"human", "user"})
 _ASSISTANT_ROLES = frozenset({"ai", "assistant"})
@@ -32,20 +38,52 @@ def _chunk_messages(chunk: dict[str, Any]) -> list[Any]:
     return []
 
 
+def checkpoint_ts_ms(message: Any) -> int | None:
+    kwargs = getattr(message, "additional_kwargs", None)
+    if not isinstance(kwargs, dict):
+        return None
+    return parse_checkpoint_ts_ms(kwargs.get(CHECKPOINT_TS_KEY))
+
+
+def _ensure_checkpoint_ts(message: Any, *, now_ms: int | None = None) -> Any:
+    """Stamp ``checkpoint_ts`` on a live copy. Existing stamps are left alone."""
+    if checkpoint_ts_ms(message) is not None:
+        return message
+    copy = getattr(message, "model_copy", None)
+    if not callable(copy):
+        return message
+    kwargs = dict(getattr(message, "additional_kwargs", None) or {})
+    kwargs[CHECKPOINT_TS_KEY] = now_ms if now_ms is not None else int(time.time() * 1000)
+    return copy(update={"additional_kwargs": kwargs})
+
+
+def _convert_message(message: Any) -> Any:
+    return convert_to_messages([message])[0] if isinstance(message, dict) else message
+
+
 def message_input(message: Any) -> ThreadMessageInput | None:
-    """Serialize one LangChain/dict message before entering a DB transaction."""
+    """Serialize one LangChain/dict message. Never invents ``checkpoint_ts``."""
     try:
-        converted = convert_to_messages([message])[0] if isinstance(message, dict) else message
+        converted = _convert_message(message)
         wire = message_to_dict(converted)
         role = _role(converted)
         if role in ("", "system"):
             return None
+        ts_ms = checkpoint_ts_ms(converted)
         return ThreadMessageInput(
             message_id=str(getattr(converted, "id", "") or "") or None,
             role=role,
             message_json=json.dumps(wire, ensure_ascii=False, default=str),
-            created_at=now_ts(),
+            created_at=(ts_ms // 1000) if ts_ms is not None else now_ts(),
         )
+    except Exception:
+        return None
+
+
+def live_message_input(message: Any, *, now_ms: int | None = None) -> ThreadMessageInput | None:
+    """Serialize a current-turn message, stamping ``checkpoint_ts`` if missing."""
+    try:
+        return message_input(_ensure_checkpoint_ts(_convert_message(message), now_ms=now_ms))
     except Exception:
         return None
 
@@ -73,6 +111,22 @@ def message_inputs(
         seen.add(key)
         out.append(item)
     return out
+
+
+def live_message_inputs(
+    messages: list[Any],
+    *,
+    dedupe_missing_ids: bool = False,
+    now_ms: int | None = None,
+) -> list[ThreadMessageInput]:
+    """Like ``message_inputs``, but stamps missing ``checkpoint_ts`` on this turn."""
+    prepared: list[Any] = []
+    for message in messages:
+        try:
+            prepared.append(_ensure_checkpoint_ts(_convert_message(message), now_ms=now_ms))
+        except Exception:
+            continue
+    return message_inputs(prepared, dedupe_missing_ids=dedupe_missing_ids)
 
 
 def _wire_text(item: ThreadMessageInput) -> str:
@@ -148,7 +202,7 @@ class TurnHistoryTracker:
         extra: dict[str, Any] = {}
         if self._reasoning_text:
             extra["reasoning_content"] = self._reasoning_text
-        return message_input(AIMessage(content=self._stream_text, additional_kwargs=extra))
+        return live_message_input(AIMessage(content=self._stream_text, additional_kwargs=extra))
 
     def _error_input(self) -> ThreadMessageInput | None:
         if not self._error_message:
@@ -156,7 +210,7 @@ class TurnHistoryTracker:
         extra: dict[str, Any] = {STREAM_ERROR_FLAG: True}
         if self._error_code:
             extra[STREAM_ERROR_CODE_KEY] = self._error_code
-        return message_input(AIMessage(content=self._error_message, additional_kwargs=extra))
+        return live_message_input(AIMessage(content=self._error_message, additional_kwargs=extra))
 
     def _inputs_cover_stream(self, items: list[ThreadMessageInput]) -> bool:
         if not self._stream_text:
@@ -172,7 +226,7 @@ class TurnHistoryTracker:
         source = (
             self._state_messages if state_has_user else [*self.seed_messages, *self._state_messages]
         )
-        items = message_inputs(
+        items = live_message_inputs(
             source,
             dedupe_missing_ids=True,
         )

--- a/src/octop/infra/gateway/process/message_keys.py
+++ b/src/octop/infra/gateway/process/message_keys.py
@@ -11,9 +11,18 @@ from octop.infra.gateway.threads import ThreadRegistry
 # Persisted on HumanMessage.additional_kwargs for dashboard history UI.
 COMPOSER_CTX_KEY = "octop_composer_context"
 INBOUND_ATTACHMENTS_KEY = "octop_inbound_attachments"
+# Must match harness_agent.messages.CHECKPOINT_TS_KEY (epoch-ms).
+CHECKPOINT_TS_KEY = "checkpoint_ts"
 # Persisted on AIMessage.additional_kwargs when a stream fails mid-turn.
 STREAM_ERROR_FLAG = "octop_stream_error"
 STREAM_ERROR_CODE_KEY = "error_code"
+
+
+def parse_checkpoint_ts_ms(raw: Any) -> int | None:
+    """Normalize a checkpoint/created_at value to epoch milliseconds."""
+    if isinstance(raw, bool) or not isinstance(raw, int | float) or raw <= 0:
+        return None
+    return int(raw) if raw > 1_000_000_000_000 else int(raw * 1000)
 
 
 def build_composer_context(

--- a/src/octop/infra/history/recorder.py
+++ b/src/octop/infra/history/recorder.py
@@ -6,15 +6,31 @@ import asyncio
 import hashlib
 import json
 import re
-from typing import Any
+from typing import Any, cast
 
-from langchain_core.messages import AIMessage, ToolMessage, message_to_dict
+from langchain_core.messages import AIMessage, ToolMessage
 
-from octop.infra.gateway.process.history_projection import TurnHistoryTracker, _role, message_input
-from octop.infra.gateway.process.message_keys import STREAM_ERROR_CODE_KEY, STREAM_ERROR_FLAG
+from octop.infra.gateway.process.history_projection import (
+    TurnHistoryTracker,
+    _role,
+    live_message_input,
+    message_input,
+)
+from octop.infra.gateway.process.message_keys import (
+    CHECKPOINT_TS_KEY,
+    STREAM_ERROR_CODE_KEY,
+    STREAM_ERROR_FLAG,
+)
 from octop.infra.history.service import HistoryArchive
 from octop.infra.history.store import dumps
 from octop.infra.trajectory.projector import _tool_result_fields
+
+
+def _live_wire(message: Any) -> dict[str, Any] | None:
+    item = live_message_input(message)
+    if item is None:
+        return None
+    return cast(dict[str, Any], json.loads(item.message_json))
 
 
 class RecordingTracker(TurnHistoryTracker):
@@ -40,9 +56,9 @@ class RecordingTracker(TurnHistoryTracker):
             restored = bool(self._parts)
             if not self._parts:
                 for seed in seeds:
-                    item = message_input(seed)
-                    if item is not None:
-                        self._parts.append(json.loads(item.message_json))
+                    wire = _live_wire(seed)
+                    if wire is not None:
+                        self._parts.append(wire)
             for wire in self._parts:
                 extra = wire["data"].get("additional_kwargs", {})
                 if extra.get("history_source"):
@@ -84,9 +100,11 @@ class RecordingTracker(TurnHistoryTracker):
         ):
             self._assistant = None
         if self._assistant is None:
-            self._assistant = message_to_dict(
+            self._assistant = _live_wire(
                 AIMessage(content="", id=f"{self.turn['id']}:stream:{len(self._parts)}")
             )
+            if self._assistant is None:
+                return {}
             if message_id:
                 self._assistant["data"]["id"] = message_id
                 self._assistant["data"].setdefault("additional_kwargs", {})["history_stream_id"] = (
@@ -161,21 +179,20 @@ class RecordingTracker(TurnHistoryTracker):
             wires: list[dict[str, Any]] = []
             if isinstance(raw, list):
                 for msg in raw:
-                    item = message_input(msg)
-                    if item is not None:
-                        wires.append(json.loads(item.message_json))
+                    wire = _live_wire(msg)
+                    if wire is not None:
+                        wires.append(wire)
             if not wires:
                 call_id, name, result = _tool_result_fields(chunk)
-                wires = [
-                    message_to_dict(
-                        ToolMessage(
-                            content=result if isinstance(result, (str, list)) else dumps(result),
-                            name=name,
-                            tool_call_id=call_id,
-                            id=f"{self.turn['id']}:tool:{call_id}",
-                        )
+                fallback = _live_wire(
+                    ToolMessage(
+                        content=result if isinstance(result, (str, list)) else dumps(result),
+                        name=name,
+                        tool_call_id=call_id,
+                        id=f"{self.turn['id']}:tool:{call_id}",
                     )
-                ]
+                )
+                wires = [fallback] if fallback is not None else []
             for wire in wires:
                 call_id = wire["data"].get("tool_call_id")
                 existing = next(
@@ -200,15 +217,15 @@ class RecordingTracker(TurnHistoryTracker):
             code = chunk.get("error_code")
             if code:
                 error_extra[STREAM_ERROR_CODE_KEY] = str(code)
-            self._append_part(
-                message_to_dict(
-                    AIMessage(
-                        content=text,
-                        id=f"{self.turn['id']}:error",
-                        additional_kwargs=error_extra,
-                    )
+            error_wire = _live_wire(
+                AIMessage(
+                    content=text,
+                    id=f"{self.turn['id']}:error",
+                    additional_kwargs=error_extra,
                 )
             )
+            if error_wire is not None:
+                self._append_part(error_wire)
             self._assistant = None
 
     def _merge_state(self) -> None:
@@ -257,9 +274,13 @@ class RecordingTracker(TurnHistoryTracker):
                 self._append_part(wire)
                 continue
             previous = target["data"]
+            prev_extra = previous.get("additional_kwargs", {})
+            data_extra = data.setdefault("additional_kwargs", {})
+            if CHECKPOINT_TS_KEY not in data_extra and prev_extra.get(CHECKPOINT_TS_KEY):
+                data_extra[CHECKPOINT_TS_KEY] = prev_extra[CHECKPOINT_TS_KEY]
             for key in ("reasoning_content", "history_source", "history_stream_id"):
-                value = previous.get("additional_kwargs", {}).get(key)
-                if value and not data.setdefault("additional_kwargs", {}).get(key):
+                value = prev_extra.get(key)
+                if value and not data_extra.get(key):
                     # Final state may already carry the same visible thinking
                     # inline. Preserve its original representation only once.
                     content = data.get("content")

--- a/tests/unit/api/test_chat_polish.py
+++ b/tests/unit/api/test_chat_polish.py
@@ -214,6 +214,49 @@ def test_serialize_history_message_includes_checkpoint_timestamp_for_tool() -> N
     assert tool["timestamp"] == 1_700_000_000_123
 
 
+def test_serialize_history_message_falls_back_to_created_at() -> None:
+    user = _serialize_history_message(
+        HumanMessage(content="hello"),
+        fallback_created_at=1_700_000_000,
+    )
+    assert user is not None
+    assert user["timestamp"] == 1_700_000_000_000
+
+
+def test_serialize_history_message_prefers_checkpoint_ts_over_created_at() -> None:
+    user = _serialize_history_message(
+        HumanMessage(
+            content="hello",
+            additional_kwargs={"checkpoint_ts": 1_700_000_000_000},
+        ),
+        fallback_created_at=1,
+    )
+    assert user is not None
+    assert user["timestamp"] == 1_700_000_000_000
+
+
+def test_load_projected_falls_back_to_created_at() -> None:
+    import json
+
+    from langchain_core.messages import message_to_dict
+
+    from octop.api.routers.chat.serialize import _load_projected_thread_messages
+
+    row = SimpleNamespace(
+        seq=1,
+        message_json=json.dumps(message_to_dict(HumanMessage(content="hi", id="m1"))),
+        created_at=1_700_000_000,
+    )
+    server = SimpleNamespace(
+        services=SimpleNamespace(
+            thread_message_repo=SimpleNamespace(page=lambda *_a, **_k: ([row], False))
+        )
+    )
+    messages, has_more = _load_projected_thread_messages(server, "agent", "thread", 25, user=None)
+    assert has_more is False
+    assert messages[0]["timestamp"] == 1_700_000_000_000
+
+
 def test_ts_to_ms_converts_seconds() -> None:
     assert _ts_to_ms(1_700_000_000.5) == 1_700_000_000_500
 

--- a/tests/unit/gateway/test_history_projection.py
+++ b/tests/unit/gateway/test_history_projection.py
@@ -1,15 +1,85 @@
 from __future__ import annotations
 
 import asyncio
+import json
 
 import pytest
+from langchain_core.messages import HumanMessage
 
 from octop.infra.gateway.history_backfill import HistoryBackfillQueue
 from octop.infra.gateway.process.history_projection import (
     TurnHistoryTracker,
     _wire_text,
+    live_message_input,
+    message_input,
 )
-from octop.infra.gateway.process.message_keys import STREAM_ERROR_FLAG
+from octop.infra.gateway.process.message_keys import (
+    CHECKPOINT_TS_KEY,
+    STREAM_ERROR_FLAG,
+    parse_checkpoint_ts_ms,
+)
+
+
+def test_message_input_preserves_existing_checkpoint_ts() -> None:
+    item = message_input(
+        HumanMessage(
+            content="hi",
+            additional_kwargs={CHECKPOINT_TS_KEY: 1_700_000_000_000},
+        )
+    )
+    assert item is not None
+    wire = json.loads(item.message_json)
+    assert wire["data"]["additional_kwargs"][CHECKPOINT_TS_KEY] == 1_700_000_000_000
+    assert item.created_at == 1_700_000_000
+
+
+def test_message_input_does_not_invent_stamp_by_default() -> None:
+    item = message_input(HumanMessage(content="hi"))
+    assert item is not None
+    wire = json.loads(item.message_json)
+    assert CHECKPOINT_TS_KEY not in (wire["data"].get("additional_kwargs") or {})
+
+
+def test_live_message_input_stamps_when_missing() -> None:
+    item = live_message_input(
+        HumanMessage(content="hi"),
+        now_ms=1_700_000_000_123,
+    )
+    assert item is not None
+    wire = json.loads(item.message_json)
+    assert wire["data"]["additional_kwargs"][CHECKPOINT_TS_KEY] == 1_700_000_000_123
+    assert item.created_at == 1_700_000_000
+
+
+def test_live_message_input_preserves_existing_stamp() -> None:
+    item = live_message_input(
+        HumanMessage(
+            content="hi",
+            additional_kwargs={CHECKPOINT_TS_KEY: 1_700_000_000_000},
+        ),
+        now_ms=9,
+    )
+    assert item is not None
+    wire = json.loads(item.message_json)
+    assert wire["data"]["additional_kwargs"][CHECKPOINT_TS_KEY] == 1_700_000_000_000
+
+
+def test_parse_checkpoint_ts_ms() -> None:
+    assert parse_checkpoint_ts_ms(1_700_000_000) == 1_700_000_000_000
+    assert parse_checkpoint_ts_ms(1_700_000_000_000) == 1_700_000_000_000
+    assert parse_checkpoint_ts_ms(0) is None
+    assert parse_checkpoint_ts_ms(True) is None
+    assert parse_checkpoint_ts_ms(None) is None
+
+
+def test_stream_tokens_stamp_checkpoint_ts() -> None:
+    tracker = TurnHistoryTracker.from_request(
+        {"messages": [{"role": "user", "content": "hi", "id": "u1"}]}
+    )
+    tracker.observe({"type": "token", "content": "hello"})
+    assistant = next(item for item in tracker.inputs if item.role in ("ai", "assistant"))
+    wire = json.loads(assistant.message_json)
+    assert CHECKPOINT_TS_KEY in (wire["data"].get("additional_kwargs") or {})
 
 
 def test_turn_tracker_keeps_only_latest_user_turn_and_dedupes_replay() -> None:

--- a/tests/unit/gateway/test_versioned_history.py
+++ b/tests/unit/gateway/test_versioned_history.py
@@ -82,6 +82,63 @@ async def test_no_migration_single_write_and_cross_boundary_cursor(archive):
 
 
 @pytest.mark.asyncio
+async def test_streamed_archive_messages_include_checkpoint_ts(archive):
+    from octop.infra.gateway.process.message_keys import CHECKPOINT_TS_KEY
+
+    turn = archive.begin("a", "t")
+    recorder = RecordingTracker(
+        archive, turn, [{"role": "user", "content": "question", "id": "u1"}]
+    )
+    recorder.observe({"type": "token", "content": "answer"})
+    await recorder.finish(completed=True)
+    messages = messages_from_dict(
+        (await archive.page("t", limit=10, cursor=None, legacy_reader=no_anchor))["messages"]
+    )
+    assert all(
+        isinstance(msg.additional_kwargs.get(CHECKPOINT_TS_KEY), int)
+        and msg.additional_kwargs[CHECKPOINT_TS_KEY] > 0
+        for msg in messages
+    )
+
+
+@pytest.mark.asyncio
+async def test_state_merge_keeps_checkpoint_ts_from_snapshot(archive):
+    from octop.infra.gateway.process.message_keys import CHECKPOINT_TS_KEY
+
+    turn = archive.begin("a", "t")
+    recorder = RecordingTracker(archive, turn, [HumanMessage(content="question", id="u1")])
+    recorder.observe({"type": "token", "message_id": "a1", "content": "partial"})
+    recorder.observe(
+        {
+            "type": "state_snapshot",
+            "data": {
+                "messages": [
+                    HumanMessage(
+                        content="question",
+                        id="u1",
+                        additional_kwargs={CHECKPOINT_TS_KEY: 1_700_000_000_111},
+                    ),
+                    AIMessage(
+                        content="final",
+                        id="a1",
+                        additional_kwargs={CHECKPOINT_TS_KEY: 1_700_000_000_222},
+                    ),
+                ]
+            },
+        }
+    )
+    await recorder.finish(completed=True)
+    messages = {
+        msg.id: msg
+        for msg in messages_from_dict(
+            (await archive.page("t", limit=10, cursor=None, legacy_reader=no_anchor))["messages"]
+        )
+    }
+    assert messages["u1"].additional_kwargs[CHECKPOINT_TS_KEY] == 1_700_000_000_111
+    assert messages["a1"].additional_kwargs[CHECKPOINT_TS_KEY] == 1_700_000_000_222
+
+
+@pytest.mark.asyncio
 async def test_state_metadata_thinking_tools_and_shared_trajectory_bodies(archive):
     text = "A final answer with sufficient distinct content"
     turn = archive.begin("a", "t")


### PR DESCRIPTION
## Summary
- Restore chat history timestamps: stamp `checkpoint_ts` on the current turn, and fall back to `created_at` when the projected message has no stamp. Backfill/fork/legacy paths still do not invent times.
- Align the user avatar with the text bubble instead of the composer chips above it; move copy/edit onto the timestamp row.
- Refresh README / README_CN so knowledge bases, plugins, PostgreSQL, WebSocket, and `octop update` match what has already shipped.

## Test plan
- [ ] Send a new user message (with and without skill/connector/model chips), refresh the thread, and confirm the timestamp stays and the avatar lines up with the blue bubble
- [ ] Hover a user bubble and confirm copy/edit sit to the left of the time
- [ ] Open an older thread that already has `created_at` but no `checkpoint_ts` and confirm times still appear
- [ ] `uv run pytest tests/unit/api/test_chat_polish.py tests/unit/gateway/test_history_projection.py tests/unit/gateway/test_versioned_history.py -q`
- [ ] Skim README / README_CN Highlights, Features, Upgrade, and Data directory for EN/CN parity


Made with [Cursor](https://cursor.com)