### PR TITLE
fix(cli): honor OCTOP_PORT/OCTOP_BIND_HOST in octop run bind resolution

### DIFF
--- a/src/octop/cli/commands/run.py
+++ b/src/octop/cli/commands/run.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 import click
 
+from octop.config import env_bind_overrides
 from octop.infra.utils.paths import PathLayout
 
 
@@ -82,6 +83,17 @@ def _load_configfile_overrides() -> tuple[str | None, int | None]:
                 port if isinstance(port, int) and not isinstance(port, bool) else None,
             )
     return None, None
+
+
+def resolve_bind(host: str | None, port: int | None) -> tuple[str | None, int | None]:
+    """Resolve the uvicorn bind address: CLI flag > env > config.json."""
+    cfg_host, cfg_port = _load_configfile_overrides()
+    env_host, env_port = env_bind_overrides()
+    # Use ``is not None`` (not ``or``) so falsy-but-valid values like port=0
+    # (OS-assigned random port) and host="0" are not silently overridden.
+    resolved_host = host if host is not None else env_host if env_host is not None else cfg_host
+    resolved_port = port if port is not None else env_port if env_port is not None else cfg_port
+    return resolved_host, resolved_port
 
 
 def _atomic_write_json(path: Path, data: dict[str, object]) -> None:
@@ -163,17 +175,13 @@ def run(
     """Run octop-server in the foreground.
 
     Host and port are resolved with the following precedence: explicit CLI
-    flags > ``~/.octop/config.json`` > launch defaults. When ``--host`` or
-    ``--port`` is passed on the CLI, that override is persisted to
-    ``config.json`` immediately before uvicorn starts.
+    flags > ``OCTOP_BIND_HOST``/``OCTOP_PORT`` env > ``~/.octop/config.json``
+    > launch defaults. When ``--host`` or ``--port`` is passed on the CLI,
+    that override is persisted to ``config.json`` immediately before uvicorn
+    starts.
     """
     cli_host, cli_port = host, port
-    cfg_host, cfg_port = _load_configfile_overrides()
-    # Use ``is not None`` (not ``or``) so falsy-but-valid values like port=0
-    # (OS-assigned random port) and host="0" are not silently overridden by
-    # the config-file fallback.
-    host = host if host is not None else cfg_host
-    port = port if port is not None else cfg_port
+    host, port = resolve_bind(host, port)
     if cli_host is not None or cli_port is not None:
         _save_configfile_overrides(cli_host, cli_port)
     certfile, keyfile = _maybe_generate_self_signed(ssl, ssl_certfile, ssl_keyfile)

--- a/src/octop/config.py
+++ b/src/octop/config.py
@@ -392,6 +392,23 @@ def _apply_database_env(merged_db: dict[str, Any]) -> dict[str, Any]:
     return out
 
 
+def env_bind_overrides() -> tuple[str | None, int | None]:
+    """``OCTOP_BIND_HOST`` / ``OCTOP_PORT`` overrides shared by config and CLI.
+
+    An invalid ``OCTOP_PORT`` logs a warning and yields no override, so the
+    file/default value wins — same fallback semantics as ``load_config``.
+    """
+    host = os.environ.get("OCTOP_BIND_HOST") or None
+    port: int | None = None
+    if v := os.environ.get("OCTOP_PORT"):
+        try:
+            port = int(v)
+        except ValueError:
+            # Do not log the raw env value.
+            logger.warning("env %s is not int; ignoring override", "OCTOP_PORT")
+    return host, port
+
+
 def load_config(path: Path) -> OctopConfig:
     """Load ``config.json``; write defaults if absent. Apply env overrides."""
     file_defaults = _defaults_for_file()
@@ -416,10 +433,11 @@ def load_config(path: Path) -> OctopConfig:
     }
     merged_db = _apply_database_env(merged_db)
 
-    if v := os.environ.get("OCTOP_BIND_HOST"):
-        merged["bind_host"] = v
-    if v := os.environ.get("OCTOP_PORT"):
-        merged["port"] = _coerce_int("OCTOP_PORT", v, merged["port"])
+    env_host, env_port = env_bind_overrides()
+    if env_host is not None:
+        merged["bind_host"] = env_host
+    if env_port is not None:
+        merged["port"] = env_port
     if v := os.environ.get("OCTOP_LOG_LEVEL"):
         merged["log_level"] = v
     if v := os.environ.get("OCTOP_ACCESS_TOKEN_TTL"):

--- a/tests/unit/cli/test_run_bind_resolution.py
+++ b/tests/unit/cli/test_run_bind_resolution.py
@@ -1,0 +1,57 @@
+"""Bind address resolution for `octop run`: CLI flag > env > config.json."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from octop.cli.commands.run import resolve_bind
+
+
+@pytest.fixture
+def octop_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setenv("OCTOP_HOME", str(tmp_path))
+    monkeypatch.delenv("OCTOP_PORT", raising=False)
+    monkeypatch.delenv("OCTOP_BIND_HOST", raising=False)
+    return tmp_path
+
+
+def _write_config(home: Path, **data: object) -> None:
+    (home / "config.json").write_text(json.dumps(data), encoding="utf-8")
+
+
+def test_no_config_no_env(octop_home: Path) -> None:
+    assert resolve_bind(None, None) == (None, None)
+
+
+def test_config_file_values(octop_home: Path) -> None:
+    _write_config(octop_home, bind_host="127.0.0.1", port=8088)
+    assert resolve_bind(None, None) == ("127.0.0.1", 8088)
+
+
+def test_env_overrides_config_file(octop_home: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _write_config(octop_home, bind_host="127.0.0.1", port=8088)
+    monkeypatch.setenv("OCTOP_PORT", "9001")
+    monkeypatch.setenv("OCTOP_BIND_HOST", "0.0.0.0")
+    assert resolve_bind(None, None) == ("0.0.0.0", 9001)
+
+
+def test_cli_flags_win_over_env_and_file(octop_home: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _write_config(octop_home, bind_host="127.0.0.1", port=8088)
+    monkeypatch.setenv("OCTOP_PORT", "9001")
+    assert resolve_bind("10.0.0.1", 7777) == ("10.0.0.1", 7777)
+
+
+def test_invalid_env_port_falls_back_to_file(
+    octop_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_config(octop_home, port=8088)
+    monkeypatch.setenv("OCTOP_PORT", "not-a-number")
+    assert resolve_bind(None, None) == (None, 8088)
+
+
+def test_legacy_host_key(octop_home: Path) -> None:
+    _write_config(octop_home, host="192.168.1.10", port=1234)
+    assert resolve_bind(None, None) == ("192.168.1.10", 1234)


### PR DESCRIPTION
## Problem

`octop run` resolved the uvicorn bind address from `config.json` only, bypassing the `OCTOP_PORT` / `OCTOP_BIND_HOST` env overrides that `load_config()` applies. With a `config.json` present, the server bound to the file port while the app config reported the env port (observed while running an isolated test instance: `OCTOP_PORT=9001` silently ignored once the setup wizard persisted `config.json`).

## Changes

- `config.env_bind_overrides()`: single source of truth for `OCTOP_BIND_HOST` / `OCTOP_PORT` semantics (invalid port logs a warning and yields no override — same fallback as before); `load_config` now reuses it
- `cli/commands/run.py`: new `resolve_bind()` with precedence **CLI flag > env > config.json > launch defaults**, used by the `run` command; docstring updated
- Tests: `tests/unit/cli/test_run_bind_resolution.py` (no config, file values, env over file, CLI over env+file, invalid env port fallback, legacy `host` key)

## Verification

- `uv run pytest tests/unit/cli/test_run_bind_resolution.py tests/unit/test_config.py` → 37 passed
- ruff / ruff format / mypy clean; pre-commit (`make all` + dashboard build) green
- Manual: with `config.json` port 8088 and `OCTOP_PORT=9001`, `octop run` now binds 9001

Follow-up to probe/STT work in #659 (out-of-scope item #3 there).
