### PR TITLE
feat(voice): make the STT probe live, symmetric with the TTS probe

### DIFF
--- a/src/octop/infra/voice/adapters.py
+++ b/src/octop/infra/voice/adapters.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import base64
 import json
+import math
 import struct
 import uuid
 from collections.abc import AsyncIterator
@@ -427,13 +428,80 @@ async def synthesize_mimo(
                 yield pcm
 
 
+_PROBE_TONE_RATE = 16000
+_PROBE_TONE_SECONDS = 1.0
+
+
+def _probe_tone_wav() -> bytes:
+    """Deterministic probe payload: 1s 440Hz tone as 16kHz mono PCM16 WAV."""
+    n = int(_PROBE_TONE_RATE * _PROBE_TONE_SECONDS)
+    pcm = struct.pack(
+        f"<{n}h",
+        *[int(1000 * math.sin(2 * math.pi * 440 * i / _PROBE_TONE_RATE)) for i in range(n)],
+    )
+    header = struct.pack(
+        "<4sI4s4sIHHIIHH4sI",
+        b"RIFF",
+        36 + len(pcm),
+        b"WAVE",
+        b"fmt ",
+        16,
+        1,
+        1,
+        _PROBE_TONE_RATE,
+        _PROBE_TONE_RATE * 2,
+        2,
+        16,
+        b"data",
+        len(pcm),
+    )
+    return header + pcm
+
+
+def _stt_credentials_error(row: VoiceProviderRow, kind: str) -> str | None:
+    if kind == "tencent":
+        try:
+            _parse_tencent_credentials(row)
+        except ValueError as exc:
+            return str(exc)
+        return None
+    if kind in {"openai", "mimo"} and not row.api_key:
+        return "API credentials missing"
+    return None
+
+
+def _stt_probe_failure(exc: Exception) -> dict[str, Any]:
+    if isinstance(exc, httpx.HTTPStatusError):
+        detail = f"provider returned HTTP {exc.response.status_code}"
+    elif isinstance(exc, httpx.HTTPError):
+        detail = f"network error: {type(exc).__name__}"
+    else:
+        detail = str(exc).strip() or type(exc).__name__
+    return {"ok": False, "error": detail}
+
+
 async def test_stt(row: VoiceProviderRow | None, kind: str) -> dict[str, Any]:
     if kind == "browser":
         return {"ok": True, "mode": "browser"}
     if row is None:
         return {"ok": False, "error": "provider not configured"}
-    if not row.api_key and kind in {"openai", "tencent", "mimo"}:
-        return {"ok": False, "error": "API credentials missing"}
+    if kind not in {"openai", "tencent", "mimo"}:
+        # edge is TTS-only and unknown kinds have no adapter: keep offline pass.
+        return {"ok": True, "mode": kind}
+    missing = _stt_credentials_error(row, kind)
+    if missing:
+        return {"ok": False, "error": missing}
+    transcribe = (
+        transcribe_mimo
+        if kind == "mimo"
+        else transcribe_openai
+        if kind == "openai"
+        else transcribe_tencent
+    )
+    try:
+        await transcribe(row, _probe_tone_wav(), mime="audio/wav", language="zh-CN")
+    except Exception as exc:  # probe reports failures, never 500s
+        return _stt_probe_failure(exc)
     return {"ok": True, "mode": kind}
 
 

--- a/tests/integration/test_voice_probe_http.py
+++ b/tests/integration/test_voice_probe_http.py
@@ -1,0 +1,76 @@
+"""HTTP glue for the live STT probe: provider errors surface as ok:false."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+import pytest
+
+import octop.infra.voice.adapters as voice_adapters
+
+TENCENT_EXTRA = {"secret_id": "sid", "secret_key": "sk", "region": "ap-guangzhou"}
+
+
+def _raising(exc: Exception) -> Any:
+    async def fake(row: Any, audio: bytes, *, mime: str, language: str) -> Any:
+        raise exc
+
+    return fake
+
+
+async def test_probe_stt_reports_provider_error_over_http(
+    env: tuple[httpx.AsyncClient, Any, dict[str, str]], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    client, _srv, auth = env
+    monkeypatch.setattr(
+        voice_adapters,
+        "transcribe_tencent",
+        _raising(RuntimeError("AuthFailure.SecretIdNotFound: The SecretId is not found.")),
+    )
+
+    r = await client.post(
+        "/api/admin/voice/providers/test-configuration",
+        headers=auth,
+        json={
+            "name": "tencent-asr",
+            "kind": "tencent",
+            "capability": "both",
+            "api_key": "sid:sk",
+            "extra_json": json.dumps(TENCENT_EXTRA),
+            "mode": "stt",
+        },
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["ok"] is False
+    assert "SecretIdNotFound" in body["error"]
+
+
+async def test_probe_stt_success_over_http(
+    env: tuple[httpx.AsyncClient, Any, dict[str, str]], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from octop.infra.voice.adapters import STTResult
+
+    async def fake(row: Any, audio: bytes, *, mime: str, language: str) -> STTResult:
+        assert mime == "audio/wav"
+        return STTResult(text="")
+
+    client, _srv, auth = env
+    monkeypatch.setattr(voice_adapters, "transcribe_tencent", fake)
+
+    r = await client.post(
+        "/api/admin/voice/providers/test-configuration",
+        headers=auth,
+        json={
+            "name": "tencent-asr",
+            "kind": "tencent",
+            "capability": "both",
+            "api_key": "sid:sk",
+            "extra_json": json.dumps(TENCENT_EXTRA),
+            "mode": "stt",
+        },
+    )
+    assert r.status_code == 200
+    assert r.json() == {"ok": True, "mode": "tencent"}

--- a/tests/unit/test_voice_stt_probe.py
+++ b/tests/unit/test_voice_stt_probe.py
@@ -1,0 +1,135 @@
+"""Live STT probe: test_stt performs a real recognition call per provider.
+
+Credential/config failures and provider errors must be reported as
+``{"ok": false, "error": ...}``, never raised into a 500.
+"""
+
+from __future__ import annotations
+
+import json
+import struct
+from collections.abc import Callable
+from typing import Any
+
+import httpx
+import pytest
+
+import octop.infra.voice.adapters as voice_adapters
+from octop.infra.db.repos.voice_providers import VoiceProviderRow
+from octop.infra.voice.adapters import STTResult, _probe_tone_wav
+from octop.infra.voice.adapters import test_stt as probe_stt
+
+
+def _row(*, kind: str, api_key: str | None = "k", extra: dict[str, Any] | None = None):
+    return VoiceProviderRow(
+        id=1,
+        name=f"{kind}-probe",
+        kind=kind,
+        capability="both",
+        base_url=None,
+        api_key=api_key,
+        extra_json=json.dumps(extra) if extra else None,
+        note=None,
+        enabled=1,
+        created_at=0,
+        updated_at=0,
+    )
+
+
+def _stt(*result: STTResult) -> Callable[..., Any]:
+    async def fake(row: VoiceProviderRow, audio: bytes, *, mime: str, language: str):
+        return result[0] if result else STTResult(text="")
+
+    return fake
+
+
+def _stt_raising(exc: Exception) -> Callable[..., Any]:
+    async def fake(row: VoiceProviderRow, audio: bytes, *, mime: str, language: str):
+        raise exc
+
+    return fake
+
+
+def _block_network(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in ("transcribe_openai", "transcribe_tencent", "transcribe_mimo"):
+        monkeypatch.setattr(voice_adapters, name, _stt_raising(AssertionError("network used")))
+
+
+TENCENT_EXTRA = {"secret_id": "sid", "secret_key": "sk", "region": "ap-guangzhou"}
+
+
+def test_probe_tone_wav_is_valid_pcm16() -> None:
+    wav = _probe_tone_wav()
+    riff, size, wave, fmt, fmt_len, audio_fmt, channels, rate = struct.unpack_from(
+        "<4sI4s4sIHHI", wav, 0
+    )
+    assert (riff, wave, fmt) == (b"RIFF", b"WAVE", b"fmt ")
+    assert size == 36 + len(wav) - 44
+    assert (audio_fmt, channels, rate) == (1, 1, 16000)
+    assert len(wav) == 44 + 16000 * 2
+
+
+@pytest.mark.asyncio
+async def test_browser_and_missing_row_stay_offline(monkeypatch: pytest.MonkeyPatch) -> None:
+    _block_network(monkeypatch)
+    assert await probe_stt(None, "browser") == {"ok": True, "mode": "browser"}
+    assert await probe_stt(None, "openai") == {"ok": False, "error": "provider not configured"}
+
+
+@pytest.mark.asyncio
+async def test_edge_and_unknown_kinds_stay_offline(monkeypatch: pytest.MonkeyPatch) -> None:
+    _block_network(monkeypatch)
+    assert await probe_stt(_row(kind="edge"), "edge") == {"ok": True, "mode": "edge"}
+    assert await probe_stt(_row(kind="wat"), "wat") == {"ok": True, "mode": "wat"}
+
+
+@pytest.mark.asyncio
+async def test_credential_errors_are_reported_without_network(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _block_network(monkeypatch)
+    assert await probe_stt(_row(kind="openai", api_key=None), "openai") == {
+        "ok": False,
+        "error": "API credentials missing",
+    }
+    tencent = _row(kind="tencent", api_key="no-colon")
+    result = await probe_stt(tencent, "tencent")
+    assert result == {"ok": False, "error": "Tencent Cloud requires secret_id and secret_key"}
+
+
+@pytest.mark.asyncio
+async def test_live_success_per_provider(monkeypatch: pytest.MonkeyPatch) -> None:
+    for kind in ("openai", "tencent", "mimo"):
+        monkeypatch.setattr(voice_adapters, f"transcribe_{kind}", _stt(STTResult(text="")))
+        row = _row(kind=kind, extra=TENCENT_EXTRA if kind == "tencent" else None)
+        assert await probe_stt(row, kind) == {"ok": True, "mode": kind}
+
+
+@pytest.mark.asyncio
+async def test_provider_error_is_reported_not_raised(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        voice_adapters,
+        "transcribe_tencent",
+        _stt_raising(RuntimeError("UnsupportedOperation.ServerNotOpen: ASR service is not open.")),
+    )
+    row = _row(kind="tencent", api_key="sid:sk", extra=TENCENT_EXTRA)
+    assert await probe_stt(row, "tencent") == {
+        "ok": False,
+        "error": "UnsupportedOperation.ServerNotOpen: ASR service is not open.",
+    }
+
+
+@pytest.mark.asyncio
+async def test_network_errors_are_reported(monkeypatch: pytest.MonkeyPatch) -> None:
+    row = _row(kind="mimo")
+    monkeypatch.setattr(voice_adapters, "transcribe_mimo", _stt_raising(httpx.ConnectError("boom")))
+    assert await probe_stt(row, "mimo") == {"ok": False, "error": "network error: ConnectError"}
+
+    request = httpx.Request("POST", "https://api.openai.com/v1/audio/transcriptions")
+    response = httpx.Response(503, request=request)
+    monkeypatch.setattr(
+        voice_adapters,
+        "transcribe_openai",
+        _stt_raising(httpx.HTTPStatusError("down", request=request, response=response)),
+    )
+    assert await probe_stt(row, "openai") == {"ok": False, "error": "provider returned HTTP 503"}


### PR DESCRIPTION
## Problem

Probe modes were asymmetric: `test_tts` performs a live synthesis call, but `test_stt` only checked credential presence. STT-only misconfigurations passed the probe and failed later during real use — e.g. Tencent ASR not opened on the account (`UnsupportedOperation.ServerNotOpen`) was invisible at config time.

Discussed in #660 (option 1: live STT probe with a deterministic payload and per-provider tolerance for "no speech" results).

## Changes

`src/octop/infra/voice/adapters.py`
- `_probe_tone_wav()`: deterministic 1s 440Hz tone as 16kHz mono PCM16 WAV (accepted by Tencent/Mimo/OpenAI; empty or hallucinated text both count as success — the probe validates reachability + auth + service activation, not recognition quality)
- `test_stt` now runs the real `transcribe_*` path for openai/tencent/mimo and converts failures (provider errors, httpx status/network) into `{"ok": false, "error": ...}`; credential problems are still caught before any network call
- `edge` (TTS-only) and unknown kinds keep the offline pass

## Verification

- `tests/unit/test_voice_stt_probe.py`: WAV header sanity, offline kinds stay offline, credential errors without network, live success per provider, provider/network error reporting — 13 passed with manager suite
- ruff / format / mypy clean; pre-commit (`make all` + dashboard build) green
- Live (real Tencent keys): `test_stt` → `{'ok': True, 'mode': 'tencent'}`; wrong keys → `{'ok': False, 'error': 'AuthFailure.SecretIdNotFound: ...'}`

## Merge-order note

Overlaps with #659 in `adapters.test_stt` (both rewrite it). Whichever merges second needs a trivial rebase; the unified result keeps #659's `_probe_failure`/`_missing_credentials` helpers and this PR's live call.
